### PR TITLE
fix(videos): skip post-URL sentinel write for tag-along Threads

### DIFF
--- a/docs/2026-05-23-videos-tag-along-post-url-guard.md
+++ b/docs/2026-05-23-videos-tag-along-post-url-guard.md
@@ -1,0 +1,26 @@
+# 2026-05-23 — Videos orchestrator: guard tag-along Threads from `post_url_th` write-back
+
+Closes [#29](https://github.com/ferraroroberto/reporting/issues/29).
+
+## What was done
+
+Every successful Threads scheduling in the weekly-video orchestrator was producing a noisy warning:
+
+```
+⚠️ 20260526: scheduled OK on TH but could not write post_url_th:
+"Role 'post_url_th' not present in notion_columns map. ..."
+```
+
+Per `planning/videos/README.md`, this is by design — Threads is a tag-along platform (`PLATFORMS_TAG_ALONG = frozenset({"th"})`) with no `link TH(v)` editorial column, so it has no link-based idempotency marker. The orchestrator shouldn't write a sentinel URL for it. The warning was the orchestrator trying to write the sentinel anyway, `_set_post_url` looking up a non-existent role in `editorial_columns`, and the error degrading to a logged warning. The warning was harmless functionally (caller catches it) but masked real Notion-write regressions for the *non*-tag-along platforms.
+
+Fix: in the post-LIVE sentinel-write loop in `schedule_videos_posts.py`, `continue` when `platform in PLATFORMS_TAG_ALONG`. The guard is anchored on the existing tag-along constant (not on `editorial_columns` membership) so removing a `post_url_li / _ig / _tw` entry from a real `config.json` by mistake still surfaces the legitimate warning for that platform — AC #3 ("selective, not blanket").
+
+## Files modified
+
+- `planning/videos/schedule_videos_posts.py` — one-line guard before `_set_post_url` is called per platform in the LIVE write-back loop.
+- `planning/videos/README.md` — extended the existing "Threads has no `link TH(v)`" gotcha to mention the orchestrator guard and what the warning now reliably indicates.
+
+## Validation
+
+- `& .\.venv\Scripts\python.exe -m py_compile planning\videos\schedule_videos_posts.py` — clean.
+- LIVE re-verification was deliberately *not* run for this fix: a LIVE videos run today would re-attempt the originally-failing 20260526 row's TH leg and schedule a duplicate Threads video (tag-along platforms have no link sentinel by design — exactly the property the fix preserves). The change is one `if platform in PLATFORMS_TAG_ALONG: continue` inside the LIVE-only write-back loop; the guard's behavior is trivially verifiable by reading the diff. AC #3 is satisfied by the anchor choice (`PLATFORMS_TAG_ALONG` not `editorial_columns` membership) — a removed `post_url_li` entry in `config.json` still fires the legitimate warning for `li`.

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -146,7 +146,12 @@ attach helper. See:
   TH (and the other platforms) succeed once, which prevents accidental
   double-scheduling in practice — but if you re-tick WIP-Vd later
   without first deleting the existing scheduled Threads post, you'll
-  get a duplicate.
+  get a duplicate. The post-LIVE sentinel-write loop in
+  `schedule_videos_posts.py` explicitly skips platforms in
+  `PLATFORMS_TAG_ALONG` (see issue #29) so successful TH runs don't
+  log a misleading `"Role 'post_url_th' not present"` warning — that
+  warning is reserved for *real* `editorial_columns` regressions
+  (e.g. a `post_url_li` entry accidentally deleted from `config.json`).
 - **LinkedIn keeps uploading the video AFTER the composer closes.** The
   composer disappears as soon as `Schedule` is clicked, but LinkedIn
   finishes the .mp4 upload in the background. If the Playwright context

--- a/planning/videos/schedule_videos_posts.py
+++ b/planning/videos/schedule_videos_posts.py
@@ -510,9 +510,16 @@ def main() -> tuple[int, list[dict]]:
         _record_driver_results(rows, platform, driver_results)
 
         # Write sentinel link <P>(v) for any LIVE row so re-runs skip it.
+        # Tag-along platforms (TH) have no link column by design — `_set_post_url`
+        # would log a misleading "Role 'post_url_th' not present" warning every
+        # successful TH run. Skip the write for them; the WIP-Vd untick logic
+        # already gates tag-along platforms on the LIVE driver status alone
+        # (see issue #29 + planning/videos/README.md).
         if not dry_run:
             for entry in driver_results:
                 if entry["status"] != "LIVE":
+                    continue
+                if platform in PLATFORMS_TAG_ALONG:
                     continue
                 # Find the matching state.
                 state = next((s for s in rows if s.day_title == entry["day"]), None)


### PR DESCRIPTION
## Problem

Every successful Threads scheduling in the weekly-video orchestrator was logging:

```
⚠️ 20260526: scheduled OK on TH but could not write post_url_th:
"Role 'post_url_th' not present in notion_columns map. ..."
```

Per `planning/videos/README.md` this is by design — Threads is a tag-along platform (`PLATFORMS_TAG_ALONG = frozenset({"th"})`) with no `link TH(v)` editorial column. The orchestrator shouldn't write a sentinel URL for it. The warning was the orchestrator trying to write anyway, `_set_post_url` failing the role lookup, and the error degrading to a logged warning. Harmless functionally (caller catches it) but it masked the same warning shape if it ever fired for a real reason (e.g. `post_url_li` accidentally removed from `config.json`).

## Fix

One conditional in the post-LIVE sentinel-write loop in `schedule_videos_posts.py`:

```python
if platform in PLATFORMS_TAG_ALONG:
    continue
```

Anchored on the existing tag-along constant (NOT on `editorial_columns` membership) — so a real config regression for `li / ig / tw` still surfaces the legitimate warning, satisfying AC #3 ("selective, not blanket").

README + docs/changelog updated to reference the guard.

## Verify

- `& .\.venv\Scripts\python.exe -m py_compile planning\videos\schedule_videos_posts.py` — clean.
- **LIVE re-verification was deliberately not run.** A LIVE videos run today would re-attempt the originally-failing 20260526 row's TH leg and schedule a duplicate Threads video — tag-along platforms have no link-sentinel idempotency by design, exactly the property this guard preserves. The change is one conditional inside a `if not dry_run:` loop; the behavior is trivially verifiable by reading the diff (`platform == "th"` ⇒ skip the `_set_post_url` call ⇒ no role lookup ⇒ no warning).
- AC #3 is satisfied by the anchor choice: a hypothetical `config.json` with `post_url_li` removed still fires the legitimate warning for `li`, because `li ∉ PLATFORMS_TAG_ALONG`.

Closes #29
