### PR TITLE
feat(newsletter): harden run_batch against LLM-hub failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,10 @@ planning/threads/chrome_user_data/
 planning/instagram/chrome_user_data/
 newsletter/chrome_user_data/
 
-# Ignore contents of results directory but keep the directory itself
+# Ignore contents of any results directory (root and reporting/ package)
 results/*
 !results/README.md
+reporting/results/*
 
 # Ignore Python cache files
 __pycache__/

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -245,6 +245,8 @@
         ],
         "llm_hub_base_url": "http://127.0.0.1:8000",
         "llm_model": "gemini_lite",
+        "consecutive_failure_limit": 3,
+        "min_body_chars": 200,
         "fuzzy_author_threshold": 88,
         "newsletter_category_cap": 8,
         "topic_to_rollup": {

--- a/docs/2026-05-23-newsletter-pipeline-resilience.md
+++ b/docs/2026-05-23-newsletter-pipeline-resilience.md
@@ -1,0 +1,44 @@
+# Newsletter pipeline — resilience against LLM-hub failures
+
+**Issue:** #24
+
+## What was done
+
+Hardened `newsletter/pipeline.py`'s `run_batch` against the LLM hub being slow, wedged, or down. The trigger was the 2026-05-22 run: the local hub (model `gemini_lite`) wedged partway through, and from that point every article failed with a 120 s `ReadTimeout`. The batch kept marching tab by tab — roughly 24 remaining tabs × 120 s ≈ 48 minutes of dead waiting — left every failed tab open, created nothing, and printed no summary. Five changes now make the pipeline fail fast and informatively, and tolerate transient blips.
+
+### 1 — Retry transient errors in `llm.call`
+
+`llm.call` now wraps its `requests.post` in a retry loop: on `requests.ReadTimeout` / `requests.ConnectionError` it retries up to 2 times with exponential backoff (2 s, 4 s) before re-raising, so one slow blip no longer discards a fully-extracted article. Each attempt keeps the full 120 s timeout. Genuine HTTP error responses are not retried.
+
+### 2 — Pre-flight hub health check
+
+New `llm.health_check` makes one tiny generation call (`max_tokens=4`, 30 s timeout, no retry) and returns a bool. `run_batch` calls it immediately after loading config — before the slow Notion cache hydration (minutes) and the Chrome connection — so a dead or unresponsive hub aborts the run in seconds instead of after the first full-length article timeout.
+
+### 3 — Skip empty-body articles
+
+`process_url` now checks the extracted body length against `min_body_chars` (default 200). A binary PDF or other page that extracts to a near-empty body can't be classified or summarised, so it logs a warning, skips the LLM steps, leaves the tab open, and returns — counted as a skip, not a failure.
+
+### 4 — Circuit-breaker + end-of-run summary
+
+`run_batch` tracks `archived` / `skipped` / `failed` counts plus a consecutive-failure counter. After `consecutive_failure_limit` consecutive tab failures (default 3) it aborts the loop with an explicit message and returns a non-zero exit code; a success or a benign skip resets the counter. Every run now ends with a `📊 N archived, N skipped, N failed` line, and when there are failures it lists the failed URLs so they are easy to re-open in Chrome for the next run.
+
+### Bundled fix — Notion rich-text chunking miscounts emoji
+
+Surfaced once the run got far enough to write articles: Notion rejected pages with `rich_text...content.length should be ≤ 2000, instead was 2001`. `_chunk_rich_text` in `newsletter/notion_io.py` sliced the body by Python `len()` (code points), but Notion's 2000-char limit counts UTF-16 code units — an emoji or other astral character is one code point but two UTF-16 units, so a 2000-char chunk holding one emoji reached 2001 units server-side. The chunker now sizes segments by UTF-16 width, so emoji-bearing bodies and summaries split correctly.
+
+## Files modified
+
+- `newsletter/llm.py` — retry loop in `call`; new `health_check` helper.
+- `newsletter/pipeline.py` — empty-body skip in `process_url`; pre-flight check, circuit-breaker, counters and summary in `run_batch`.
+- `newsletter/notion_io.py` — `_chunk_rich_text` now chunks by UTF-16 code-unit width (bundled fix; see above).
+- `config/config.json` — added `consecutive_failure_limit` (3) and `min_body_chars` (200) under `newsletter_archive`.
+- `config/config_example.json` — mirrored the two new keys.
+
+## Validation
+
+- `py_compile` on `newsletter/llm.py` and `newsletter/pipeline.py` — clean.
+- Both `config/config.json` and `config/config_example.json` re-parsed as valid JSON after the edits.
+- `llm.health_check` exercised directly against the live hub (`claude_sonnet`) — returns `True` for the running hub and `False`, without raising, for a dead endpoint.
+- `_chunk_rich_text` checked against plain, boundary, and emoji-dense inputs — no chunk exceeds 2000 UTF-16 units and every split rejoins losslessly, including the exact 1999-chars-plus-one-emoji case that previously produced a 2001-unit chunk.
+
+There is no automated test suite under `newsletter/`; `newsletter.dry_run` runs a single tab through `process_url` directly and does not go through `run_batch`, so the circuit-breaker and end-of-run summary are covered by compile-check and review rather than an end-to-end run.

--- a/newsletter/llm.py
+++ b/newsletter/llm.py
@@ -3,15 +3,26 @@
 from __future__ import annotations
 
 import logging
+import time
 
 import requests
 
 logger = logging.getLogger("newsletter_archive.llm")
 
+# Transient network failures worth retrying — the hub may be briefly slow
+# or mid-restart. A genuine bad response (4xx/5xx) is not retried here.
+_RETRYABLE = (requests.ReadTimeout, requests.ConnectionError)
+
 
 def call(*, base_url: str, model: str, prompt: str, max_tokens: int = 512,
-         timeout: int = 120) -> str:
-    """Single-turn user → assistant round-trip. Returns the assistant text."""
+         timeout: int = 120, retries: int = 2, backoff: float = 2.0) -> str:
+    """Single-turn user → assistant round-trip. Returns the assistant text.
+
+    On a transient network error (read timeout / connection error) the call
+    is retried up to ``retries`` times with exponential backoff before the
+    error is re-raised — so one slow blip doesn't discard a fully-extracted
+    article. Each attempt uses the full ``timeout``.
+    """
     payload = {
         "model": model,
         "max_tokens": max_tokens,
@@ -19,14 +30,50 @@ def call(*, base_url: str, model: str, prompt: str, max_tokens: int = 512,
     }
     logger.debug("LLM call: model=%s max_tokens=%d prompt_chars=%d",
                  model, max_tokens, len(prompt))
-    resp = requests.post(
-        f"{base_url.rstrip('/')}/v1/messages",
-        json=payload,
-        timeout=timeout,
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    for part in data.get("content", []):
-        if part.get("type") == "text":
-            return (part.get("text") or "").strip()
-    raise RuntimeError(f"Unexpected /v1/messages response shape: {data!r}")
+    last_exc: Exception | None = None
+    for attempt in range(1, retries + 2):  # 1 initial + `retries` retries
+        try:
+            resp = requests.post(
+                f"{base_url.rstrip('/')}/v1/messages",
+                json=payload,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for part in data.get("content", []):
+                if part.get("type") == "text":
+                    return (part.get("text") or "").strip()
+            raise RuntimeError(f"Unexpected /v1/messages response shape: {data!r}")
+        except _RETRYABLE as exc:
+            last_exc = exc
+            if attempt <= retries:
+                wait = backoff * (2 ** (attempt - 1))
+                logger.warning("⚠️ LLM call failed (%s) — attempt %d/%d, "
+                               "retrying in %.0fs",
+                               type(exc).__name__, attempt, retries + 1, wait)
+                time.sleep(wait)
+            else:
+                logger.error("❌ LLM call failed after %d attempts: %s",
+                              retries + 1, type(exc).__name__)
+    assert last_exc is not None
+    raise last_exc
+
+
+def health_check(*, base_url: str, model: str, timeout: int = 30) -> bool:
+    """Fast pre-flight probe of the LLM hub.
+
+    Makes one tiny generation call so a dead or wedged hub fails in seconds
+    instead of after the first full-length article timeout. Returns True
+    only if the hub answers with usable text.
+    """
+    try:
+        text = call(
+            base_url=base_url, model=model,
+            prompt="Reply with: ok", max_tokens=4,
+            timeout=timeout, retries=0,
+        )
+    except Exception as exc:  # noqa: BLE001 — any failure means "not healthy"
+        logger.error("❌ LLM hub health check failed: %s: %s",
+                      type(exc).__name__, exc)
+        return False
+    return bool(text)

--- a/newsletter/notion_io.py
+++ b/newsletter/notion_io.py
@@ -188,12 +188,31 @@ def create_connection(client: Client, *, connections_db_id: str, name: str,
 
 
 def _chunk_rich_text(text: str, limit: int = NOTION_RICH_TEXT_LIMIT) -> List[Dict[str, Any]]:
+    """Split ``text`` into rich-text segments Notion will accept.
+
+    Notion's 2000-char limit counts UTF-16 code units, not Python code
+    points — an astral character (emoji etc.) is one ``len()`` char but
+    two UTF-16 units. Slicing by ``len()`` therefore lets a 2000-char
+    chunk holding one emoji reach 2001 units and get rejected. We size
+    chunks by UTF-16 width instead.
+    """
     if not text:
         return [{"type": "text", "text": {"content": ""}}]
-    return [
-        {"type": "text", "text": {"content": text[i : i + limit]}}
-        for i in range(0, len(text), limit)
-    ]
+    chunks: List[str] = []
+    current: List[str] = []
+    current_len = 0
+    for ch in text:
+        ch_len = 2 if ord(ch) > 0xFFFF else 1
+        if current_len + ch_len > limit:
+            chunks.append("".join(current))
+            current = [ch]
+            current_len = ch_len
+        else:
+            current.append(ch)
+            current_len += ch_len
+    if current:
+        chunks.append("".join(current))
+    return [{"type": "text", "text": {"content": c}} for c in chunks]
 
 
 def _body_to_blocks(body_text: str, *, max_blocks: int = NOTION_BLOCK_LIMIT - 1) -> List[Dict[str, Any]]:

--- a/newsletter/pipeline.py
+++ b/newsletter/pipeline.py
@@ -28,7 +28,8 @@ for _stream in (sys.stdout, sys.stderr):
 
 from config.logger_config import setup_logger  # noqa: E402
 from newsletter import (  # noqa: E402
-    author_resolver, chrome_tabs, classifier, extractor, notion_io, summarizer,
+    author_resolver, chrome_tabs, classifier, extractor, llm, notion_io,
+    summarizer,
 )
 from newsletter.cache import CacheState  # noqa: E402
 
@@ -53,6 +54,15 @@ def process_url(
     logger.info("📝 Title: %s", art.title)
     logger.info("✍️  Byline (raw): %s", art.author or "<none>")
     logger.info("📄 Body length: %d chars", len(art.body_text))
+
+    # An empty/near-empty body (e.g. a binary PDF that didn't extract) can't
+    # be classified or summarised — skip the LLM steps, leave the tab open.
+    min_body = archive_cfg.get("min_body_chars", 200)
+    if len(art.body_text) < min_body:
+        logger.warning("⏭️  Body too short (%d < %d chars) — skipping LLM "
+                        "steps, leaving tab open: %s",
+                        len(art.body_text), min_body, url)
+        return False
 
     topic = classifier.classify(
         base_url=archive_cfg["llm_hub_base_url"],
@@ -149,6 +159,17 @@ def run_batch(*, write: bool, debug: bool = False) -> int:
         logger.error("❌ config.json is missing the 'newsletter_archive' section")
         return 1
     archive_cfg = cfg["newsletter_archive"]
+
+    # Pre-flight: a dead or wedged hub should fail in seconds — before the
+    # slow Notion cache hydration (minutes) and the Chrome connection.
+    if not llm.health_check(
+        base_url=archive_cfg["llm_hub_base_url"],
+        model=archive_cfg["llm_model"],
+    ):
+        logger.error("❌ LLM hub unreachable/unresponsive at %s — aborting "
+                     "before cache hydration", archive_cfg["llm_hub_base_url"])
+        return 1
+
     client = notion_io.init_client(cfg["notion"]["api_token"])
 
     cache = notion_io.hydrate_cache(
@@ -157,6 +178,12 @@ def run_batch(*, write: bool, debug: bool = False) -> int:
         connections_db_id=archive_cfg["connections_db_id"],
         fuzzy_threshold=archive_cfg["fuzzy_author_threshold"],
     )
+
+    failure_limit = archive_cfg.get("consecutive_failure_limit", 3)
+    archived = skipped = 0
+    failed_urls: list[str] = []
+    consecutive = 0
+    aborted = False
 
     browser = chrome_tabs.connect(archive_cfg["chrome_debug_port"])
     try:
@@ -174,14 +201,39 @@ def run_batch(*, write: bool, debug: bool = False) -> int:
                     url=t.url, page=t.page, archive_cfg=archive_cfg,
                     client=client, cache=cache, write=write, logger=logger,
                 )
-                if write and created:
-                    t.page.close()
-                    logger.info("🗑️  Closed tab")
+                if created:
+                    archived += 1
+                    if write:
+                        t.page.close()
+                        logger.info("🗑️  Closed tab")
+                else:
+                    # Duplicate or empty-body skip — not an error.
+                    skipped += 1
+                consecutive = 0
             except Exception:
                 logger.exception("❌ Failed on tab %s — leaving it open", t.url)
+                failed_urls.append(t.url)
+                consecutive += 1
+                if consecutive >= failure_limit:
+                    aborted = True
+                    logger.error(
+                        "🛑 Aborting — %d consecutive failures (limit %d). "
+                        "The LLM hub is likely down; remaining tabs left open.",
+                        consecutive, failure_limit,
+                    )
+                    break
     finally:
         chrome_tabs.close_browser(browser)
 
+    logger.info("📊 %d archived, %d skipped, %d failed",
+                archived, skipped, len(failed_urls))
+    if failed_urls:
+        logger.info("❌ Failed URLs (left open for re-run):")
+        for u in failed_urls:
+            logger.info("   • %s", u)
+
+    if aborted:
+        return 1
     logger.info("🎉 Done")
     return 0
 


### PR DESCRIPTION
## Summary

- Hardens `newsletter/pipeline.py`'s `run_batch` so a slow/wedged/down LLM hub stops costing the run 48 minutes of dead 120 s timeouts. The 2026-05-22 run wedged on the local hub partway through and ground through every remaining tab with no recovery and no end-of-run signal.
- `newsletter/llm.py` — `call` now retries `requests.ReadTimeout` / `requests.ConnectionError` up to 2 times with exponential backoff (2 s, 4 s) before re-raising, so a single blip doesn't discard a fully-extracted article. New `health_check(base_url, model)` makes one tiny `max_tokens=4` call and returns a bool without raising.
- `newsletter/pipeline.py` — pre-flight `llm.health_check` runs **before** the multi-minute Notion cache hydration, so a dead hub aborts in ~seconds. `process_url` now skips the LLM steps when the extracted body is under `min_body_chars` (the 0-char Readwise-PDF case), leaving the tab open and counting it as a skip, not a failure. `run_batch` tracks `archived` / `skipped` / `failed` counts plus a consecutive-failure counter — after `consecutive_failure_limit` consecutive tab failures it breaks the loop and returns non-zero, and every run ends with a `📊 N archived, N skipped, N failed` line plus the list of failed URLs.
- `config/config_example.json` — new `newsletter_archive.consecutive_failure_limit` (3) and `min_body_chars` (200) knobs.
- Bundled fix in the second commit: `newsletter/notion_io.py` `_chunk_rich_text` was sizing chunks by Python `len()` (code points), but Notion's 2000-char rich-text limit counts UTF-16 code units. A 2000-char chunk containing one emoji measured 2001 server-side and was rejected with a 400 — exactly what the live run hit on "Focus lasts 47 seconds 🧐" and the Wes Kao "detail-oriented" article. The chunker now sizes segments by UTF-16 width.
- Out of scope (per the issue): no changes to the `local-llm-hub` repo, no auto-reprocessing of left-open tabs (re-running the pipeline already deduplicates via the cache and picks them up).

## Validation

- `py_compile` on `newsletter/llm.py`, `newsletter/pipeline.py`, `newsletter/notion_io.py` — clean.
- Both `config/config.json` and `config/config_example.json` re-parsed as valid JSON after the edits.
- `llm.health_check` exercised directly against the live hub (`claude_sonnet`): returns `True` for the running hub and `False`, without raising, for a dead endpoint.
- `_chunk_rich_text` checked against plain, boundary, and emoji-dense inputs — no chunk exceeds 2000 UTF-16 units and every split rejoins losslessly, including the exact 1999-chars-plus-one-emoji case that previously produced a 2001-unit chunk.
- No automated test suite under `newsletter/`; `newsletter.dry_run` bypasses `run_batch`, so the circuit-breaker and end-of-run summary are covered by compile-check and review rather than an end-to-end run.

Closes #24
