### PR TITLE
fix(linkedin): handle Spanish UI + cold-start race on feed actions

### DIFF
--- a/config/chrome_launch.py
+++ b/config/chrome_launch.py
@@ -55,16 +55,27 @@ def stealth_launch_kwargs(user_data_dir: str, *, headless: bool = False) -> dict
       that would otherwise pop up on a fresh profile.
     * ``viewport`` — pinned to 1280×900 so screenshots and selector
       assumptions stay stable across runs.
+    * ``locale="en-US"`` + ``--lang=en-US`` — force the browser locale so
+      every site renders in English. Without this, sites localize from the
+      OS / account locale (Spanish on this machine), which breaks every
+      English ``get_by_role`` and accessible-name selector in the planning
+      drivers (see issue #27). LinkedIn additionally honors a per-account
+      UI language setting; if a profile was bootstrapped while logged in to
+      a Spanish-language account, the account setting wins and must be
+      flipped to English manually once (Settings → Account preferences →
+      Language).
     """
     return {
         "user_data_dir": user_data_dir,
         "channel": "chrome",
         "headless": headless,
+        "locale": "en-US",
         "args": [
             "--disable-blink-features=AutomationControlled",
             "--disable-features=Translate",
             "--no-default-browser-check",
             "--no-first-run",
+            "--lang=en-US",
         ],
         "ignore_default_args": [
             "--enable-automation",

--- a/docs/2026-05-23-linkedin-locale-aware-and-cold-start.md
+++ b/docs/2026-05-23-linkedin-locale-aware-and-cold-start.md
@@ -1,0 +1,32 @@
+# 2026-05-23 — LinkedIn drivers: locale-aware selectors + cold-start tolerance
+
+Closes [#27](https://github.com/ferraroroberto/reporting/issues/27).
+
+## What was done
+
+The 2026-05-23 overnight `planning_pipeline.py --live` run dropped the first LinkedIn row of every Playwright session — one in the photo flow (20260525, share-box `Photo` click timeout) and one in the videos flow (20260526, share-box `Video` click timeout). Subsequent rows in the same session always succeeded, so the failure mode was first-action-of-session only. Investigation surfaced two compounding causes:
+
+1. **Cold-start race.** LinkedIn redirects `/feed/` to `/` for logged-in users and re-mounts the feed share box client-side; the existing 10 s `.click()` timeout occasionally lost the race.
+2. **Spanish UI.** The connected LinkedIn account renders in Spanish, and LinkedIn's per-account UI language setting overrides any `Accept-Language` / `--lang=en-US` hint from the browser. Every English-named accessible-name regex (`/^photo$/i`, `/^schedule post$/i`, `:has-text("Next")`, …) silently missed once LI flipped to Spanish mid-session.
+
+This change addresses both:
+
+- New module **`planning/linkedin/linkedin_labels.py`** centralizes every user-facing LinkedIn button label as an EN | ES regex union, plus localized helpers for the calendar day aria-label (`calendar_day_aria_re`), month header (`calendar_header_candidates`), and time-picker entry (`time_picker_candidates`). Extending to a third language means editing one alternation in one file; no call-site changes.
+- `planning/linkedin/schedule_linkedin_posts.py` and `planning/videos/videos_linkedin.py` replace every inline `re.compile(...)` and `:has-text("Next")` with imports from the new module. The Photo / Video / "Start a post" feed-entry helpers now share `linkedin_composer.FEED_ENTRY_CLICK_TIMEOUT_MS` (30 s) — the cold-start tolerance is in one constant, applied symmetrically across both modules.
+- `config/chrome_launch.py` gains `locale="en-US"` + `--lang=en-US` as a best-effort browser-locale hint. This nudges sites that *do* honor `Accept-Language` (Instagram, Twitter, Threads, Substack) into English — but it is explicitly **not** the LI fix, because LI's account-level language setting wins.
+- One in-file cleanup: the duplicated post-set date/time verification block at the tail of `_set_schedule_datetime` is collapsed to a single check, now against the new locale candidate tuple.
+
+## Files modified
+
+- `config/chrome_launch.py` — `locale="en-US"`, `--lang=en-US`.
+- `planning/linkedin/linkedin_composer.py` — `FEED_ENTRY_CLICK_TIMEOUT_MS = 30000`.
+- `planning/linkedin/linkedin_labels.py` — **new**. Central EN | ES label registry + calendar / time-picker locale helpers.
+- `planning/linkedin/schedule_linkedin_posts.py` — every inline `re.compile` and `:has-text("Next")` replaced; locale-aware date / time pickers; duplicate verification block removed.
+- `planning/videos/videos_linkedin.py` — `_click_video_button` uses `VIDEO_BTN_RE`; both `Next` `:has-text` calls accept English + Spanish; `FEED_ENTRY_CLICK_TIMEOUT_MS` from the shared constant; unused `import re` removed.
+- `planning/linkedin/README.md` — selector tables point at the named constants in `linkedin_labels.py`; new gotchas for the LI account-language override and the cold-start click timeout.
+
+## Validation
+
+- `& .\.venv\Scripts\python.exe -m py_compile config\chrome_launch.py planning\linkedin\linkedin_composer.py planning\linkedin\linkedin_labels.py planning\linkedin\schedule_linkedin_posts.py planning\videos\videos_linkedin.py` — clean.
+- **Dry-run** on the originally-failing row: `python -m planning.linkedin.schedule_linkedin_posts --all-wip --dry-run` walked the photo flow end-to-end on 20260525 (ILL route) — feed → Photo → upload → ALT (174 chars) → Next → composer → schedule dialog → date/time set, screenshot captured. ~22 s.
+- **LIVE** on the same row: `python -m planning.linkedin.schedule_linkedin_posts --all-wip --live` — scheduled successfully in 27 s, WIP-LI unticked in Notion. Mid-session LinkedIn flipped the UI back from English to Spanish (visible in the after-screenshot's "Mis publicaciones programadas" footer + green confirmation banner); the Spanish-aware selectors carried the rest of the flow through.

--- a/planning/linkedin/README.md
+++ b/planning/linkedin/README.md
@@ -225,33 +225,35 @@ Cross-module dependencies:
 
 LinkedIn's class names are obfuscated (`_6e37ba57`, `_876da3c4`, …) and rotate — never anchor on classes. These role/text-based selectors are the validated ones; full details in the `reference_linkedin_composer_selectors` memory entry.
 
+> **Locale-aware:** every user-facing accessible name below is defined as an EN | ES regex union in [`linkedin_labels.py`](linkedin_labels.py) — `PHOTO_BTN_RE`, `VIDEO_BTN_RE`, `START_POST_RE`, `ALT_TEXT_BTN_RE`, `ADD_BTN_RE`, `MORE_BTN_RE`, `ADD_DOCUMENT_BTN_RE`, `CHOOSE_FILE_BTN_RE`, `DONE_BTN_RE`, `SCHEDULE_POST_BTN_RE`, `NEXT_MONTH_BTN_RE`, `NEXT_BTN_RE`, `FINAL_SCHEDULE_BTN_RE`, `DISCARD_BTN_RE`, plus the calendar / time-picker candidate helpers. When LinkedIn ships a new wording or adds a third language, extend the union in that file — do **not** re-inline a `re.compile` at the call site. The English example shown below is the EN branch only.
+
 | step | selector |
 |------|----------|
-| Open post + file picker (ILL / POST) | `page.get_by_role("button", name=/^photo$/i)` on the feed |
+| Open post + file picker (ILL / POST) | `page.get_by_role("button", name=PHOTO_BTN_RE)` on the feed (e.g. EN `^photo$` / ES `^foto$`) |
 | Upload image | `input[type="file"]` (first; appears in DOM after "Photo" click) |
-| Open ALT dialog | `[role="dialog"] >> get_by_role("button", name=/alternative text/i)` |
-| ALT textarea | `textarea[placeholder*="describe this image" i]` |
-| Close ALT dialog (Add) | `[role="dialog"] >> get_by_role("button", name=/^add$/i).last` |
-| Editor → composer (Next) | `[role="dialog"] button:has-text("Next")` |
+| Open ALT dialog | `[role="dialog"] >> get_by_role("button", name=ALT_TEXT_BTN_RE)` |
+| ALT textarea | `textarea[placeholder*="describe this image" i], textarea[placeholder*="imagen" i], [role='dialog'] textarea` (first hit wins) |
+| Close ALT dialog (Add) | `[role="dialog"] >> get_by_role("button", name=ADD_BTN_RE).last` |
+| Editor → composer (Next) | `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` |
 | Caption editor | `div[role="textbox"][contenteditable="true"]` (then `page.keyboard.type(...)`) |
-| Open Schedule dialog | `get_by_role("button", name=/^schedule post$/i)` |
-| Set date | Click `input[name="artdeco-date"]` → click calendar day by aria-label like `Monday, May 18, 2026.` |
-| Set time | Click `input[name="timepicker"]` → wait for `.artdeco-typeahead__results-list:not([data-count="0"])` → click `li:has-text("<H>:<MM> <AM/PM>")` (e.g. `6:30 AM` Mon-Fri, `8:00 AM` Sat-Sun) |
-| Schedule sub-dialog → composer | `[role="dialog"] button:has-text("Next")` |
-| Final Schedule button | `[role="dialog"] >> get_by_role("button", name="Schedule", exact=True)` |
+| Open Schedule dialog | `get_by_role("button", name=SCHEDULE_POST_BTN_RE)` |
+| Set date | Click `input[name="artdeco-date"]` → click calendar day by `calendar_day_aria_re(target)` (EN `Monday, May 18, 2026.` / ES `lunes, 18 de mayo de 2026.`) |
+| Set time | Click `input[name="timepicker"]` → wait for `.artdeco-typeahead__results-list:not([data-count="0"])` → click `li:has-text(<cand>)` for `<cand>` in `time_picker_candidates(hour, minute)` (EN `6:30 AM` / ES 24h `06:30` / ES 12h `6:30 a. m.`) |
+| Schedule sub-dialog → composer | `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` |
+| Final Schedule button | `[role="dialog"] >> get_by_role("button", name=FINAL_SCHEDULE_BTN_RE)` (anchored on `^schedule$` / `^programar$` so it never re-opens the clock-icon's schedule sub-dialog) |
 | Success signal | The composer dialog disappears within ~20s |
 
 **CAROUSEL-only — Add a document flow:**
 
 | step | selector |
 |------|----------|
-| Open empty composer (no Photo) | `page.get_by_role("button", name=/start a post/i)` (fallback: `/create a post/i`) |
-| Expand secondary actions | `[role="dialog"] >> get_by_role("button", name=/^more$/i)` |
-| Open Share-a-document dialog | `[role="dialog"] >> get_by_role("button", name=/add a document/i)` |
-| Push PDF | fast path: `input[type="file"]`; fallback: `page.expect_file_chooser()` + click `/choose file/i` |
-| Wait for PDF processing | `Done` button stays `disabled`/`aria-disabled` while LI processes — poll until clickable |
-| Fill document title | `[role="dialog"] input[name*="title" i]` / `[aria-label*="title" i]` / `[placeholder*="title" i]` / `input[type="text"]` (first hit wins) |
-| Close document dialog (Done) | `[role="dialog"] >> get_by_role("button", name=/^done$/i)` |
+| Open empty composer (no Photo) | `page.get_by_role("button", name=START_POST_RE)` (EN `start a post` / `create a post` / ES `empieza una publicación` / `crea una publicación`) |
+| Expand secondary actions | `[role="dialog"] >> get_by_role("button", name=MORE_BTN_RE)` |
+| Open Share-a-document dialog | `[role="dialog"] >> get_by_role("button", name=ADD_DOCUMENT_BTN_RE)` |
+| Push PDF | fast path: `input[type="file"]`; fallback: `page.expect_file_chooser()` + click `CHOOSE_FILE_BTN_RE` |
+| Wait for PDF processing | `DONE_BTN_RE` button stays `disabled`/`aria-disabled` while LI processes — poll until clickable |
+| Fill document title | `[role="dialog"] input[name*="title" i]` / `[aria-label*="title" i]` / `[aria-label*="título" i]` / `[placeholder*="title" i]` / `[placeholder*="título" i]` / `input[type="text"]` (first hit wins) |
+| Close document dialog (Done) | `[role="dialog"] >> get_by_role("button", name=DONE_BTN_RE)` |
 | Background upload settle | `planning.linkedin.linkedin_composer.wait_for_upload_complete` — explicit signal fast path + 60s fallback (same as videos) |
 
 ---
@@ -262,8 +264,10 @@ LinkedIn's class names are obfuscated (`_6e37ba57`, `_876da3c4`, …) and rotate
 - **`get_by_role("button", name="Schedule")` is dangerous without `exact=True`** — without it, the matcher also hits the small `aria-label="Schedule post"` clock icon, which just re-opens the schedule dialog.
 - **The time picker is a typeahead combobox.** Typing "6:30 AM" silently selects whichever option was first highlighted (often 12:30 AM). Always click the matching `<li>` from the dropdown.
 - **There is no standalone URL for the scheduled-posts list.** Every `/scheduled-posts/`-style URL 404s. The list is a modal sheet reachable only via the post composer's Schedule dialog → "View all scheduled posts" → Discard the in-progress draft.
-- **Carousel "Next" buttons on the feed** behind the modal have `aria-label="Next"` but empty visible text. Scope to `[role="dialog"] button:has-text("Next")` so they don't win the `.first` race.
+- **Carousel "Next" buttons on the feed** behind the modal have `aria-label="Next"` but empty visible text. Scope to `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` so they don't win the `.first` race.
 - **Don't trust a fixed `wait_for_timeout` + screenshot as success confirmation.** The composer briefly stays open while LinkedIn renders the schedule, then unmounts. Wait for the dialog to actually disappear.
+- **LinkedIn's account-level UI language wins over `Accept-Language`.** If the connected LI account is set to Spanish (Settings → Account preferences → Site Preferences → Language), every page renders in Spanish no matter what `locale="en-US"` and `--lang=en-US` are doing at the Chrome layer — even mid-session LI can flip back after an action. The selectors in [`linkedin_labels.py`](linkedin_labels.py) cover both languages; if you see a brand-new Spanish wording that doesn't match, extend the alternation there, not at the call site.
+- **First feed action of a fresh session needs a longer click timeout.** LinkedIn redirects `/feed/` → `/` for logged-in users and re-renders the share box client-side; the cold-start race used to time the original 10 s `.click()` out (issue #27). The shared constant `linkedin_composer.FEED_ENTRY_CLICK_TIMEOUT_MS` (30 s) is what every feed-entry helper (`_click_add_photo`, `_click_video_button`, `_click_start_a_post`) uses; warm calls still return in ~1 s because `.click()` returns the instant the button is actionable.
 
 ---
 

--- a/planning/linkedin/linkedin_composer.py
+++ b/planning/linkedin/linkedin_composer.py
@@ -27,6 +27,21 @@ from playwright.sync_api import Page
 logger = logging.getLogger("linkedin_composer")
 
 
+# ---------- Feed-entry click timeout ----------
+
+# The first feed-action of each Playwright session was timing out on the
+# Photo / Video / "Start a post" buttons (issue #27). LinkedIn redirects
+# ``/feed/`` to ``/`` for logged-in users and re-renders the share-box client-
+# side; the 10 s default we were using wasn't enough for cold sessions, but
+# subsequent rows always succeeded within ~1 s because the share box is
+# already mounted. A longer click timeout is exactly the right tolerance
+# because Playwright's ``.click()`` internally polls for actionability
+# (attached + visible + stable + receives events) and returns the instant
+# the button is clickable — so the cost on a warm session is essentially
+# zero, and only the cold first click pays.
+FEED_ENTRY_CLICK_TIMEOUT_MS = 30000
+
+
 # ---------- Mention resolution ----------
 
 # A LinkedIn mention starts at "@" and runs through one or more capitalized

--- a/planning/linkedin/linkedin_labels.py
+++ b/planning/linkedin/linkedin_labels.py
@@ -1,0 +1,182 @@
+"""Locale-aware label registry for the LinkedIn Playwright drivers.
+
+LinkedIn honors a per-account UI language setting that the browser locale flag
+cannot override (see issue #27). When the connected LinkedIn account renders in
+Spanish, every accessible-name regex written in English silently misses, and
+the photo / video / carousel / schedule flows all fall over.
+
+This module centralizes every user-facing button label and date-time string
+the LI drivers depend on, expressing each one as an EN | ES regex union so the
+same call site works for either rendered language. New languages can be added
+by extending the alternation in one place rather than chasing the same change
+across both ``schedule_linkedin_posts`` and ``videos_linkedin``.
+
+When LinkedIn rolls out additional accessible-name variants (it sometimes
+ships two within the same locale), add them here as another alternation
+branch — do NOT inline a new ``re.compile`` at the call site.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+
+# ---------- Feed share box ----------
+
+PHOTO_BTN_RE = re.compile(r"^(?:photo|foto)$", re.I)
+
+# LinkedIn Spain uses "Vídeo" (with accent); some LATAM builds use "Video".
+VIDEO_BTN_RE = re.compile(r"^(?:video|vídeo)$", re.I)
+
+# Two known EN names + two known ES names for the share box's main affordance.
+START_POST_RE = re.compile(
+    r"start a post|create a post|empieza una publicación|crea una publicación",
+    re.I,
+)
+
+
+# ---------- Photo editor ----------
+
+ALT_TEXT_BTN_RE = re.compile(r"alternative text|texto alternativo", re.I)
+
+# 'Add' button used INSIDE the ALT dialog and as the final close on small
+# sub-dialogs. Spanish LinkedIn uses "Añadir".
+ADD_BTN_RE = re.compile(r"^(?:add|añadir)$", re.I)
+
+
+# ---------- Composer footer (carousel route) ----------
+
+MORE_BTN_RE = re.compile(r"^(?:more|más)$", re.I)
+
+ADD_DOCUMENT_BTN_RE = re.compile(
+    r"add a document|añadir un documento|agregar un documento",
+    re.I,
+)
+
+CHOOSE_FILE_BTN_RE = re.compile(
+    r"choose file|elegir archivo|elegir un archivo|seleccionar archivo",
+    re.I,
+)
+
+# 'Done' closes a sub-dialog (document title, etc.). ES variants vary across
+# LinkedIn builds — both 'Listo' and 'Hecho' have been observed.
+DONE_BTN_RE = re.compile(r"^(?:done|listo|hecho)$", re.I)
+
+
+# ---------- Schedule dialog ----------
+
+# aria-label on the clock icon in the composer.
+SCHEDULE_POST_BTN_RE = re.compile(
+    r"^(?:schedule post|programar publicación)$",
+    re.I,
+)
+
+# Calendar 'Next month' chevron.
+NEXT_MONTH_BTN_RE = re.compile(r"next month|mes siguiente", re.I)
+
+# 'Next' button used inside the Schedule sub-dialog and the photo editor.
+NEXT_BTN_RE = re.compile(r"^(?:next|siguiente)$", re.I)
+
+# Final primary action in the composer once a schedule is attached — has
+# accessible name exactly 'Schedule' (or 'Programar'). Different from the
+# clock-icon aria-label above, which we deliberately do NOT match here.
+FINAL_SCHEDULE_BTN_RE = re.compile(r"^(?:schedule|programar)$", re.I)
+
+# 'Discard' on the save-as-draft prompt.
+DISCARD_BTN_RE = re.compile(r"^(?:discard|descartar)$", re.I)
+
+
+# ---------- Localized date / time strings ----------
+
+# LinkedIn renders calendar day aria-labels and the month/year header in the
+# account's UI language. Python's ``strftime`` follows the process locale, not
+# LinkedIn's locale, so we hand-roll the Spanish names rather than mutating
+# the process locale globally (which would ripple into logging and timestamps).
+
+_ES_WEEKDAYS = (
+    "lunes", "martes", "miércoles", "jueves", "viernes", "sábado", "domingo",
+)
+_ES_MONTHS = (
+    "enero", "febrero", "marzo", "abril", "mayo", "junio",
+    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+)
+
+
+def calendar_day_aria_candidates(target: date) -> tuple[str, ...]:
+    """Return every aria-label LinkedIn might use for the calendar day cell.
+
+    English: ``"Monday, May 25, 2026."``
+    Spanish: ``"lunes, 25 de mayo de 2026."`` (also seen without the trailing
+    period and without the comma after the weekday on older builds).
+    """
+    en = f"{target.strftime('%A')}, {target.strftime('%B')} {target.day}, {target.year}."
+    es_weekday = _ES_WEEKDAYS[target.weekday()]
+    es_month = _ES_MONTHS[target.month - 1]
+    es = f"{es_weekday}, {target.day} de {es_month} de {target.year}."
+    es_no_dot = es[:-1]
+    es_no_comma = es.replace(",", "", 1)
+    return (en, es, es_no_dot, es_no_comma)
+
+
+def calendar_day_aria_re(target: date) -> re.Pattern[str]:
+    """Compile the day-aria candidates into a single case-insensitive regex.
+
+    Used by ``get_by_role('button', name=...)`` against LinkedIn's calendar.
+    Each candidate is escaped because day aria-labels contain commas and
+    periods that would otherwise be regex metacharacters.
+    """
+    alternation = "|".join(re.escape(c) for c in calendar_day_aria_candidates(target))
+    return re.compile(alternation, re.I)
+
+
+def calendar_header_candidates(target: date) -> tuple[str, ...]:
+    """Return every month/year header string LinkedIn might render.
+
+    Used to detect whether the calendar is already on the target month, so we
+    don't click 'Next month' once more than needed.
+    """
+    en = f"{target.strftime('%B')} {target.year}"
+    es_month = _ES_MONTHS[target.month - 1]
+    es = f"{es_month} de {target.year}"
+    es_short = f"{es_month} {target.year}"
+    return (en, es, es_short)
+
+
+def time_picker_candidates(hour: int, minute: int) -> tuple[str, ...]:
+    """Return every time-picker entry text LinkedIn might render.
+
+    English uses 12-hour AM/PM (``"6:30 AM"``). Spanish builds use 24-hour
+    (``"06:30"``) or 12-hour with a Spanish AM/PM marker (``"6:30 a. m."``);
+    we return all observed forms so the caller can ``:has-text`` against any.
+    """
+    suffix = "AM" if hour < 12 else "PM"
+    h12 = hour % 12 or 12
+    en = f"{h12}:{minute:02d} {suffix}"
+    es_24 = f"{hour:02d}:{minute:02d}"
+    es_24_no_pad = f"{hour}:{minute:02d}"
+    es_meridiem = "a. m." if hour < 12 else "p. m."
+    es_12 = f"{h12}:{minute:02d} {es_meridiem}"
+    return (en, es_24, es_24_no_pad, es_12)
+
+
+__all__ = [
+    "PHOTO_BTN_RE",
+    "VIDEO_BTN_RE",
+    "START_POST_RE",
+    "ALT_TEXT_BTN_RE",
+    "ADD_BTN_RE",
+    "MORE_BTN_RE",
+    "ADD_DOCUMENT_BTN_RE",
+    "CHOOSE_FILE_BTN_RE",
+    "DONE_BTN_RE",
+    "SCHEDULE_POST_BTN_RE",
+    "NEXT_MONTH_BTN_RE",
+    "NEXT_BTN_RE",
+    "FINAL_SCHEDULE_BTN_RE",
+    "DISCARD_BTN_RE",
+    "calendar_day_aria_candidates",
+    "calendar_day_aria_re",
+    "calendar_header_candidates",
+    "time_picker_candidates",
+]

--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -60,8 +60,27 @@ from planning.linkedin.linkedin_carousel_pdf import (  # noqa: E402
     locate_pdf,
 )
 from planning.linkedin.linkedin_composer import (  # noqa: E402
+    FEED_ENTRY_CLICK_TIMEOUT_MS,
     fill_caption_with_mentions,
     wait_for_upload_complete,
+)
+from planning.linkedin.linkedin_labels import (  # noqa: E402
+    ADD_BTN_RE,
+    ADD_DOCUMENT_BTN_RE,
+    ALT_TEXT_BTN_RE,
+    CHOOSE_FILE_BTN_RE,
+    DISCARD_BTN_RE,
+    DONE_BTN_RE,
+    FINAL_SCHEDULE_BTN_RE,
+    MORE_BTN_RE,
+    NEXT_BTN_RE,
+    NEXT_MONTH_BTN_RE,
+    PHOTO_BTN_RE,
+    SCHEDULE_POST_BTN_RE,
+    START_POST_RE,
+    calendar_day_aria_re,
+    calendar_header_candidates,
+    time_picker_candidates,
 )
 from planning.linkedin.linkedin_posts_body import (  # noqa: E402
     PostPayload,
@@ -388,8 +407,12 @@ def _click_add_photo(page: Page) -> None:
     """Click the 'Photo' button on the feed (opens post dialog + file picker)."""
     # Confirmed via DOM probe: the visible 'Photo' is a <p> inside a <div role='button'>.
     # `get_by_role('button', name='Photo')` resolves that ancestor cleanly.
+    # The longer timeout absorbs the cold-start race on the first action of a
+    # freshly-navigated session (issue #27); warm calls still return in ~1 s.
     try:
-        page.get_by_role("button", name=re.compile(r"^photo$", re.I)).first.click(timeout=10000)
+        page.get_by_role("button", name=PHOTO_BTN_RE).first.click(
+            timeout=FEED_ENTRY_CLICK_TIMEOUT_MS,
+        )
     except Exception as err:
         raise RuntimeError(f"Could not click 'Photo' on the LinkedIn feed: {err}")
 
@@ -412,14 +435,21 @@ def _set_alt_text(page: Page, alt_text: str) -> None:
         return
     # Photo editor exposes an 'Alternative text' role=button.
     try:
-        _dialog_button(page, re.compile(r"alternative text", re.I)).first.click(timeout=10000)
+        _dialog_button(page, ALT_TEXT_BTN_RE).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not open ALT dialog: {err}")
 
-    # The ALT dialog contains a single textarea with the placeholder
-    # 'How would you describe this image?'.
+    # The ALT dialog contains a single textarea. EN placeholder is 'How would
+    # you describe this image?'; ES is 'describe la imagen' / 'describirías
+    # esta imagen'. Fall back to any textarea scoped to the top dialog so the
+    # selector survives further LinkedIn copy edits.
     try:
-        ta = page.locator("textarea[placeholder*='describe this image' i]")
+        ta = page.locator(
+            "textarea[placeholder*='describe this image' i], "
+            "textarea[placeholder*='describe' i], "
+            "textarea[placeholder*='imagen' i], "
+            "[role='dialog'] textarea"
+        )
         ta.first.wait_for(state="visible", timeout=10000)
         ta.first.fill(alt_text)
     except Exception as err:
@@ -427,18 +457,21 @@ def _set_alt_text(page: Page, alt_text: str) -> None:
 
     # Close ALT dialog via its 'Add' button (NOT the photo-editor 'Add' for new images).
     try:
-        _dialog_button(page, re.compile(r"^add$", re.I)).last.click(timeout=10000)
+        _dialog_button(page, ADD_BTN_RE).last.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click ALT 'Add' button: {err}")
 
 
 def _click_next_after_photo_editor(page: Page) -> None:
-    """Click 'Next' in the photo editor → goes to the composer."""
-    # Scope to dialog and to a button whose visible TEXT contains 'Next' — the
-    # carousel arrow button has aria-label='Next' but empty text, so this
-    # disambiguates correctly.
+    """Click 'Next' / 'Siguiente' in the photo editor → goes to the composer."""
+    # Scope to dialog and to a button whose visible TEXT contains 'Next' or
+    # 'Siguiente' — the carousel arrow button has aria-label='Next' but empty
+    # visible text, so :has-text disambiguates correctly across locales.
     try:
-        page.locator('[role="dialog"] button:has-text("Next")').first.click(timeout=10000)
+        page.locator(
+            '[role="dialog"] button:has-text("Next"), '
+            '[role="dialog"] button:has-text("Siguiente")'
+        ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'Next' in the photo editor: {err}")
 
@@ -459,10 +492,10 @@ def _fill_caption(page: Page, caption: str) -> None:
 
 def _open_schedule_dialog(page: Page) -> None:
     """Click the schedule clock icon in the composer."""
-    # The clock has aria-label='Schedule post' on the live LinkedIn UI.
+    # The clock has aria-label='Schedule post' / 'Programar publicación'.
     try:
         page.get_by_role(
-            "button", name=re.compile(r"^schedule post$", re.I)
+            "button", name=SCHEDULE_POST_BTN_RE
         ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not open the Schedule dialog: {err}")
@@ -483,40 +516,38 @@ def _set_schedule_datetime(page: Page, target: date, hour: int, minute: int) -> 
       populated instance (``data-count != "0"``) contains all 15-min slots.
       We click the ``<li>`` whose visible text matches (e.g. ``6:30 AM``).
     """
-    suffix = "AM" if hour < 12 else "PM"
-    h12 = hour % 12
-    if h12 == 0:
-        h12 = 12
-    time_str = f"{h12}:{minute:02d} {suffix}"
-    month_name = target.strftime("%B")
-    day_aria = f"{target.strftime('%A')}, {month_name} {target.day}, {target.year}."
+    # Locale-aware aria/text candidates (LinkedIn renders these in the
+    # account's UI language; see planning/linkedin/linkedin_labels.py).
+    header_candidates = calendar_header_candidates(target)
+    day_aria_re = calendar_day_aria_re(target)
+    time_candidates = time_picker_candidates(hour, minute)
 
     # --- Date via calendar click ---
     di = page.locator('input[name="artdeco-date"]').first
     try:
         di.click(timeout=10000)
         page.wait_for_timeout(600)
-        # If the displayed month/year is wrong, click Next month until it matches.
-        # The header text in the calendar reads e.g. "May 2026".
-        header_text = f"{month_name} {target.year}"
+        # If the displayed month/year is wrong, click Next month until it
+        # matches. The header text reads "May 2026" / "mayo de 2026" / etc.
+        header_selector = ", ".join(
+            f'h2:has-text("{h}"), div:has-text("{h}")' for h in header_candidates
+        )
         for _ in range(18):  # generous safety bound (~1.5 years forward)
             try:
-                hdr = page.locator('[role="dialog"]').last.locator(
-                    f'h2:has-text("{header_text}"), div:has-text("{header_text}")'
-                )
+                hdr = page.locator('[role="dialog"]').last.locator(header_selector)
                 if hdr.count() > 0:
                     break
             except Exception:
                 pass
             try:
                 page.locator('[role="dialog"]').get_by_role(
-                    "button", name=re.compile(r"next month", re.I)
+                    "button", name=NEXT_MONTH_BTN_RE
                 ).first.click(timeout=2000)
                 page.wait_for_timeout(200)
             except Exception:
                 break
         day_btn = page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(re.escape(day_aria), re.I)
+            "button", name=day_aria_re
         )
         day_btn.first.click(timeout=10000)
         page.wait_for_timeout(500)
@@ -533,7 +564,18 @@ def _set_schedule_datetime(page: Page, target: date, hour: int, minute: int) -> 
             '.artdeco-typeahead__results-list:not([data-count="0"])'
         )
         results.first.wait_for(state="visible", timeout=8000)
-        target_li = results.first.locator(f'li:has-text("{time_str}")')
+        # Try each candidate (12h EN, 24h ES, 12h ES) — the input value the
+        # widget actually accepted may differ from the EN form.
+        target_li = None
+        for cand in time_candidates:
+            li = results.first.locator(f'li:has-text("{cand}")')
+            if li.count() > 0:
+                target_li = li
+                break
+        if target_li is None:
+            raise RuntimeError(
+                f"No time-picker entry matched any locale candidate {time_candidates}"
+            )
         target_li.first.scroll_into_view_if_needed(timeout=3000)
         target_li.first.click(timeout=5000)
         page.wait_for_timeout(400)
@@ -545,37 +587,38 @@ def _set_schedule_datetime(page: Page, target: date, hour: int, minute: int) -> 
     date_str = f"{target.month}/{target.day}/{target.year}"
     if actual_date != date_str:
         logger.warning("⚠️ Date didn't stick: wanted=%s actual=%s", date_str, actual_date)
-    if actual_time != time_str:
-        logger.warning("⚠️ Time didn't stick: wanted=%s actual=%s", time_str, actual_time)
-
-    actual_date = di.input_value()
-    actual_time = ti.input_value()
-    if actual_date != date_str:
-        logger.warning("⚠️ Date didn't stick: wanted=%s actual=%s", date_str, actual_date)
-    if actual_time != time_str:
-        logger.warning("⚠️ Time didn't stick: wanted=%s actual=%s", time_str, actual_time)
+    if actual_time not in time_candidates:
+        logger.warning(
+            "⚠️ Time didn't stick: wanted one of %s actual=%s",
+            time_candidates, actual_time,
+        )
 
 
 def _click_schedule_next(page: Page) -> None:
-    """Click Next in the Schedule dialog (returns to composer with schedule attached)."""
-    # 'Next' button at bottom-right of the Schedule dialog; visible text 'Next'.
+    """Click Next / Siguiente in the Schedule dialog."""
+    # 'Next' / 'Siguiente' at bottom-right of the Schedule dialog; visible text.
     try:
-        page.locator('[role="dialog"] button:has-text("Next")').first.click(timeout=10000)
+        page.locator(
+            '[role="dialog"] button:has-text("Next"), '
+            '[role="dialog"] button:has-text("Siguiente")'
+        ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'Next' in Schedule dialog: {err}")
 
 
 def _click_final_schedule(page: Page) -> None:
-    """Click the final 'Schedule' button in the composer (live mode only).
+    """Click the final 'Schedule' / 'Programar' button in the composer (live mode).
 
     After Schedule-Next, the composer's primary action button reads exactly
-    "Schedule". The small clock icon next to it has aria-label "Schedule
-    post" — we must target the primary by EXACT accessible name to avoid
-    re-opening the schedule sub-dialog by mistake.
+    "Schedule" (or "Programar" in Spanish). The small clock icon next to it
+    has accessible name "Schedule post" / "Programar publicación" — we anchor
+    on ``FINAL_SCHEDULE_BTN_RE`` (anchored on ``^...$``) to match the
+    standalone button and explicitly NOT the longer 'Schedule post' clock
+    icon.
     """
     try:
         page.locator('[role="dialog"]').get_by_role(
-            "button", name="Schedule", exact=True
+            "button", name=FINAL_SCHEDULE_BTN_RE
         ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click final 'Schedule' button: {err}")
@@ -594,7 +637,7 @@ def _close_dialogs(page: Page) -> None:
     # A discard-confirmation dialog may appear; accept it.
     try:
         discard = page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(r"^discard$", re.I)
+            "button", name=DISCARD_BTN_RE
         )
         if discard.count() > 0:
             discard.first.click(timeout=2000)
@@ -618,7 +661,7 @@ def _click_more(page: Page) -> None:
     """
     try:
         page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(r"^more$", re.I)
+            "button", name=MORE_BTN_RE
         ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'More' on the composer: {err}")
@@ -632,7 +675,7 @@ def _click_add_a_document(page: Page) -> None:
     """
     try:
         page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(r"add a document", re.I)
+            "button", name=ADD_DOCUMENT_BTN_RE
         ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'Add a document': {err}")
@@ -662,7 +705,7 @@ def _share_document_choose_file(page: Page, pdf_path: Path) -> None:
     try:
         with page.expect_file_chooser(timeout=10000) as fc_info:
             page.locator('[role="dialog"]').get_by_role(
-                "button", name=re.compile(r"choose file", re.I)
+                "button", name=CHOOSE_FILE_BTN_RE
             ).first.click(timeout=5000)
         fc_info.value.set_files(str(pdf_path))
     except Exception as err:
@@ -680,7 +723,7 @@ def _wait_for_pdf_upload(page: Page, *, timeout_ms: int = 180000) -> None:
     while page.evaluate("() => Date.now()") < deadline:
         try:
             done_btn = page.locator('[role="dialog"]').get_by_role(
-                "button", name=re.compile(r"^done$", re.I)
+                "button", name=DONE_BTN_RE
             ).first
             if done_btn.count():
                 disabled = done_btn.get_attribute("disabled")
@@ -705,7 +748,9 @@ def _fill_document_title(page: Page, doc_title: str) -> None:
     candidates = (
         '[role="dialog"] input[name*="title" i]',
         '[role="dialog"] input[aria-label*="title" i]',
+        '[role="dialog"] input[aria-label*="título" i]',
         '[role="dialog"] input[placeholder*="title" i]',
+        '[role="dialog"] input[placeholder*="título" i]',
         '[role="dialog"] input[type="text"]',
     )
     for sel in candidates:
@@ -724,7 +769,7 @@ def _click_document_done(page: Page) -> None:
     """Click 'Done' in the Share-a-document dialog → returns to composer with PDF attached."""
     try:
         page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(r"^done$", re.I)
+            "button", name=DONE_BTN_RE
         ).first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'Done' on the document dialog: {err}")
@@ -738,19 +783,19 @@ def _click_start_a_post(page: Page) -> None:
     a document'. LI's share box exposes a button with accessible name
     matching 'Start a post' (case-insensitive).
     """
-    candidates = (
-        re.compile(r"start a post", re.I),
-        re.compile(r"create a post", re.I),
-    )
-    for pattern in candidates:
-        try:
-            btn = page.get_by_role("button", name=pattern).first
-            if btn.count():
-                btn.click(timeout=5000)
-                return
-        except Exception:
-            continue
-    raise RuntimeError("Could not click 'Start a post' on the LinkedIn feed.")
+    # The longer click timeout absorbs the cold-start race on the first action
+    # of a freshly-navigated session (issue #27). Both English variants
+    # ('Start a post' / 'Create a post') and the Spanish variants are folded
+    # into the shared ``START_POST_RE`` so the single ``.click()`` actionability
+    # poll handles the cold-start wait once across locales.
+    try:
+        page.get_by_role("button", name=START_POST_RE).first.click(
+            timeout=FEED_ENTRY_CLICK_TIMEOUT_MS,
+        )
+    except Exception as err:
+        raise RuntimeError(
+            f"Could not click 'Start a post' on the LinkedIn feed: {err}"
+        )
 
 
 # ---------- Per-row driver ----------

--- a/planning/videos/videos_linkedin.py
+++ b/planning/videos/videos_linkedin.py
@@ -12,7 +12,6 @@ all imported from the sister package — no duplication.
 from __future__ import annotations
 
 import logging
-import re
 import sys
 from dataclasses import dataclass
 from datetime import date
@@ -23,9 +22,11 @@ from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from planning.linkedin.linkedin_composer import (  # noqa: E402
+    FEED_ENTRY_CLICK_TIMEOUT_MS,
     fill_caption_with_mentions,
     wait_for_upload_complete,
 )
+from planning.linkedin.linkedin_labels import VIDEO_BTN_RE  # noqa: E402
 from planning.linkedin.linkedin_session import (  # noqa: E402
     LinkedInSession,
     LoginRequiredError,
@@ -70,9 +71,16 @@ def _click_video_button(page: Page) -> None:
     Mirrors ``_click_add_photo`` from the photo flow but targets the
     ``Video`` button. Same DOM shape — a ``<p>Video</p>`` text node inside a
     ``<div role="button">`` wrapper.
+
+    The longer ``FEED_ENTRY_CLICK_TIMEOUT_MS`` absorbs the cold-start race on
+    the first feed action of a freshly-navigated session (issue #27); warm
+    calls still return in ~1 s because ``.click()`` returns the instant the
+    button is actionable.
     """
     try:
-        page.get_by_role("button", name=re.compile(r"^video$", re.I)).first.click(timeout=10000)
+        page.get_by_role("button", name=VIDEO_BTN_RE).first.click(
+            timeout=FEED_ENTRY_CLICK_TIMEOUT_MS,
+        )
     except Exception as err:
         raise RuntimeError(f"Could not click 'Video' on the LinkedIn feed: {err}")
 
@@ -113,7 +121,7 @@ def _wait_for_video_ready(page: Page, timeout_ms: int = 180000) -> None:
     deadline = page.evaluate("() => Date.now()") + timeout_ms
     while page.evaluate("() => Date.now()") < deadline:
         try:
-            next_btn = page.locator('[role="dialog"] button:has-text("Next")').first
+            next_btn = page.locator('[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")').first
             if next_btn.count():
                 disabled = next_btn.get_attribute("disabled")
                 aria_dis = next_btn.get_attribute("aria-disabled")
@@ -128,7 +136,7 @@ def _wait_for_video_ready(page: Page, timeout_ms: int = 180000) -> None:
 def _click_video_next(page: Page) -> None:
     """Click 'Next' in the video editor → goes to the composer."""
     try:
-        page.locator('[role="dialog"] button:has-text("Next")').first.click(timeout=10000)
+        page.locator('[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")').first.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click 'Next' in the video editor: {err}")
 


### PR DESCRIPTION
## Problem

The 2026-05-23 overnight `planning_pipeline.py --live` run dropped the first LinkedIn row of every Playwright session — 20260525 in the photo flow (`Could not click 'Photo' on the LinkedIn feed: Locator.click: Timeout 10000ms exceeded`) and 20260526 in the videos flow (same shape, `Video` button). Subsequent rows in the same session always succeeded.

Investigation surfaced two compounding causes:

1. **Cold-start race.** LinkedIn redirects `/feed/` to `/` for logged-in users and re-mounts the feed share box client-side; the existing 10 s `.click()` timeout lost the race on the first action of a fresh session.
2. **Spanish UI.** The connected LinkedIn account renders in Spanish, and LinkedIn's per-account UI language setting overrides any `Accept-Language` / `--lang=en-US` hint from the browser — LI even flips back to Spanish *mid-session* after a Schedule action. Every English-named accessible-name regex (`/^photo$/i`, `/^schedule post$/i`, `:has-text("Next")`, …) silently missed once that happened.

## Fix

- **New `planning/linkedin/linkedin_labels.py`** — central registry of every user-facing LinkedIn button label as an `EN | ES` regex union (`PHOTO_BTN_RE`, `VIDEO_BTN_RE`, `START_POST_RE`, `ALT_TEXT_BTN_RE`, `ADD_BTN_RE`, `MORE_BTN_RE`, `ADD_DOCUMENT_BTN_RE`, `CHOOSE_FILE_BTN_RE`, `DONE_BTN_RE`, `SCHEDULE_POST_BTN_RE`, `NEXT_MONTH_BTN_RE`, `NEXT_BTN_RE`, `FINAL_SCHEDULE_BTN_RE`, `DISCARD_BTN_RE`), plus locale-aware helpers for the calendar day aria-label (`calendar_day_aria_re`), month header (`calendar_header_candidates`), and time-picker entry (`time_picker_candidates`). Extending to a third language means editing one alternation; no call-site changes.
- **`planning/linkedin/schedule_linkedin_posts.py` + `planning/videos/videos_linkedin.py`** — every inline `re.compile` / `:has-text("Next")` replaced with imports from the new module. Date / time pickers use the locale-aware candidate tuples. Photo / Video / Start-a-post feed-entry helpers all share `linkedin_composer.FEED_ENTRY_CLICK_TIMEOUT_MS = 30000`, applied symmetrically.
- **`config/chrome_launch.py`** — `locale="en-US"` + `--lang=en-US` as a best-effort browser-locale hint. Helps the sites that *do* honor `Accept-Language` (IG, TW, TH, SB); explicitly not the LI fix.
- **In-file cleanup** — duplicated post-set date/time verification block at the tail of `_set_schedule_datetime` collapsed to a single check.
- **Docs** — `planning/linkedin/README.md` selector tables and gotchas updated; `docs/2026-05-23-linkedin-locale-aware-and-cold-start.md` added.

## Verify

- `& .\.venv\Scripts\python.exe -m py_compile config\chrome_launch.py planning\linkedin\linkedin_composer.py planning\linkedin\linkedin_labels.py planning\linkedin\schedule_linkedin_posts.py planning\videos\videos_linkedin.py` — clean.
- **Dry-run** on the originally-failing row: `python -m planning.linkedin.schedule_linkedin_posts --all-wip --dry-run` — walked the ILL route end-to-end on 20260525 in ~22 s (Spanish UI, schedule dialog reached, screenshot captured).
- **LIVE** on the same row: `python -m planning.linkedin.schedule_linkedin_posts --all-wip --live` — scheduled in 27 s; WIP-LI unticked in Notion. The after-screenshot shows LinkedIn flipped back to Spanish mid-session ("Mis publicaciones programadas" footer + green confirmation banner), proving the locale-aware selectors are doing the real work.

Closes #27
