### PR TITLE
fix(app): stream live log into control-panel pipelines

### DIFF
--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -175,17 +175,17 @@ def render_status_badge(name: str) -> None:
 
 def render_log_panel(name: str, *, height: int = 380, autorefresh_secs: float = 1.0) -> None:
     """Render the rolling log tail. While the subprocess is alive, sleep + rerun
-    once so the user sees a live stream without clicking refresh."""
+    once so the user sees a live stream without clicking refresh.
+
+    Uses a scrollable container + st.code (display element, not a widget) so
+    the body actually updates on every rerun. A keyed st.text_area caches its
+    first-render value in session_state and ignores subsequent `value=` args,
+    which left the panel stuck on "(no output yet)" while the deque filled up.
+    """
     lines = list(_get_lines(name))
     body = "\n".join(lines) if lines else "(no output yet)"
-    st.text_area(
-        f"log — {name}",
-        value=body,
-        height=height,
-        key=f"_proc_{name}_textarea",
-        label_visibility="collapsed",
-        disabled=True,
-    )
+    with st.container(height=height, border=True, autoscroll=True):
+        st.code(body, language=None, wrap_lines=False)
     cols = st.columns([1, 1, 6])
     with cols[0]:
         st.button("🛑 stop", key=f"_proc_{name}_stop", on_click=stop_pipeline, args=(name,), disabled=not is_running(name))


### PR DESCRIPTION
## Problem

Clicking ▶ run on any control-panel pipeline (reporting / planning / newsletter / engagement scrape & classify) left the log panel stuck on (no output yet) even though the subprocess was running and the status badge was correctly updating.

## Root cause

render_log_panel in app/process_runner.py used a keyed st.text_area(value=body, key=…, disabled=True). Per Streamlit's docs, value on a keyed widget is the value **when it first renders** — subsequent reruns ignore the new value= and display whatever is cached in st.session_state[key]. On first render the body was (no output yet), so the widget cached that and never updated, while the pump thread was correctly filling the deque the whole time.

## Fix

Replace the keyed st.text_area with a scrollable st.container(height=…, border=True, autoscroll=True) wrapping st.code(body, language=None). st.code is a display element, not a widget — it has no session-state cache and re-renders the current body every time. autoscroll=True keeps the newest log line visible without manual scrolling.

One change, app/process_runner.py:render_log_panel, affects all four pipelines that share that helper.

## Verify

- py_compile app/process_runner.py passes.
- Reload the control panel and run any pipeline — the $ <cmd> / # started … lines appear instantly and stdout streams in live with autoscroll to the bottom.