### PR TITLE
fix(planning): drop stale article-LI skips, tolerate partial IG carousel, poll video upload before Schedule

### DIFF
--- a/docs/2026-05-23-ig-scheduling-skips-and-video-upload-wait.md
+++ b/docs/2026-05-23-ig-scheduling-skips-and-video-upload-wait.md
@@ -1,0 +1,57 @@
+# 2026-05-23 — Instagram scheduling: drop stale `article LI` skip, tolerate missing carousel image, wait for video upload before Schedule
+
+Closes [#35](https://github.com/ferraroroberto/reporting/issues/35).
+
+## What was done
+
+Three IG-side scheduling regressions surfaced on the 2026-05-23 overnight run; all silently dropped rows that should have gone through.
+
+### 1. Stale `article LI` skip — IG, TW, TH planners
+
+Each platform planner carried an identical 4-line guard:
+
+```python
+article_rels = props.get(article_col, {}).get("relation", []) or []
+if article_rels:
+    logger.info("⏭️  %s: has article LI — Phase 2 scope (LinkedIn), skipping IG too.", title)
+    continue
+```
+
+The rationale dated to before issue #16 (the LinkedIn POST + CAROUSEL routes) shipped — at the time, LinkedIn-article days were not yet handled, and the IG/TW/TH planners were defensively skipping them. #16 is closed and merged; LinkedIn now dispatches article days off the relation pattern directly (ILL / POST / CAROUSEL — `planning/linkedin/schedule_linkedin_posts.py:6-15`). The IG/TW/TH coupling was leftover scaffolding that silently dropped 20260526 and 20260528 from the overnight run even though their `Work in Progress IG = true` rows had independent illustration + caption ready to schedule.
+
+The three guards and their `article_col = ed_cols["article_rel"]` locals are removed. `config/config.json` `editorial_columns.article_rel` entries stay in place — LinkedIn still uses them.
+
+### 2. Sunday carousel: fail-one no longer = fail-all
+
+`resolve_post_payload`'s `thread_ig` branch built the 10-image carousel with no `try` around `_resolve_image_path`, so a single missing PNG aborted the whole day with `payload resolution failed: Illustration not found: …`. On 2026-05-23 that killed 20260531 because one of the ten files was missing from `archived_IGformat/`.
+
+The loop now logs a per-illustration warning, continues on `FileNotFoundError`, and at the end logs a summary line:
+
+```
+🖼️ 20260531: carousel built with 9/10 images (1 missing illustration(s) skipped).
+```
+
+If fewer than 2 illustrations survive (IG's hard floor for carousel posts), the row fails honestly rather than silently downgrading to a single-image post that the caller would treat as the non-thread route.
+
+### 3. Videos-IG: wait for upload to finish, don't hard-sleep
+
+`planning/videos/videos_instagram.py` uploaded the .mp4 and then hard-slept 6 seconds before clicking Schedule. On 2026-05-23 that wasn't enough — Meta's composer kept the Schedule action `aria-disabled="true"` for the full 10 s `_click_action_button` timeout window, and 20260526 IG-video failed after the locator iterated 23 retries on a stuck-disabled button.
+
+A new shared helper `wait_action_button_enabled(page, name, *, timeout_ms=90000)` lives next to `_click_action_button` in the IG planner module. The videos-IG driver now keeps a small 2 s head-start (to let the upload mount + re-render the Schedule button) and then polls `aria-disabled` for up to 90 s before clicking. On ceiling-hit, it raises `Action button 'Schedule' stayed aria-disabled after 90000 ms — media upload likely did not finish.` rather than a generic Playwright click-timeout traceback.
+
+LinkedIn's video driver already uses a poll-based readiness check (`_wait_for_video_ready` + `_wait_for_upload_complete`); TW and TH still hard-sleep 2.5 s after upload, but no failures have been observed there in practice — generalising the poll across all four drivers is parked as a follow-up (out of scope per the issue).
+
+## Files modified
+
+- `planning/instagram/schedule_instagram_posts.py` — removed `article LI` skip block + `article_col` local in `fetch_wip_ig_rows`; added `try / except FileNotFoundError` + summary logging in `resolve_post_payload`'s thread branch; added `wait_action_button_enabled` helper next to `_click_action_button`.
+- `planning/twitter/schedule_twitter_posts.py` — removed `article LI` skip block + `article_col` local in `fetch_wip_tw_rows`.
+- `planning/threads/schedule_threads_posts.py` — removed `article LI` skip block + `article_col` local in `fetch_wip_th_rows`.
+- `planning/videos/videos_instagram.py` — import `wait_action_button_enabled`; replaced the 6 s fixed sleep with a 2 s head-start + `wait_action_button_enabled(page, "Schedule", timeout_ms=90000)` before the Schedule click.
+- `planning/instagram/README.md` — Mermaid filter node no longer mentions `article LI`; scope sentence rewritten; column table no longer lists `article_rel` (now LI-only); carousel partial-tolerance behaviour documented.
+- `planning/twitter/README.md`, `planning/threads/README.md` — removed the `article LI` "skip-marker (Phase-2 LinkedIn scope)" row from the column tables.
+- `planning/videos/README.md` — IG video bullet rewritten to describe the upload-ready poll instead of the old 6 s sleep.
+
+## Validation
+
+- `& .\.venv\Scripts\python.exe -m py_compile planning\instagram\schedule_instagram_posts.py planning\twitter\schedule_twitter_posts.py planning\threads\schedule_threads_posts.py planning\videos\videos_instagram.py` — clean.
+- A LIVE re-run of the failed 20260526 IG-video and 20260531 IG-carousel cases is left for the user — both require actual Meta scheduling on the live editorial DB, which the issue's acceptance criteria explicitly expect during follow-up planning runs.

--- a/planning/instagram/README.md
+++ b/planning/instagram/README.md
@@ -14,8 +14,8 @@ flowchart TD
     Clone[<b>run:</b><br/>python -m planning.instagram.clone_to_other_platforms<br/>--week-start YYYY-MM-DD --live]
     CloneDo[For each WIP-IG day:<br/>• non-thread: copy illustration IG + text IG + repost IG<br/>• thread: derive first illustration from <b>post IG</b>,<br/>  derive canonical caption via <b>publishIG</b><br/>• write to TW/TH/SB columns (no WIP for SB)<br/>• back-fill Sunday IG row: illustration IG + template text IG]
     Run[<b>run:</b><br/>python -m planning.instagram.schedule_instagram_posts<br/>--week-start YYYY-MM-DD --live]
-    Filter{For each day,<br/>WIP IG = true<br/>AND article LI empty?}
-    Skip[skip<br/>article days,<br/>days not in scope]
+    Filter{For each day,<br/>WIP IG = true?}
+    Skip[skip<br/>days not in scope]
     Resolve[Resolve story = 1 image,<br/>post = 1 image OR 10 images<br/>caption = text IG]
     Browser[<b>Launch real Chrome</b> via Playwright<br/>persistent profile, no automation banners]
     Story[Hover day cell → <b>Schedule ▾</b> →<br/><b>Schedule story</b> → upload 1 image →<br/>FB+IG default-checked at 10:00 → Save]
@@ -94,12 +94,14 @@ Screenshots, success/failure artifacts, and per-row dry-run images land in `resu
 - `thread <P>` is never replicated. Only IG has thread-posts.
 - Idempotency: target platforms whose row already has illustration OR a non-empty caption are skipped unless `--force`.
 
-**Scheduling on Meta** runs for each day where `Work in Progress IG = true` AND `article LI` is empty (article days are LinkedIn's Phase 2, out of scope for IG):
+**Scheduling on Meta** runs for each day where `Work in Progress IG = true`:
 
 - **Story at 10:00** (Europe/Madrid): one image (the day's first illustration), Facebook + Instagram both default-checked.
 - **Feed Post at 15:00**: one image on regular days, 10 images on Sunday-thread days. Caption = the row's `text IG`.
 
-Days with nothing checked are silently skipped.
+Days with nothing checked are silently skipped. The presence of `article LI` (a LinkedIn-article day) no longer suppresses IG — the IG and LI sides are scheduled independently off their own `Work in Progress <P>` flags.
+
+If a Sunday carousel is missing one or more illustration files on disk, the missing entries are logged and skipped and the carousel goes up with the survivors (IG accepts 2 – 10 images per post). If fewer than 2 survive, the day fails honestly.
 
 ### Idempotency — running twice is safe
 
@@ -123,7 +125,6 @@ All field names come from `config/config.json` `instagram.editorial_columns` / `
 | `title_day` | `day` | title | Row's day in `YYYYMMDD`. |
 | `wip_checkbox` | `Work in Progress IG` | checkbox | The scope marker; auto-unticked after live schedule. |
 | `illustration_rel` | `illustration IG` | relation | Source illustration (single). Back-filled on Sunday from `post IG`. |
-| `article_rel` | `article LI` | relation | If non-empty, row is skipped (LinkedIn-article scope). |
 | `post_url` | `link IG` | url | Idempotency check; not written by this script. |
 | `caption_text` | `text IG` | rich_text | The per-day caption typed into the post composer. |
 | `repost_checkbox` | `repost IG` | checkbox | Replicated to TW/TH/SB by the clone step. |

--- a/planning/instagram/schedule_instagram_posts.py
+++ b/planning/instagram/schedule_instagram_posts.py
@@ -133,7 +133,6 @@ def fetch_wip_ig_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
     thread_col = ed_cols["thread_checkbox"]
     post_col = ed_cols["post_rel"]
     post_url_col = ed_cols["post_url"]
-    article_col = ed_cols["article_rel"]
 
     rows: list[ScheduleRow] = []
 
@@ -154,11 +153,6 @@ def fetch_wip_ig_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
             row_day = default_day or _row_day(r)
             if row_day is None:
                 logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
-                continue
-            title = date_to_day_title(row_day)
-            article_rels = props.get(article_col, {}).get("relation", []) or []
-            if article_rels:
-                logger.info("⏭️  %s: has article LI — Phase 2 scope (LinkedIn), skipping IG too.", title)
                 continue
             illust_rels = props.get(illust_col, {}).get("relation", []) or []
             post_rels = props.get(post_col, {}).get("relation", []) or []
@@ -251,9 +245,24 @@ def resolve_post_payload(notion, cfg: dict, row: ScheduleRow) -> PostPayload:
                 f"{row.day_title}: thread post has no illustration relations."
             )
         paths: list[Path] = []
+        missing = 0
         for rel in illust_rels:
             fname = _illustration_filename(notion, rel["id"], illust_cols)
-            paths.append(_resolve_image_path(folder, fname))
+            try:
+                paths.append(_resolve_image_path(folder, fname))
+            except FileNotFoundError as err:
+                missing += 1
+                logger.warning("⚠️  %s: carousel illustration missing, skipping: %s", row.day_title, err)
+        if missing:
+            logger.info(
+                "🖼️ %s: carousel built with %d/%d images (%d missing illustration(s) skipped).",
+                row.day_title, len(paths), len(illust_rels), missing,
+            )
+        if len(paths) < 2:
+            raise RuntimeError(
+                f"{row.day_title}: carousel has only {len(paths)} surviving illustration(s) "
+                f"(IG requires at least 2)."
+            )
         return PostPayload(image_paths=paths, caption=row.text_ig)
 
     if not row.illustration_ig_ids:
@@ -822,6 +831,39 @@ def _click_action_button(page: Page, name: str, exact: bool = True) -> None:
         page.get_by_role("button", name=pattern).last.click(timeout=10000)
     except Exception as err:
         raise RuntimeError(f"Could not click action button '{name}': {err}")
+
+
+def wait_action_button_enabled(
+    page: Page, name: str, *, exact: bool = True, timeout_ms: int = 90000,
+    poll_ms: int = 500,
+) -> None:
+    """Wait until the composer's action button is no longer ``aria-disabled``.
+
+    Meta's composer keeps Schedule / Share now ``aria-disabled="true"`` while
+    the uploaded media is still transcoding server-side. Videos in particular
+    can take well over the 6 s fixed sleep the drivers used to wait — once
+    they're past that, the button enables and the click succeeds instantly.
+    Raises ``RuntimeError`` if the button stays disabled past ``timeout_ms``.
+    """
+    pattern = re.compile(rf"^{re.escape(name)}$", re.I) if exact else re.compile(name, re.I)
+    btn = page.get_by_role("button", name=pattern).last
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    last_state = None
+    while page.evaluate("() => Date.now()") < deadline:
+        try:
+            disabled = btn.get_attribute("aria-disabled")
+        except Exception:
+            disabled = None
+        if disabled in (None, "false"):
+            return
+        if disabled != last_state:
+            logger.debug("⏳ '%s' button still aria-disabled=%s, polling…", name, disabled)
+            last_state = disabled
+        page.wait_for_timeout(poll_ms)
+    raise RuntimeError(
+        f"Action button '{name}' stayed aria-disabled after {timeout_ms} ms — "
+        f"media upload likely did not finish."
+    )
 
 
 def _wait_composer_closes(page: Page, planner_url: str, *, timeout_ms: int = 25000) -> bool:

--- a/planning/threads/README.md
+++ b/planning/threads/README.md
@@ -55,7 +55,6 @@ Default mode (no `--live` / `--dry-run`) is governed by
 | Image filename source | `illustration TH` → illustrations DB → `illustration` |
 | Caption | `text TH` |
 | Already-posted guard (`--force` to override) | `link TH` |
-| Skip-marker (Phase-2 LinkedIn scope) | `article LI` |
 
 All TH columns are pre-populated by `instagram/clone_to_other_platforms.py`
 from the IG side of the editorial DB. The scheduler only **reads** these

--- a/planning/threads/schedule_threads_posts.py
+++ b/planning/threads/schedule_threads_posts.py
@@ -113,7 +113,6 @@ def fetch_wip_th_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
     illust_col = ed_cols["illustration_rel"]
     text_col = ed_cols["caption_text"]
     post_url_col = ed_cols["post_url"]
-    article_col = ed_cols["article_rel"]
 
     rows: list[ScheduleRow] = []
 
@@ -134,11 +133,6 @@ def fetch_wip_th_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
             row_day = default_day or _row_day(r)
             if row_day is None:
                 logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
-                continue
-            title = date_to_day_title(row_day)
-            article_rels = props.get(article_col, {}).get("relation", []) or []
-            if article_rels:
-                logger.info("⏭️  %s: has article LI — Phase 2 scope (LinkedIn), skipping.", title)
                 continue
             illust_rels = props.get(illust_col, {}).get("relation", []) or []
             text_rt = props.get(text_col, {}).get("rich_text", []) or []

--- a/planning/twitter/README.md
+++ b/planning/twitter/README.md
@@ -53,7 +53,6 @@ Default mode (no `--live` / `--dry-run`) is governed by
 | Image filename source | `illustration TW` → illustrations DB → `illustration` |
 | Caption | `text TW` |
 | Already-posted guard (`--force` to override) | `link TW` |
-| Skip-marker (Phase-2 LinkedIn scope) | `article LI` |
 
 All TW columns are pre-populated by
 `instagram/clone_to_other_platforms.py` from the IG side of the editorial

--- a/planning/twitter/schedule_twitter_posts.py
+++ b/planning/twitter/schedule_twitter_posts.py
@@ -117,7 +117,6 @@ def fetch_wip_tw_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
     illust_col = ed_cols["illustration_rel"]
     text_col = ed_cols["caption_text"]
     post_url_col = ed_cols["post_url"]
-    article_col = ed_cols["article_rel"]
 
     rows: list[ScheduleRow] = []
 
@@ -138,11 +137,6 @@ def fetch_wip_tw_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[dat
             row_day = default_day or _row_day(r)
             if row_day is None:
                 logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
-                continue
-            title = date_to_day_title(row_day)
-            article_rels = props.get(article_col, {}).get("relation", []) or []
-            if article_rels:
-                logger.info("⏭️  %s: has article LI — Phase 2 scope (LinkedIn), skipping.", title)
                 continue
             illust_rels = props.get(illust_col, {}).get("relation", []) or []
             text_rt = props.get(text_col, {}).get("rich_text", []) or []

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -87,8 +87,12 @@ attach helper. See:
 - Instagram (Meta planner): `planning/instagram/schedule_instagram_posts.py`
   — same `Schedule post` menu, same FileChooser-intercept upload (accepts
   .mp4), same `Set date and time` toggle + split hours/minutes/meridiem.
-  Extra 6-second wait after upload before filling the caption to let
-  Meta's transcoder catch up.
+  After upload the driver waits a short 2-second head-start, fills the
+  caption + date/time, then **polls the Schedule button's
+  `aria-disabled` attribute** (via `wait_action_button_enabled`, shared
+  helper in the IG planner module) for up to 90 s before clicking.
+  Meta keeps the Schedule control disabled until the .mp4 finishes
+  server-side transcoding; a fixed sleep is not reliable.
 - Twitter (X): `planning/twitter/schedule_twitter_posts.py` — same
   `SideNav_NewTweet_Button`, same `fileInput` (accepts .mp4 directly),
   same `scheduleOption` + 6 native selects.

--- a/planning/videos/videos_instagram.py
+++ b/planning/videos/videos_instagram.py
@@ -36,6 +36,7 @@ from planning.instagram.schedule_instagram_posts import (  # noqa: E402
     _wait_composer_closes,
     dismiss_meta_verified_modal,
     return_to_planner,
+    wait_action_button_enabled,
 )
 from planning.videos.videos_session import ClipPayload  # noqa: E402
 
@@ -70,7 +71,9 @@ def schedule_one_video(
     # Meta's "Add photo/video" accepts .mp4 — give the same helper a list of one.
     _upload_files(page, [row.payload.video_path])
     # Video transcoding in Meta's composer takes noticeably longer than images.
-    page.wait_for_timeout(6000)
+    # Give it a head-start before we poll, so we don't spin on a button that's
+    # been re-rendered by the upload mid-attach.
+    page.wait_for_timeout(2000)
     _fill_post_text(page, row.payload.caption_short)
     _ensure_set_date_toggle_on(page)
     _set_all_visible_date_time(
@@ -88,6 +91,10 @@ def schedule_one_video(
         _cancel_composer(page)
         return "IG:DRY"
 
+    # Wait for Meta's transcode to finish — the Schedule button is
+    # ``aria-disabled="true"`` while the upload is still being processed.
+    # 90 s is comfortably above the typical short-clip transcode time.
+    wait_action_button_enabled(page, "Schedule", timeout_ms=90000)
     _click_action_button(page, "Schedule")
     if not _wait_composer_closes(page, ig_cfg["feed_url"], timeout_ms=30000):
         shot = out_dir / f"{label}-ig-FAIL.png"


### PR DESCRIPTION
## Summary

Three IG-side scheduling regressions from the 2026-05-23 overnight run — each silently dropping a row that should have gone through.

1. **Stale `article LI` skip — IG / TW / TH planners.** The "Phase 2 (LinkedIn)" skip block dates to before #16 shipped (the LinkedIn POST + CAROUSEL routes). LinkedIn now dispatches article days directly off the relation pattern; the IG/TW/TH coupling is dead scaffolding. Result on 2026-05-23: 20260526 and 20260528 dropped from IG even though their IG payloads were ready. Skip block + `article_col` local removed in all three planners; `config/config.json` `article_rel` entries kept (LinkedIn still uses them).

2. **Sunday carousel: fail-one no longer = fail-all (IG planner).** `resolve_post_payload`'s thread branch now wraps each `_resolve_image_path` in `try / except FileNotFoundError`, logs a per-illustration warning, and at the end emits `"🖼️ <day>: carousel built with N/M images (X missing illustration(s) skipped)."`. If fewer than 2 illustrations survive (IG's hard floor for carousels) the row fails honestly rather than silently downgrading.

3. **Videos-IG: upload-ready poll, not a hard sleep.** New shared `wait_action_button_enabled(page, name, *, timeout_ms=90000)` helper next to `_click_action_button` in the IG planner module. Videos-IG keeps a 2 s head-start (so the Schedule button has settled after the upload mounts) then polls `aria-disabled` for up to 90 s before clicking. On ceiling hit it raises a clean "media upload likely did not finish" error rather than a 10 s Playwright click-timeout traceback. LinkedIn's video driver already uses a poll-based readiness check; TW / TH still hard-sleep 2.5 s after upload but no failures have been observed there in practice — generalising the poll is parked as a follow-up per the issue's out-of-scope note.

READMEs for IG / TW / TH updated (Mermaid filter, scope sentence, column tables no longer treat `article LI` as a skip marker); videos README rewritten to describe the upload-ready poll.

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile planning\instagram\schedule_instagram_posts.py planning\twitter\schedule_twitter_posts.py planning\threads\schedule_threads_posts.py planning\videos\videos_instagram.py` — clean.
- **LIVE re-verification deliberately deferred to the next planning run** — both AC paths (20260526 IG-video + 20260531 IG-carousel) require actual Meta scheduling on the editorial DB; the issue's acceptance criteria explicitly expect that path. The carousel `< 2` floor + 90 s aria-disabled poll behaviours are trivially verifiable by reading the diff.

Closes #35
