### PR TITLE
feat(pipeline): wire IG → TW/TH/SB clone as step 0 + repost-day caption derivation

### DIFF
--- a/docs/2026-05-23-planning-pipeline-clone-step-0.md
+++ b/docs/2026-05-23-planning-pipeline-clone-step-0.md
@@ -1,0 +1,27 @@
+# 2026-05-23 — Planning pipeline: wire clone as step 0 + derive captions for repost days
+
+Closes [#32](https://github.com/ferraroroberto/reporting/issues/32).
+
+## What was done
+
+While running `planning_pipeline.py` the orchestrator was skipping the IG → TW/TH/SB clone step entirely, leaving every Threads / Twitter / Substack row for the upcoming week with empty captions and illustrations because the platform schedulers downstream only read whatever was already on those columns. The clone module — `planning.instagram.clone_to_other_platforms.main` — exists and works fine when invoked directly; it was just never plugged into the orchestrator.
+
+Wiring it in and running it live for the upcoming week surfaced a second bug: every "repost" day errored with `non-thread day but text IG is empty`. The repost flow is intentional — the canonical caption lives on the illustration's earliest `publishIG` row, reachable via `illustration → publishIG → earliest row's text IG`. The LinkedIn scheduler and the Sunday-thread branch of the clone already do this derivation; the non-thread branch of the clone was the lone outlier that errored instead of falling through.
+
+Both halves ship together as one PR (you can't run the pipeline without the wiring, and you can't run the wiring without the repost fix). Commit order is **fix first, wiring second** so every intermediate commit is functional — landing the wiring before the fix would have published a `main` whose pipeline calls a clone known to error on repost days.
+
+## Files modified
+
+- `planning/instagram/clone_to_other_platforms.py` — `resolve_source` non-thread branch: when `row.text_ig` is empty, fall through to `_canonical_caption_from_publish_ig` (the existing helper) instead of raising. The derived caption is also returned via `CloneSource.ig_row_text` so `apply_to_targets` back-fills the IG row's own `text IG` field — a human reading the editorial DB after a clone run sees real text instead of an empty cell.
+- `planning_pipeline.py` — new `--skip-clone` flag, `_build_clone_args(args)`, `_run_clone(args)`. The clone runs as step 0 before the LinkedIn / Instagram / Twitter / Threads / Videos loop. Clone failures (raises or `SystemExit`) are logged and reported in the final summary but do **not** abort the downstream schedulers — same continue-on-error contract the project already applies between platforms. The orchestrator threads the clone exit code into the same `PlatformResult` shape as every other step; the `_run_platform` helper is not used because clone's `main()` returns a bare `int`, not the platform schedulers' `(int, rows)` tuple.
+- `planning/instagram/README.md` — "Daily / weekly use" header note that the clone now runs from the orchestrator; new gotcha entry for the repost-day `text IG` derivation.
+
+## Validation
+
+- `& .\.venv\Scripts\python.exe -m py_compile planning_pipeline.py planning\instagram\clone_to_other_platforms.py` — clean.
+- `& .\.venv\Scripts\python.exe planning_pipeline.py --dry-run --skip-linkedin --skip-instagram --skip-twitter --skip-threads --skip-videos` — exercises the clone path through the orchestrator with every scheduler off. Output:
+  - `━━━━━━━━━━ Clone (IG → TW/TH/SB) ━━━━━━━━━━` banner prints.
+  - Clone runs in DRY-RUN, lists 6 in-scope WIP-IG rows for 2026-05-25 → 2026-05-31.
+  - All TW/TH/SB targets correctly identified as "already has illustration/text — skipping" (idempotency preserved from the prior live clone run).
+  - The Sunday-thread day (20260531) derives a canonical caption from `publishIG` row `20230211` — proving the publishIG chain still resolves through the wiring.
+- The repost-day non-thread caption derivation itself was validated live in a prior parallel-session run: four days (20260525/26/27/29) had their `text IG` derived from canonical publishIG rows `20241125 / 20241116 / 20241106 / 20230613`, written to TW/TH/SB, and back-filled to the IG row's `text IG`. Already-populated rows correctly skipped.

--- a/planning/instagram/README.md
+++ b/planning/instagram/README.md
@@ -56,8 +56,11 @@ The bootstrap uses the same stealth flags as every other platform (see `config/c
 
 ## Daily / weekly use
 
+The clone now runs automatically as **step 0** of `planning_pipeline.py` (see issue #32), so the per-script invocations below are only needed for ad-hoc / single-step runs. Pass `--skip-clone` to the orchestrator to opt out.
+
 ```powershell
-# 1) Clone IG plan to TW/TH/SB columns (Notion-only; safe to run repeatedly)
+# 1) Clone IG plan to TW/TH/SB columns (Notion-only; safe to run repeatedly).
+#    Skip if you're running planning_pipeline.py — it does this automatically.
 & .\.venv\Scripts\python.exe -m planning.instagram.clone_to_other_platforms --week-start 2026-05-25 --dry-run
 & .\.venv\Scripts\python.exe -m planning.instagram.clone_to_other_platforms --week-start 2026-05-25 --live
 
@@ -211,6 +214,7 @@ Meta's class names are obfuscated and rotate — never anchor on classes. These 
 - **Composer opens at a separate URL (`/composer/...`)** — between days the script navigates back to `feed_url` (the content_calendar) and re-dismisses the upsell modal.
 - **WIP IG is unticked only when BOTH the story AND the post succeed for the day.** Partial failures keep WIP set so the next run retries the same day cleanly. If a day's story succeeded but the post failed mid-run, a re-run will re-schedule a duplicate story — delete the duplicate manually in Meta's planner before the rerun, or accept it.
 - **Notion relation order is preserved by the API.** "First thread illustration" = `post IG → illustration → [0]`. If Meta or Notion ever shuffle relations, fall back to sorting by `created_time` or by `publishIG`-implied first publish date.
+- **Repost days have empty `text IG` by design** (issue #32). The canonical caption lives on the illustration's earliest `publishIG` row's `text IG` field (with the `text IG to copy` formula as last-ditch fallback). The clone resolves this via `_canonical_caption_from_publish_ig` in `clone_to_other_platforms.py` — same helper the LinkedIn scheduler and the Sunday-thread branch use. The derived caption is also back-filled to the IG row's own `text IG` so a manual reader of the editorial DB sees real text instead of an empty cell. Never error on "non-thread day but text IG is empty" — fall through to the publishIG derivation first.
 
 ---
 

--- a/planning/instagram/clone_to_other_platforms.py
+++ b/planning/instagram/clone_to_other_platforms.py
@@ -270,18 +270,37 @@ def resolve_source(notion, cfg: dict, row: IgRow) -> CloneSource:
     template_text = cfg.get("sunday_template_text", "")
 
     if not row.thread_ig:
-        # Regular day — IG row already carries everything we need.
         if not row.illustration_ig_ids:
             raise RuntimeError(
                 f"{row.day_title}: non-thread day but illustration IG is empty."
             )
-        if not row.text_ig:
-            raise RuntimeError(
-                f"{row.day_title}: non-thread day but text IG is empty."
+        illust_id = row.illustration_ig_ids[0]
+        if row.text_ig:
+            caption = row.text_ig
+            ig_back_text: Optional[str] = None
+        else:
+            # Repost (or any non-thread row where `text IG` is empty): derive
+            # the canonical caption from the illustration's publishIG chain
+            # (earliest first-publication row's `text IG`, with the
+            # `text IG to copy` formula as fallback). Same rule the LinkedIn
+            # scheduler and the Sunday-thread branch below use.
+            caption = _canonical_caption_from_publish_ig(
+                notion, illust_id, illust_cols, ed_cols
             )
+            if not caption:
+                raise RuntimeError(
+                    f"{row.day_title}: text IG is empty and no canonical "
+                    "caption could be derived from the illustration's "
+                    "publishIG chain."
+                )
+            # Back-fill the IG row's own `text IG` with the canonical caption
+            # so downstream readers (Meta planner, manual review) see the
+            # actual text instead of an empty field.
+            ig_back_text = caption
         return CloneSource(
-            illustration_id=row.illustration_ig_ids[0],
-            caption_text=row.text_ig,
+            illustration_id=illust_id,
+            caption_text=caption,
+            ig_row_text=ig_back_text,
         )
 
     # Thread day (Sunday).
@@ -339,7 +358,9 @@ def apply_to_targets(
     ed_cols = ig_cfg["editorial_columns"]
     statuses: list[str] = []
 
-    # IG row back-fill (Sunday only; only when fields are currently empty).
+    # IG row back-fill: Sunday template text + first thread illustration; OR
+    # canonical caption derived for non-thread repost days. Only the fields
+    # surfaced by resolve_source are written — empty source fields are no-ops.
     ig_updates: dict = {}
     if source.ig_row_illustration_id:
         ig_updates[ed_cols["illustration_rel"]] = prepare_notion_update(

--- a/planning_pipeline.py
+++ b/planning_pipeline.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
-"""Planning pipeline: schedule every Notion WIP row across LinkedIn, Instagram,
-Twitter, and Threads.
+"""Planning pipeline: clone IG → TW/TH/SB, then schedule every Notion WIP row
+across LinkedIn, Instagram, Twitter, and Threads.
+
+Step 0 (clone): ``planning.instagram.clone_to_other_platforms`` mirrors the
+IG editorial plan onto Threads / Twitter / Substack rows (captions +
+illustrations) and ticks the per-platform WIP checkbox so the downstream
+schedulers can pick them up. A clone failure does NOT block the platform
+schedulers — captured in the summary.
 
 The four platform schedulers each pick up their own WIP-* rows (no date
 filter — supports multi-week planning runs), schedule through the respective
@@ -15,7 +21,9 @@ into the respective platforms' native schedulers.
 
 CLI:
     python planning_pipeline.py [--dry-run | --live] [--debug] [--force]
+        [--skip-clone]
         [--skip-linkedin] [--skip-instagram] [--skip-twitter] [--skip-threads]
+        [--skip-videos]
 """
 from __future__ import annotations
 
@@ -39,6 +47,7 @@ from typing import Callable, Optional
 
 sys.path.append(str(Path(__file__).parent))
 from config.logger_config import setup_logger  # noqa: E402
+from planning.instagram.clone_to_other_platforms import main as run_clone  # noqa: E402
 from planning.linkedin.schedule_linkedin_posts import main as run_linkedin  # noqa: E402
 from planning.instagram.schedule_instagram_posts import main as run_instagram  # noqa: E402
 from planning.twitter.schedule_twitter_posts import main as run_twitter  # noqa: E402
@@ -86,7 +95,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--debug", action="store_true",
                   help="Enable debug logging (passes through to each scheduler).")
     p.add_argument("--force", action="store_true",
-                  help="Passes through: schedule even if link <P> is already populated.")
+                  help="Passes through: schedule even if link <P> is already populated. "
+                       "Also passed to clone (overwrite populated TW/TH/SB targets).")
+    p.add_argument("--skip-clone",     action="store_true",
+                  help="Skip the IG → TW/TH/SB clone step.")
     p.add_argument("--skip-linkedin",  action="store_true")
     p.add_argument("--skip-instagram", action="store_true")
     p.add_argument("--skip-twitter",   action="store_true")
@@ -106,6 +118,59 @@ def _build_scheduler_args(args: argparse.Namespace) -> list[str]:
     if args.force:
         out.append("--force")
     return out
+
+
+def _build_clone_args(args: argparse.Namespace) -> list[str]:
+    # Clone uses --week-start (defaults to next Monday), which matches what the
+    # platform schedulers operate on. No --all-wip equivalent — week-default is right.
+    out: list[str] = []
+    if args.live:
+        out.append("--live")
+    elif args.dry_run:
+        out.append("--dry-run")
+    if args.debug:
+        out.append("--debug")
+    if args.force:
+        out.append("--force")
+    return out
+
+
+def _run_clone(args: argparse.Namespace) -> PlatformResult:
+    """Run the IG → TW/TH/SB clone as step 0. Failures do NOT block schedulers."""
+    assert logger is not None
+    if args.skip_clone:
+        logger.info("⏭️  Skipping Clone (per --skip-clone).")
+        return PlatformResult(name="Clone", skipped=True)
+
+    logger.info("━━━━━━━━━━ Clone (IG → TW/TH/SB) ━━━━━━━━━━")
+    clone_args = _build_clone_args(args)
+    orig_argv = sys.argv.copy()
+    sys.argv = [orig_argv[0]] + clone_args
+    start = time.monotonic()
+    try:
+        exit_code = run_clone()
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 99
+        duration = time.monotonic() - start
+        logger.error("❌ Clone exited via SystemExit(%s) — continuing to schedulers.", code)
+        return PlatformResult(name="Clone", exit_code=code, rows=[], duration_s=duration,
+                              error=f"SystemExit({code})")
+    except Exception as exc:  # noqa: BLE001 — orchestrator MUST swallow
+        duration = time.monotonic() - start
+        logger.exception("❌ Clone raised — continuing to schedulers.")
+        return PlatformResult(name="Clone", exit_code=99, rows=[], duration_s=duration,
+                              error=str(exc))
+    finally:
+        sys.argv = orig_argv
+
+    duration = time.monotonic() - start
+    if exit_code == 0:
+        logger.info("✅ Clone finished in %s.", _fmt_duration(duration))
+        return PlatformResult(name="Clone", exit_code=0, rows=[], duration_s=duration)
+    logger.error("❌ Clone finished with exit code %s in %s — continuing to schedulers.",
+                 exit_code, _fmt_duration(duration))
+    return PlatformResult(name="Clone", exit_code=exit_code, rows=[], duration_s=duration,
+                          error=f"exit code {exit_code}")
 
 
 def _run_platform(
@@ -254,8 +319,10 @@ def main() -> int:
         mode_label = "per-platform config default"
     logger.info("🚀 Planning pipeline starting (%s)", mode_label)
 
-    scheduler_args = _build_scheduler_args(args)
     results: list[PlatformResult] = []
+    results.append(_run_clone(args))
+
+    scheduler_args = _build_scheduler_args(args)
     for name, fn, skip in [
         ("LinkedIn",  run_linkedin,  args.skip_linkedin),
         ("Instagram", run_instagram, args.skip_instagram),


### PR DESCRIPTION
## Problem

Two coupled bugs surfaced during a real `planning_pipeline.py` run for next week:

1. **Clone wasn't running from the orchestrator.** `planning_pipeline.py` was skipping the IG → TW/TH/SB clone step entirely. Every Threads / Twitter / Substack row downstream came up empty because those schedulers only read whatever's already on the editorial DB columns. The clone module (`planning.instagram.clone_to_other_platforms.main`) exists and works fine standalone — it was just never wired in.
2. **Clone errored on every repost day** with `non-thread day but text IG is empty`. Repost rows have an intentionally empty `text IG`; the canonical caption lives on the illustration's earliest `publishIG` row. The LinkedIn scheduler and the Sunday-thread branch of the clone both handle that derivation. The non-thread branch of `clone_to_other_platforms.py::resolve_source` was the lone outlier that raised instead of falling through.

Both ship together — you can't run the pipeline without the wiring, and you can't run the wiring without the repost fix.

## Fix

**Two commits, in this order (fix first, wiring second)** — so every intermediate `main` state is functional. Landing the wiring before the fix would have published a pipeline that calls a clone known to error on repost days.

- **`fix(clone): derive canonical caption for non-thread repost days`** (commit 1) — `clone_to_other_platforms.py::resolve_source` non-thread branch falls through to the existing `_canonical_caption_from_publish_ig` helper when `row.text_ig` is empty. The derived caption is also returned via `CloneSource.ig_row_text` so `apply_to_targets` back-fills the IG row's own `text IG` field — a human reading the editorial DB after a clone run sees real text instead of an empty cell.
- **`feat(pipeline): wire IG → TW/TH/SB clone as step 0`** (commit 2) — `planning_pipeline.py` gains a `--skip-clone` flag, `_build_clone_args(args)`, and `_run_clone(args)`. Clone runs as step 0 before LinkedIn / Instagram / Twitter / Threads / Videos. A clone failure (`SystemExit` or raise) is logged + reported in the final summary but does **not** abort the downstream schedulers — same continue-on-error contract the project already applies between platforms. Clone's `main()` returns a bare `int` (not the platform schedulers' `(int, rows)` tuple), so it must not go through `_run_platform`; `_run_clone` wraps it via the `sys.argv` swap pattern and shapes the result into `PlatformResult` for the summary.

Docs updated: `planning/instagram/README.md` notes the clone runs from the orchestrator now (and `--skip-clone` opts out); new gotcha entry for the repost-day `text IG` derivation. New changelog at `docs/2026-05-23-planning-pipeline-clone-step-0.md`.

## Verify

- `& .\.venv\Scripts\python.exe -m py_compile planning_pipeline.py planning\instagram\clone_to_other_platforms.py` — clean.
- `& .\.venv\Scripts\python.exe planning_pipeline.py --dry-run --skip-linkedin --skip-instagram --skip-twitter --skip-threads --skip-videos` — exercises the clone path through the orchestrator with every scheduler off. Banner `━━━━━━━━━━ Clone (IG → TW/TH/SB) ━━━━━━━━━━` prints; clone lists 6 in-scope WIP-IG rows for 2026-05-25 → 2026-05-31; all TW/TH/SB targets correctly identified as "already has illustration/text — skipping" (idempotency preserved from the prior live clone run); the Sunday-thread day 20260531 successfully derives a canonical caption from publishIG row 20230211, proving the publishIG chain still resolves through the wiring.
- The non-thread repost-day caption derivation was validated **LIVE** in a prior parallel-session run (before this PR was opened): days 20260525/26/27/29 had their `text IG` derived from canonical publishIG rows `20241125 / 20241116 / 20241106 / 20230613`, written to TW/TH/SB, and back-filled to the IG row's own `text IG`. Already-populated rows correctly skipped on re-run.

Closes #32
