### PR TITLE
chore(docs): track docs/*.md changelogs in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Ignore virtual environment directory
 .venv/
 
-# Ignore docs and logs directory
-docs/
+# Track docs/*.md changelogs; ignore heavy media/binary docs (videos, .docx)
+docs/*
+!docs/*.md
 logs/
 
 # Ignore config.json file and .env file in the process directory

--- a/docs/2026-03-06-supabase-anon-key-deprecation.md
+++ b/docs/2026-03-06-supabase-anon-key-deprecation.md
@@ -1,0 +1,66 @@
+# Supabase Anon Key Deprecation — Impact Analysis
+
+**Date:** 2026-03-06
+**Source:** Supabase official notification email
+
+---
+
+## Source — Original Supabase Email
+
+> We're reaching out because one or more of your Supabase projects have recently made requests to the Data API root endpoint (`/rest/v1/`) using the anon key.
+>
+> Starting **April 8th 2026**, we will be removing anon key access to this endpoint as part of an ongoing effort to tighten default security across Supabase.
+>
+> Normal Data API usage, i.e. querying tables via `/rest/v1/your_table` or via any Supabase client library is not affected.
+>
+> **Your projects that may be impacted:**
+> - reporting (project-ref: `<redacted>`)
+>
+> Full details: https://github.com/orgs/supabase/discussions/42949
+
+---
+
+## Analysis — Codebase Audit
+
+A full audit of the codebase was performed to determine whether any code relies on the deprecated endpoint.
+
+### What is being removed
+
+Anon key access to the bare `/rest/v1/` root endpoint — used by some clients to fetch the OpenAPI/PostgREST schema spec. Table-level queries (e.g. `/rest/v1/posts`) and all Supabase client library calls are unaffected.
+
+### How this project connects to Supabase
+
+The reporting pipeline interacts with the database through **direct PostgreSQL connections via `psycopg2`**:
+
+```python
+connection = psycopg2.connect(
+    user=db_config.get("user"),
+    password=db_config.get("password"),
+    host=db_config.get("host"),
+    port=db_config.get("port"),
+    dbname=db_config.get("dbname")
+)
+```
+
+Credentials are read from `.env`. No API key is involved.
+
+### Findings
+
+| Check | Result |
+|---|---|
+| Calls to `/rest/v1/` root endpoint | None found |
+| Anon key used for API authentication | None found |
+| Direct HTTP calls to any Supabase endpoint | None found |
+| OpenAPI / schema spec fetching | None found |
+
+**Notes on near-misses:**
+- The word `anon` appears in SQL RLS policy names (e.g. `anon_select_all`) — this is a PostgreSQL role name, unrelated to the API anon key.
+- `config/config_example.json` contains placeholder `supabase.url` and `supabase.key` fields.
+
+---
+
+## Conclusion
+
+**As of this audit, the reporting pipeline was not affected by the April 8th 2026 deprecation** — it connects to Supabase exclusively via direct PostgreSQL (port 5432), bypassing the REST API entirely.
+
+> **Update (post-audit):** the later `engagement/` pipeline *does* use the Supabase client library (`create_client` in `engagement/db/client.py`). The deprecation still does not apply — the client library calls table-level endpoints, not the `/rest/v1/` root — but note that key handling now matters: the engagement client prefers `service_role_key` and falls back to the anon/`key`.

--- a/docs/2026-05-17-instagram-scheduling.md
+++ b/docs/2026-05-17-instagram-scheduling.md
@@ -1,0 +1,83 @@
+# 2026-05-17 — Instagram (Meta planner) scheduling automation
+
+Issue: [#13](https://github.com/ferraroroberto/reporting/issues/13).
+
+Adds the third per-platform scheduler to the repo, mirroring `linkedin/` (#9) and `substack/` shapes. Same Notion editorial DB, same illustration folder (different sub-folder for IG-vertical format), same `config/chrome_launch.py` stealth.
+
+## What was done
+
+1. **Notion clone step** (`instagram/clone_to_other_platforms.py`) — Notion-only module that mirrors the IG side of the editorial DB to Threads/Twitter/Substack:
+   - For non-thread days: straight copy of `illustration IG` / `text IG` / `repost IG` onto the matching `<P>` columns.
+   - For Sunday-thread days: derives the first illustration from `post IG → illustration[0]`, then resolves the canonical first-publication caption for that illustration via `publishIG → earliest editorial row's text IG` (same rule the LinkedIn scheduler uses for every day). The IG row itself is back-filled when blank: `illustration IG ← derived first thread image`, `text IG ← instagram.sunday_template_text`.
+   - TW and TH get `Work in Progress <P> = true` after clone; SB does not (Substack is posted day-by-day by `substack/daily_pipeline.py`).
+   - Idempotency: skips target rows that already have illustration or caption set unless `--force`.
+
+2. **Meta planner driver** (`instagram/schedule_instagram_posts.py`) — Playwright driver against `business.facebook.com/latest/content_calendar`:
+   - Per WIP-IG day, schedules a Story at 10:00 (FB + IG, both default-checked, 1 image) and a Feed Post at 15:00 (1 image on regular days, 10-image carousel on Sunday-thread days).
+   - Hover-then-click pattern for the per-day `Schedule ▾` dropdown (it's invisible until the cell is hovered).
+   - Multi-image upload via `set_input_files([...])` in a single call.
+   - Untick `Work in Progress IG` only when BOTH story and post succeeded; partial failures keep WIP set so the next run retries the day.
+
+3. **Bootstrap + session manager** (`instagram/bootstrap_session.py`, `instagram/instagram_session.py`) — direct port of the LinkedIn equivalents. Dedicated `instagram/chrome_user_data/` (gitignored), Meta-specific login-redirect markers.
+
+4. **README** (`instagram/README.md`) — mermaid workflow, CLI table, Notion field table, selectors table, gotchas, mirroring `linkedin/README.md`.
+
+## Files modified / created
+
+- **New**: `instagram/{__init__.py,bootstrap_session.py,instagram_session.py,clone_to_other_platforms.py,schedule_instagram_posts.py,README.md}`
+- **Modified**: `config/config.json` — added top-level `instagram` block (URL, profile dir, illustration folder, editorial/illustration/posts column maps, Sunday template, default story/post times, dry-run default) and a `clone_ig_to_others` block (per-target field maps for TW/TH/SB).
+- **Modified**: `.gitignore` — already had `instagram/chrome_user_data/`, no change needed.
+
+## Validation
+
+```powershell
+# Phase 1 — config + sessions compile
+& .\.venv\Scripts\python.exe -m py_compile instagram\bootstrap_session.py instagram\instagram_session.py
+
+# Phase 2 — Notion clone dry-run for the pre-staged week 2026-05-18 → 2026-05-24
+& .\.venv\Scripts\python.exe -m instagram.clone_to_other_platforms --week-start 2026-05-18 --dry-run --debug
+#   → 7 in-scope rows; 6 non-thread + 1 Sunday-thread.
+#   → All 7 generate writes to {illustration <P>, text <P>, repost <P>, Work in Progress <P>} for TW & TH and to {illustration SB, text SB, repost SB} for SB.
+#   → Sunday: canonical caption resolved from publishIG row 20240131 (45 chars, "Fill up your own cup first 🌱"); IG row back-fill queued for illustration IG + text IG (template).
+
+# Phase 3 — Meta scheduler dry-run, single day and Sunday-thread
+& .\.venv\Scripts\python.exe -m instagram.schedule_instagram_posts --date 20260518 --dry-run --debug
+#   → 1 row in-scope; story=1 image, post=1 image, caption=86 chars; fails at session-open with the expected FileNotFoundError until bootstrap is run.
+
+& .\.venv\Scripts\python.exe -m instagram.schedule_instagram_posts --date 20260524 --dry-run --debug
+#   → 1 row in-scope; story=1 image, post=10 images (all resolved from disk under archived_IGformat/); caption=0 chars (clone hasn't run live yet to back-fill the template).
+```
+
+End-to-end live verification (executed after bootstrap):
+
+```powershell
+& .\.venv\Scripts\python.exe -m instagram.bootstrap_session                                    # manual Meta login
+& .\.venv\Scripts\python.exe -m instagram.clone_to_other_platforms --week-start 2026-05-18 --live
+& .\.venv\Scripts\python.exe -m instagram.schedule_instagram_posts   --week-start 2026-05-18 --live
+```
+
+Outcome (2026-05-17 morning): clone written cleanly for all 7 days; planner scheduled 7 stories + 7 posts (Mon 18 – Sun 24) including the Sunday 10-image carousel; all 7 days had WIP-IG auto-unticked. Mon 18 ended up with a duplicate story due to a mid-iteration post failure on the first try (post path was fixed and the day was re-run, which re-scheduled the story too). User must manually delete the duplicate Mon 18 story in the Meta planner.
+
+Failure artifacts land in `results/instagram/` (same convention as `results/linkedin/`).
+
+## Selectors / approaches that DIDN'T work — and what does
+
+The initial implementation guessed at the Meta planner UI based on the user's screenshots. Five iterations against the live DOM landed on:
+
+1. **`Get Meta Verified` upsell blocks every click on first load.** Added `dismiss_meta_verified_modal()` after navigation and between days. The modal carries `data-surface=GeoIllustrationModal` and intercepts pointer events on the whole planner — without dismissing it, every hover/click silently times out.
+
+2. **Day-column discovery: nested `div:has(> *:text-is("Mon 18"))` doesn't resolve.** Replaced with a JS DOM walker (`_FIND_COLUMN_JS`): find the literal text node "Mon 18", climb until an ancestor contains a Schedule button; that ancestor IS the column. Hover + click happen via that handle's `query_selector_all`.
+
+3. **Week navigation buttons are labelled `"Left"` / `"Right"`, not `"Next week"` / `"Previous week"`.** The chevron glyph is the button's visible text and the aria-label is empty. `navigate_to_week()` clicks `Right` until the target day's column appears.
+
+4. **Each `Schedule story` / `Schedule post` menu click opens a SUB-modal with default date+time.** The sub-modal sits ON TOP of the main composer; the main composer also has its own Cancel button. A page-wide `get_by_role("button", "Cancel").first` clicks the wrong one. `_dismiss_initial_schedule_submodal()` now does a JS climb from the sub-modal's heading to find its OWN Cancel button.
+
+5. **Meta does NOT pre-mount an addressable `input[type=file]`.** The `Add photo/video` click opens the OS file picker. `set_input_files` on an unmounted input times out. `_upload_files()` wraps the click in `page.expect_file_chooser()` and feeds files via `file_chooser.set_files([...])` — works for both single image and 10-image carousels.
+
+6. **Date is `<input placeholder="mm/dd/yyyy">`; time is THREE inputs** (`aria-label=hours/minutes/meridiem`), not button-styled divs as initially assumed. `_set_all_visible_date_time()` enumerates the inputs by their stable attributes and fills each via `Control+A → Delete → type` (Meta's React onChange ignores `.fill()`'s synthetic event in some builds).
+
+7. **The post composer's date/time row is hidden until the `Set date and time` toggle is on.** The toggle is `<input type="checkbox" aria-label="Set date and time">` whose `value` reads `"false"` until clicked. `cb.click(force=True)` then read-back via `input_value()` to confirm.
+
+8. **The composer opens at a separate URL** (`/composer/?asset_id=...`). After each day the script `goto`s `feed_url` to return to the planner — without that, the next iteration's column-finder reports "Mon 18 not present in current week".
+
+All of this is captured in `instagram/README.md` § Selectors / Gotchas for the next platform port.

--- a/docs/2026-05-17-newsletter-article-archive.md
+++ b/docs/2026-05-17-newsletter-article-archive.md
@@ -1,0 +1,136 @@
+# Newsletter / article archive automation
+
+**Issue:** #17
+
+## What was done
+New `archive/newsletter/` package that closes the last manual step in the
+weekly content workflow. Walks the open article tabs in a CDP-attached real
+Chrome, archives each one to Notion, and closes the tab on success. End state
+of a run: only Gmail (and other skipped utility tabs) remain.
+
+Per-tab pipeline (`pipeline.process_url`):
+1. Skip URLs that contain `mail.google.com`, `notion.so`, `chrome://`,
+   `about:`, `localhost`.
+2. Extract title + body text + author byline with Playwright +
+   `readability-lxml`. OpenGraph / standard meta tags are the byline
+   fallback.
+3. Call the local-llm-hub (`gemini_lite`, `/v1/messages`) for the 3-line
+   summary and the topic (`personal development` / `innovation` /
+   `leadership and management`). Classifier validates the response with one
+   retry and falls back to `personal development` if it stays off-spec.
+4. Resolve the author against an in-memory cache of all Notion connections:
+   1. **Single clean byline** → exact then `rapidfuzz.token_sort_ratio ≥ 88`.
+      Hit → use it. Miss → CREATE the connection (real byline = trusted).
+   2. **Multi-author / missing byline / ambiguity** → ask the LLM to pick
+      the primary author (person or publishing org). Verify the LLM's
+      answer against the cache. Match → use it. Miss → fall back to the
+      `(not classified)` connection.
+   3. We never create connections from LLM output, only from a real byline
+      — the fallback exists so the pipeline cannot invent people.
+5. Pick the newsletter: query newsletter DB filtered to `Date >= today`
+   sorted ascending, take the first row where the per-topic rollup
+   (`n persdev` / `n innov` / `n leader`) is `< 8`. Re-queried before
+   every article so the rollups stay fresh after the previous insert.
+6. Skip duplicates: canonicalize the URL (drop `www.`, fragment,
+   `utm_*`/`mc_*`/`_hsenc`/`_hsmi`/`ref`/`gclid`/`fbclid`) and check
+   against the cached article-URL set.
+7. Create the Notion article page with title, link, summary, topic,
+   author relation, newsletter relation, `type = article`, and the body
+   text as paragraph blocks (chunked to respect Notion's 2000-char rich
+   text and 100-block limits).
+8. Close the tab on success. Leave open on failure.
+
+## Files
+- `archive/__init__.py`
+- `archive/newsletter/__init__.py`
+- `archive/newsletter/README.md` — workflow, setup, CLI, gotchas
+- `archive/newsletter/bootstrap_chrome.bat` — kill-all-chrome + relaunch on
+  `:9222` with the dedicated `--user-data-dir`, polled until responsive
+- `archive/newsletter/bootstrap_session.py` — one-time Gmail login flow,
+  mirrors `planning/linkedin/bootstrap_session.py`
+- `archive/newsletter/chrome_tabs.py` — CDP attach / list / skip filter /
+  tab close
+- `archive/newsletter/extractor.py` — Playwright + readability-lxml + meta
+  tag author fallback + byline-div heuristic
+- `archive/newsletter/llm.py` — `requests` wrapper for the hub's
+  `/v1/messages` (Anthropic shape)
+- `archive/newsletter/classifier.py` — 3-topic classifier, one retry,
+  configurable fallback
+- `archive/newsletter/summarizer.py` — 3-line plain-text summary
+- `archive/newsletter/author_resolver.py` — byline / LLM-pick-primary /
+  fallback resolver
+- `archive/newsletter/cache.py` — in-memory cache, URL canonicaliser,
+  `rapidfuzz` name match
+- `archive/newsletter/notion_io.py` — paginated DB iterator with
+  exponential-backoff retry on transient Notion errors, newsletter picker,
+  connection + article writers
+- `archive/newsletter/pipeline.py` — batch orchestrator over every
+  non-skipped tab
+- `archive/newsletter/dry_run.py` — single-tab entrypoint
+  (`--single-url` / `--first-non-gmail-tab` / `--no-write` /
+  `--keep-tab`)
+
+## Configuration
+New section in `config/config.json` (and `config_example.json`):
+```jsonc
+"newsletter_archive": {
+  "articles_db_id":     "67fbcee66711465c852ebf97303787a3",
+  "connections_db_id":  "33a1990d72f949f0983acd55ccd15724",
+  "newsletter_db_id":   "71fed31953b84183a9e77c48493bf9f4",
+  "chrome_debug_port":  9222,
+  "skip_url_substrings": ["mail.google.com", "notion.so", "chrome://", "about:", "localhost"],
+  "llm_hub_base_url":   "http://127.0.0.1:8000",
+  "llm_model":          "gemini_lite",
+  "fuzzy_author_threshold": 88,
+  "newsletter_category_cap": 8,
+  "topic_to_rollup": {
+    "personal development":      "n persdev",
+    "innovation":                "n innov",
+    "leadership and management": "n leader"
+  },
+  "author_fallback_name": "(not classified)"
+}
+```
+
+## Dependencies added
+`requirements.txt`: `readability-lxml`, `lxml_html_clean`, `rapidfuzz`.
+
+## Validation
+- `python -m py_compile` on all new modules — clean.
+- Smoke-tested URL canonicaliser (strips `utm_*` + `triedRedirect` +
+  `www.` + trailing slash; preserves meaningful params), name normaliser
+  (lowercase + accent strip + whitespace collapse).
+- Dry-run (`--no-write`) on `https://elenaverna.com/p/ic-work-is-the-new-career-flex`
+  ran clean three times: extracted title + body + byline, classified
+  topic, generated 3-line summary, identified target newsletter `N215`,
+  flagged Elena Verna as a new connection.
+- Live run (`--single-url ... ` without `--no-write`) created the article
+  page + the Elena Verna connection in Notion and closed the tab — both
+  rows verified via direct Notion API query.
+
+## Gotchas captured
+- **Chrome 136+** silently refuses to bind `--remote-debugging-port`
+  against the default profile dir. We launch with an explicit
+  `--user-data-dir=archive\newsletter\chrome_user_data\` to work around
+  this. The bat also kills every `chrome.exe` first (logging what it
+  killed) because a single orphan from a parallel Playwright run will
+  otherwise grab the binary and swallow the debug flag.
+- Notion's public API throws transient `temporarily unavailable` /
+  `timeout` / `internal_server_error` errors under load. The retry
+  wrapper in `notion_io._retry` applies 2/4/8/16 s exponential backoff
+  and gives up after the fourth attempt.
+- Windows console default `cp1252` crashes on emoji-bearing log
+  messages. The two entrypoints reconfigure stdio to UTF-8 before
+  configuring logging.
+- Child-module loggers (`newsletter_archive.notion_io`,
+  `.author_resolver`, …) propagate to the package-root `newsletter_archive`
+  logger, so both entrypoints call
+  `setup_logger("newsletter_archive", ...)` to get a single shared file
+  handler.
+
+## Deferred / future
+- LinkedIn auto-search for newly-created authors.
+- Auto-creating a new newsletter row when every visible future newsletter
+  is full (today we warn and stop).
+- Pinning LLM `temperature = 0` for reproducible topic classification
+  (today the same article can be classified differently across runs).

--- a/docs/2026-05-17-newsletter-pipeline-and-migration.md
+++ b/docs/2026-05-17-newsletter-pipeline-and-migration.md
@@ -1,0 +1,131 @@
+# Newsletter pipeline + monorepo migration
+
+**Issue:** #18 (follow-on to #17)
+
+## What was done
+Pulled the weekly newsletter workflow into a single orchestrated pipeline.
+Two structural changes + three migrations + one orchestrator + one
+launcher, then the monorepo originals get retired.
+
+### B1 — Folder rename
+- `archive/newsletter/` → `newsletter/`
+- Dropped the redundant `archive/` parent (it never had any siblings).
+- `chrome_user_data/` (gitignored) moved with the rest; Gmail session
+  preserved.
+- Updated imports across the package: `archive.newsletter.X` →
+  `newsletter.X`.
+- Fixed `REPO_ROOT = Path(__file__).resolve().parent.parent.parent` (4
+  levels) → `parent.parent` (2 levels) in `pipeline.py`, `dry_run.py`,
+  `bootstrap_session.py`.
+- Updated `.gitignore`, both READMEs, and `bootstrap_chrome.bat`
+  comments.
+
+### B2 — Migrated 3 scripts from `E:\automation\automation\notion\`
+- `newsletter/normalize_names.py` — title → sentence case with proper
+  name preservation, ALL-CAPS acronym handling, optional spaCy PERSON
+  entity detection.
+- `newsletter/normalize_url.py` — strip query params + fragments except
+  for domains in the preserve list.
+- `newsletter/build_newsletter.py` — group articles by topic for one
+  newsletter, sort, emit HTML, prompt for must-read line, copy to
+  clipboard.
+- `newsletter/normalize_names_words.json` — sidecar with
+  `proper_name_whitelist` (299 entries), `special_cases`,
+  `common_words`, `common_words_with_punct`. Only the word lists — API
+  token and DB ids now come from `config/config.json`.
+
+Each migrated script keeps its original CLI but now also exposes a
+`run(...)` callable that the orchestrator drives directly (no
+`subprocess`). Config loading switched from per-script JSON +
+`NOTION_API_TOKEN` env var to a single read of `config/config.json`
+(`notion.api_token` plus the existing `newsletter_archive` block).
+HTML output landed under `results/newsletter/N{NNN}.html` instead of
+next to the script.
+
+### B3 — Orchestrator
+- `newsletter_pipeline.py` (repo root) — sequences:
+  1. `bootstrap_chrome.bat` (kill + relaunch + poll `:9222`)
+  2. Press-Enter wait for the user to open article tabs
+  3. `newsletter.pipeline.run_batch(write=True)`
+  4. Press-Enter wait
+  5. `newsletter.normalize_names.run(days=14)`
+  6. `newsletter.normalize_url.run(days=14)`
+  7. Prompt for newsletter number
+  8. `newsletter.build_newsletter.run(number)` — HTML + must-read line
+- `launch_newsletter.bat` (repo root) — visible launcher, mirrors
+  `launch_planning.bat` / `launch_reporting.bat`.
+- CLI flags: `--newsletter NNN`, `--skip-bootstrap`, `--days N`,
+  `--debug`.
+
+### B4 — Docs
+- Global `README.md`: "Three pipelines" intro now mentions the full
+  newsletter flow (not just archive). Project tree shows
+  `newsletter_pipeline.py` + `launch_newsletter.bat`. Launchers table
+  becomes 3 rows.
+- `newsletter/README.md`: full rewrite covering bootstrap → archive →
+  normalise → build, with mermaid for all 4 stages, full one-time setup
+  list, CLI table for running steps in isolation.
+- This changelog.
+
+## Configuration changes
+Added to the `newsletter_archive` block in `config/config.json` and
+`config/config_example.json`:
+```jsonc
+"url_preserve_domains": [
+  "youtube.com", "www.youtube.com", "youtu.be",
+  "vimeo.com", "twitter.com", "x.com"
+]
+```
+Used by `normalize_url`. The previous fields (DB ids, LLM hub, fuzzy
+threshold, category cap, topic→rollup map, author_fallback_name) all
+unchanged.
+
+## Dependencies added
+`requirements.txt`: `spacy`. Plus the model:
+```
+.venv\Scripts\python -m spacy download en_core_web_sm
+```
+Falls back to whitelist-only behaviour if spaCy or the model isn't
+available — install is not strictly required.
+
+## Files changed
+| Type | Path |
+|---|---|
+| Renamed | `archive/newsletter/*` → `newsletter/*` (13 files) |
+| Renamed | `archive/__init__.py` → `newsletter/__init__.py` |
+| New | `newsletter/normalize_names.py` |
+| New | `newsletter/normalize_names_words.json` |
+| New | `newsletter/normalize_url.py` |
+| New | `newsletter/build_newsletter.py` |
+| New | `newsletter_pipeline.py` (repo root) |
+| New | `launch_newsletter.bat` (repo root) |
+| Modified | `README.md` (root) — newsletter section + launchers + tree |
+| Modified | `newsletter/README.md` — full rewrite |
+| Modified | `config/config.json`, `config/config_example.json` —
+            `url_preserve_domains` added |
+| Modified | `.gitignore` — `archive/newsletter/chrome_user_data/` →
+            `newsletter/chrome_user_data/` |
+| Modified | `requirements.txt` — `spacy` added |
+
+## Validation
+- `py_compile` on all 5 new modules + 11 renamed modules: clean.
+- Each migrated class instantiates with config from `config/config.json`:
+  - `NotionNameNormalizer` → 299-entry whitelist + spaCy loaded
+  - `NotionURLNormalizer` → preserve domains = the 6 expected
+  - `NotionNewsletterBuilder` → articles + newsletter DB ids resolved
+- Orchestrator imports cleanly; all `step_*` functions present.
+
+## Monorepo cleanup (separate commit in the monorepo)
+After the orchestrator has run successfully end-to-end, delete from
+`E:\automation\automation\notion\`:
+- `normalize_names.{py,bat,json,md}`
+- `normalize_url.{py,bat,json,md}`
+- `build_newsletter.{py,bat,json,md,html}`
+
+That commit lives in the `automation` repo, not this one.
+
+## Deferred (Phase C)
+Rename `reporting` → `content-management`: GitHub repo, local folder,
+the parent-level `reporting-remote.bat` and `reporting.code-workspace`.
+Will get its own issue once Phase B has been used in anger for a couple
+of weekly cycles.

--- a/docs/2026-05-17-restructure-planning-reporting.md
+++ b/docs/2026-05-17-restructure-planning-reporting.md
@@ -1,0 +1,122 @@
+# 2026-05-17 — Restructure: `planning/` + `reporting/`, `launch_planning` orchestrator
+
+Issue: [#14](https://github.com/ferraroroberto/reporting/issues/14).
+
+## What changed
+
+### Layout
+
+Five platform packages moved under `planning/`, three data packages moved
+under `reporting/`:
+
+```
+BEFORE                              AFTER
+linkedin/                           planning/linkedin/
+instagram/                          planning/instagram/
+twitter/                            planning/twitter/
+threads/                            planning/threads/
+substack/                           planning/substack/
+notion/                             reporting/notion/
+social_client/                      reporting/social_client/
+process/                            reporting/process/
+init.py                             reporting_pipeline.py
+launcher.bat                        launch_reporting.bat
+(new)                               planning_pipeline.py
+(new)                               launch_planning.bat
+```
+
+`config/`, `results/`, `logs/`, `docs/`, `tmp/` stayed at root — shared by
+both pipelines.
+
+### New orchestrator: `planning_pipeline.py` + `launch_planning.bat`
+
+Runs **LinkedIn → Instagram → Twitter → Threads** in fixed order on
+whatever rows have `Work in Progress <P>` ticked in the Notion editorial
+DB (no date filter — supports multi-week planning runs). Each scheduler's
+`main()` returns `(exit_code, list[dict])` with per-day status; the
+orchestrator aggregates these into a markdown summary at
+`results/planning/YYYY-MM-DD-HHMMSS-summary.md` (+ stdout).
+
+**Continue-on-error**: a per-platform failure does not stop the next
+platform. The summary's verdict line distinguishes idempotent no-op vs
+successful runs vs failures.
+
+### Scheduler changes (additive)
+
+All four schedulers gained:
+- `--all-wip` flag (mutex with `--week-start` / `--date`) — fetches every
+  WIP-<P> row in the editorial DB via a single Notion query with no title
+  filter.
+- `main()` returns `tuple[int, list[dict]]` instead of `int`. The
+  `if __name__ == "__main__": raise SystemExit(main()[0])` guard takes
+  the exit code; the orchestrator consumes the result list.
+
+### Renames + import rewrites
+
+- `init.py` → `reporting_pipeline.py`
+- `launcher.bat` → `launch_reporting.bat`
+- All `from instagram.…` etc → `from planning.instagram.…` (and same for
+  the four other planning packages).
+- All `from notion.…` / `from social_client.…` / `from process.…` → the
+  `reporting.…` namespace.
+- Each inner script's `sys.path.append(Path(__file__).parent.parent)`
+  bumped to `parent.parent.parent` (need repo root on path, not the
+  bucket dir).
+- `*_session.py` `CONFIG_PATH` bumped one level deeper for the same
+  reason.
+
+### Cleanup
+
+- Deleted 43 zero-byte dev `.log` files from this week's selector
+  iteration in `logs/`.
+- Removed stray `__pycache__/` at repo root.
+- Re-pointed `.gitignore` entries to the new locations
+  (`planning/<P>/chrome_user_data/`, `reporting/process/.env`).
+
+### Config
+
+`config/config.json` — five `user_data_dir` paths re-pointed to
+`planning/<P>/chrome_user_data`. Nothing else moved.
+
+## Validation
+
+```powershell
+# 1. py_compile across the entire moved tree
+$files = Get-ChildItem -Path planning, reporting -Recurse -Include *.py
+$files += Get-ChildItem -Path planning_pipeline.py, reporting_pipeline.py
+& .\.venv\Scripts\python.exe -m py_compile ($files | %% { $_.FullName })
+# → ALL 48 FILES OK
+
+# 2. Single-platform smoke from the new path
+& .\.venv\Scripts\python.exe -m planning.twitter.schedule_twitter_posts --all-wip --dry-run --debug
+# → "🎯 All-WIP mode" + "⚠️ No WIP-TW rows in target range. Nothing to do."
+
+# 3. Idempotency dual-run (acceptance gate)
+.\launch_reporting.bat auto        # daily numbers — upserts no-op for already-collected day
+.\launch_planning.bat              # dry-run; all four platforms find 0 WIP rows → ✅ Idempotent run
+```
+
+## Stream Deck / scheduled-task migration
+
+Anything outside the repo that called `launcher.bat` needs to be
+re-pointed at `launch_reporting.bat`. The planning workflow gets a new
+shortcut to `launch_planning.bat live auto`.
+
+## What did NOT change
+
+- `reporting/` internals (data_processor, supabase_*, notion_supabase_sync)
+  — move-only.
+- Database schema, Notion editorial column names, illustrations folder
+  path.
+- The Notion editorial-clone step still lives at
+  `planning/instagram/clone_to_other_platforms.py` — it's logically part
+  of the IG workflow.
+- `process/.env`, `config/config.json`, `config/mapping.json` — content
+  unchanged.
+
+## Future work hooks (not built — layout reserves room)
+
+- `planning/_common/` for shared session-manager / scheduler base classes
+  if the duplication earns the abstraction.
+- `planning/engagement/` for in-work self-engagement (e.g. liking my own
+  posts). External-interaction automation is explicitly out of scope.

--- a/docs/2026-05-17-twitter-threads-scheduling.md
+++ b/docs/2026-05-17-twitter-threads-scheduling.md
@@ -1,0 +1,148 @@
+# 2026-05-17 — Twitter (X) + Threads scheduling automation
+
+Issues: [#10](https://github.com/ferraroroberto/reporting/issues/10) (Twitter),
+[#11](https://github.com/ferraroroberto/reporting/issues/11) (Threads),
+[#12](https://github.com/ferraroroberto/reporting/issues/12) (Substack — no code).
+
+Ships the 4th and 5th per-platform schedulers (after `linkedin/` #9,
+`substack/` already in-tree, `instagram/` #13). Mirror of the IG module
+shape. Both consume the IG-clone output written by
+`instagram/clone_to_other_platforms.py`. No new Notion columns.
+
+## What was done
+
+1. **Twitter / X scheduler** (`twitter/schedule_twitter_posts.py`) —
+   Playwright driver against `https://x.com/home`:
+   - Per WIP-TW day, opens the modal composer via the side-rail
+     `[data-testid="SideNav_NewTweet_Button"]`, types the caption,
+     uploads one image via the pre-mounted
+     `input[data-testid="fileInput"]`, clicks the Schedule toolbar icon,
+     fills 6 native `<select>` (Month / Day / Year / Hour / Minute /
+     AM-PM) by positional index, clicks Confirm, then the final Schedule
+     action (`[data-testid="tweetButton"]`).
+   - Untick `Work in Progress TW` on success.
+
+2. **Threads scheduler** (`threads/schedule_threads_posts.py`) —
+   Playwright driver against `https://www.threads.com/@ferraroroberto`:
+   - Per WIP-TH day, opens the `New thread` modal from the inline `What's
+     new?` row, types the caption, uploads one image via the pre-mounted
+     `input[type=file]` inside the dialog, clicks the top-right 3-dots
+     (positional JS — no aria-label), clicks `Schedule…`, navigates the
+     calendar popup to the target month, clicks the day-cell via a JS
+     walk from the digit's leaf `<span>` to its nearest
+     `[role="gridcell"]` ancestor (the only element with the React click
+     handler), fills `input[placeholder="hh"]` and
+     `input[placeholder="mm"]` (24h, zero-padded), clicks Done, then the
+     final Schedule action.
+   - Untick `work in progress TH` on success.
+
+3. **Bootstrap + session managers** for both platforms — direct ports of
+   the IG equivalents. Login markers per platform (x.com `/i/flow/login`;
+   threads.com `/login` or `instagram.com/accounts/login`).
+
+4. **READMEs** (`twitter/README.md`, `threads/README.md`) — mermaid
+   workflow, CLI table, validated selectors, gotchas, file layout.
+
+5. **Substack #12 closed manually** with a comment pointing at the
+   existing `substack/daily_pipeline.py` package and at #13 (Notion
+   replica already shipped via the clone step). No new code.
+
+## Files modified / created
+
+- **New**: `twitter/{__init__.py, bootstrap_session.py, twitter_session.py, schedule_twitter_posts.py, README.md}`
+- **New**: `threads/{__init__.py, bootstrap_session.py, threads_session.py, schedule_threads_posts.py, README.md}`
+- **Modified**: `config/config.json` — added top-level `twitter` and
+  `threads` blocks (URL, profile dir, illustration folder, editorial
+  column maps, post time, dry-run default).
+- **No change**: `.gitignore` already had both `chrome_user_data/`
+  entries from the IG ship.
+
+## Validation
+
+```powershell
+# Phase 1 — config + sessions compile
+& .\.venv\Scripts\python.exe -m py_compile `
+    twitter\bootstrap_session.py twitter\twitter_session.py twitter\__init__.py `
+    threads\bootstrap_session.py threads\threads_session.py threads\__init__.py
+
+# Phase 1 HANDOFF — user-run bootstraps (one Chrome window each)
+& .\.venv\Scripts\python.exe -m twitter.bootstrap_session
+& .\.venv\Scripts\python.exe -m threads.bootstrap_session
+
+# Phase 2 — Twitter live for the full week 2026-05-18 → 2026-05-24
+& .\.venv\Scripts\python.exe -m twitter.schedule_twitter_posts --date 20260518 --dry-run --debug
+#   → composer + 6-select schedule modal verified ("Will send on Mon, May 18, 2026 at 3:00 PM").
+& .\.venv\Scripts\python.exe -m twitter.schedule_twitter_posts --date 20260518 --live --debug
+#   → LIVE; WIP-TW unticked.
+& .\.venv\Scripts\python.exe -m twitter.schedule_twitter_posts --week-start 2026-05-18 --live --debug
+#   → 6/6 remaining days LIVE in one pass; all WIP-TW unticked.
+
+# Phase 3 — Threads live for the full week
+& .\.venv\Scripts\python.exe -m threads.schedule_threads_posts --date 20260518 --dry-run --debug
+#   → first dry-run: day-click selected today (17) — bug found, fixed.
+#   → second dry-run: day-cell highlight visually moves to 18; time 15:00.
+& .\.venv\Scripts\python.exe -m threads.schedule_threads_posts --week-start 2026-05-18 --live --debug
+#   → 7/7 days LIVE; all WIP-TH unticked.
+```
+
+End-to-end outcome (2026-05-17 morning): Twitter clean sweep (7/7 days
+LIVE, 0 retries needed). Threads ended with the same 7/7 result on the
+second iteration — but the **first** Threads run silently scheduled all
+seven posts for **today** (May 17) at 15:00 instead of for May 18-24,
+because the day-click was hitting an inert ancestor and the calendar's
+selected-day never updated (today was the default). User must delete the
+7 mis-scheduled May 17 Threads posts manually. Mid-iteration the
+`_click_calendar_day` function was rewritten to walk from the digit's
+leaf `<span>` up to its `[role="gridcell"]` ancestor (the actual element
+with the React click handler), and to pick the lowest-lightness span
+color so that today (white text on black pill = lightness 255) is
+excluded.
+
+Failure artifacts land in `results/twitter/` and `results/threads/`.
+
+## Selectors / approaches that DIDN'T work — and what does
+
+### Twitter
+1. **The inline `/home` composer carries stale draft text.** Don't try
+   to type into `[data-testid="tweetTextarea_0"]` directly on the feed —
+   always open the modal via the side-rail button
+   `[data-testid="SideNav_NewTweet_Button"]` for a clean slate.
+
+2. **Page-wide `get_by_role("button", name=/^close$/i)` clicks the
+   side-rail "Close" nav** and breaks the composer flow. Scope every
+   modal dismissal to `[role="dialog"]`.
+
+3. **`select_option(label="May")` flakes on X's Month select.** Anchor
+   the 6 Schedule selects by their FIXED ORDER inside the dialog
+   (`[role="dialog"] select` positional) and `select_option(value="5")`
+   with X's 1-indexed month value.
+
+### Threads
+1. **Clicking the day's `<span>` does NOTHING — calendar selection
+   doesn't update.** Walk up to the nearest `[role="gridcell"]` ancestor
+   and click that.
+
+2. **"Brightest" cell does NOT mean "current month".** Today is white
+   text on a dark pill → highest lightness; current-month days are black
+   text on white → lowest lightness; prev/next-month days are light grey
+   → intermediate. Pick the LOWEST.
+
+3. **`aria-label*="options"` matches the bottom "Reply options" button**
+   instead of the top-right 3-dots. The 3-dots has NO aria-label and NO
+   test-id — anchor positionally in the dialog header band (y < 80 from
+   dialog top, rightmost svg-only button).
+
+4. **"New thread" text appears in the side-nav permanently.** Composer-
+   close detection must check for `[role="dialog"]` count == 0, never
+   for the text.
+
+All of this is captured in `twitter/README.md` and `threads/README.md`
+under § Gotchas for the next platform port.
+
+## Issue closure
+
+- **#10 (Twitter)** — closed via `Closes #10` in the merge commit.
+- **#11 (Threads)** — closed via `Closes #11` in the merge commit.
+- **#12 (Substack)** — closed manually with a comment pointing at the
+  existing `substack/daily_pipeline.py` package and at #13 (Notion
+  replica via clone). No code change.

--- a/docs/2026-05-22-engagement-triage-cleanup.md
+++ b/docs/2026-05-22-engagement-triage-cleanup.md
@@ -1,0 +1,60 @@
+# Engagement triage — UI cleanup pass
+
+**Date:** 2026-05-22
+**Branch:** feat/engagement-triage
+
+## What was done
+
+A cleanup pass over the engagement review UI based on hands-on feedback.
+
+### Comment permalink fix
+`_comment_link` now emits LinkedIn's `?dashCommentUrn=urn:li:fsd_comment:(<comment-num>,<post-urn>)`
+instead of the ignored `?commentUrn=urn:li:comment:(...)`. The two URN halves are
+the same — reversed in order and re-wrapped as `fsd_comment` — which is the form
+LinkedIn's "copy link to comment" produces and the only one that actually scrolls
+to the comment. The stored `comment_id` is unchanged (still the canonical
+`urn:li:comment:(...)` primary key); the transform happens only at link-render time,
+so no Supabase migration was needed.
+
+### Filters + counts on one line
+`render_sidebar_metrics()` gained a `horizontal` keyword — the engagement-tab
+expander now lays pending / approved / sent / rejected+ignored across a single
+row. The standalone `review_app.py` sidebar keeps the default vertical layout.
+
+### Compact comment cards
+Card header collapsed from a 3-column stacked block into a single inline row
+(name · verdict · commenter whitelist/blacklist badge · profile/comment links ·
+status). Action buttons now sit on one tight row sized to the exact button count
+(previously allocated 6 columns and skipped index 3, leaving a visible gap).
+
+### pending / all view filter
+`render_real_tab` and `render_ai_tab` gained a `pending / all` radio (default
+`pending`). `all` loads every status so comments already marked read / AI /
+approved stay findable. Per-commenter review remains served by the commenters tab.
+
+### Commenter-class badge
+Each card now shows the commenter's whitelist/blacklist/unknown classification,
+making the surface / whitelist / blacklist routing legible at a glance. Auto-routing
+itself was already correct (blacklist → auto-approved, whitelist → "real comments")
+— no logic change.
+
+## Files modified
+
+- `engagement/ui.py`
+- `app/tab_engagement.py`
+
+## Not code bugs (no change)
+
+- *"Invalid HTTP request received"* — the app's server logging non-HTTP
+  connections on its port (stale `https://` browser tab or another process
+  probing it).
+- *`supabase service_role_key failed: Invalid API key`* — the `service_role_key`
+  in `config/config.json` is invalid/expired; the engagement client falls back to
+  the anon/`key` so the app keeps working. Paste a valid service-role key to
+  silence it.
+
+## Validation
+
+- `py_compile` on both edited files — OK.
+- Streamlit boot check (`streamlit run app/app.py --server.headless true`) —
+  HTTP 200.


### PR DESCRIPTION
## Summary
- `.gitignore` no longer ignores the entire `docs/` folder. The new rule tracks `docs/*.md` while keeping heavy/binary docs out (`docs/*` + `!docs/*.md`) — demo videos, `.docx`, the `.lnk` shortcut and `fotos/` stay untracked.
- Renamed `supabase_anon_key_deprecation_2026.md` to `2026-03-06-supabase-anon-key-deprecation.md` to match the repo's `YYYY-MM-DD-short-description.md` changelog convention. Redacted the Supabase project-ref and trimmed internal file paths so the doc is safe for a public repo; added a post-audit note that the later `engagement/` pipeline does use the Supabase client library.
- Brings 6 previously-uncommitted changelogs under version control: the five `2026-05-17-*` entries and `2026-05-22-engagement-triage-cleanup.md`.

## Validation
Docs-only change. `git add --dry-run` confirms only `docs/*.md` is tracked; `git check-ignore` confirms the videos, `.docx` and `fotos/` remain ignored.
