### PR TITLE
feat(engagement): Phase 2a — local sklearn classifier + UI polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ supabase/.branches/_current_branch
 
 # temp files
 /tmp
+
+# Local sklearn classifier artifact (user-specific, trained from accumulated labels).
+engagement/classify/local_model.joblib
+engagement/classify/local_model.json

--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -186,11 +186,75 @@ def render_log_panel(name: str, *, height: int = 380, autorefresh_secs: float = 
     body = "\n".join(lines) if lines else "(no output yet)"
     with st.container(height=height, border=True, autoscroll=True):
         st.code(body, language=None, wrap_lines=False)
-    cols = st.columns([1, 1, 6])
-    with cols[0]:
+    with st.container(horizontal=True, gap="small"):
         st.button("🛑 stop", key=f"_proc_{name}_stop", on_click=stop_pipeline, args=(name,), disabled=not is_running(name))
-    with cols[1]:
         st.button("🧹 clear", key=f"_proc_{name}_clear", on_click=clear_log, args=(name,), disabled=is_running(name))
     if is_running(name):
+        time.sleep(autorefresh_secs)
+        st.rerun()
+
+
+def render_combined_status_badge(names: list[str]) -> None:
+    """One badge for a group of pipelines that share a UI section. Shows which
+    pipeline is currently running (if any) and the worst exit code from the
+    last completed runs (a single nonzero exit wins)."""
+    running = [n for n in names if is_running(n)]
+    if running:
+        meta = _get_meta(running[0])
+        st.info(f"⏳ {running[0]} running  ·  started {meta.get('started_at', '')}")
+        return
+    codes = [exit_code(n) for n in names]
+    if all(c is None for c in codes):
+        st.caption("idle  ·  no run yet this session")
+    elif any(c is not None and c != 0 for c in codes):
+        failed = [n for n, c in zip(names, codes) if c not in (None, 0)]
+        st.error(f"❌ last run failed: {', '.join(failed)}")
+    else:
+        st.success("✅ last run finished cleanly")
+
+
+def render_combined_log_panel(
+    names: list[str],
+    *,
+    height: int = 480,
+    autorefresh_secs: float = 1.0,
+) -> None:
+    """One scrollable panel that concatenates the logs of multiple pipelines.
+
+    Each pipeline's lines are already framed by `$ ...` / `# started ...` /
+    `# exit code ...` markers from `start_pipeline`, so concatenation alone is
+    enough — no extra section headers needed. A blank line is inserted between
+    deques only when both have content, to keep the boundary visible.
+
+    Stop/clear act on whichever pipeline is currently running (only one at a
+    time in this group), or clear all deques.
+    """
+    parts: list[str] = []
+    for n in names:
+        block = "\n".join(_get_lines(n))
+        if block:
+            parts.append(block)
+    body = "\n\n".join(parts) if parts else "(no output yet)"
+    with st.container(height=height, border=True, autoscroll=True):
+        st.code(body, language=None, wrap_lines=False)
+
+    running_now = next((n for n in names if is_running(n)), None)
+    any_running = running_now is not None
+
+    def _clear_all() -> None:
+        for n in names:
+            clear_log(n)
+
+    with st.container(horizontal=True, gap="small"):
+        st.button(
+            "🛑 stop", key=f"_proc_combined_{'+'.join(names)}_stop",
+            on_click=stop_pipeline, args=(running_now,) if running_now else (names[0],),
+            disabled=not any_running,
+        )
+        st.button(
+            "🧹 clear", key=f"_proc_combined_{'+'.join(names)}_clear",
+            on_click=_clear_all, disabled=any_running,
+        )
+    if any_running:
         time.sleep(autorefresh_secs)
         st.rerun()

--- a/app/tab_engagement.py
+++ b/app/tab_engagement.py
@@ -7,8 +7,8 @@ import streamlit as st
 from app.process_runner import (
     VENV_PY,
     is_running,
-    render_log_panel,
-    render_status_badge,
+    render_combined_log_panel,
+    render_combined_status_badge,
     start_pipeline,
 )
 from engagement.ui import (
@@ -24,18 +24,94 @@ SCRAPE_NAME = "engagement-scrape"
 CLASSIFY_NAME = "engagement-classify"
 
 
+_HOW_IT_WORKS = """\
+### What this pipeline does
+
+Reads comments on your own LinkedIn posts, classifies each as **human / AI / unknown**, and stages canned acknowledgements for the AI ones so you can batch them through LinkedIn's native composer with one copy-paste per reply.
+
+The pipeline **never auto-sends**. Every reply is a manual copy-paste — by design, because automating reply submission via the web UI violates LinkedIn's User Agreement §8.2 (see [issue #20](https://github.com/ferraroroberto/reporting/issues/20)).
+
+---
+
+### Stage 1 — scrape
+
+**Source.** The Notion editorial database (the same one the planning pipeline writes into). Rows where `link LI` is set and `date >= today - (days-1)` are the inputs. `days` is the input above; `days=5` means today plus the four prior days.
+
+**Browser session.** Each post URL is opened in the **`planning/linkedin/chrome_user_data`** profile — a persistent Chrome session that's already logged into your LinkedIn account. Reused so we don't need a separate engagement bootstrap. Headful by default for first runs (so you can watch selector iteration); headless is opt-in once selectors are stable.
+
+**Selectors.** LinkedIn obfuscates CSS class names and shuffles them every deploy, so the scraper hooks the *stable* parts:
+
+- comment list container — `[data-testid$='FeedType_FEED_DETAIL']`
+- comment text — `[data-testid='expandable-text-box']`
+- profile links — `<a href="https://www.linkedin.com/in/<handle>/">`
+
+Sort is switched to **Most recent** before extraction so we don't miss comments below LinkedIn's relevance threshold. "Show more replies" buttons are clicked until exhausted (capped at `expand_max_clicks` in config).
+
+**Per-comment fields.** `commenter_url`, `display_name`, `text`, `comment_id` (LinkedIn URN), `posted_at` (reconstructed from LinkedIn's relative `2h` / `5m` / `1d` timestamps by subtracting the offset from scrape time — accurate to ~1 display unit, fine for cadence rules).
+
+**Output.** Upserted into Supabase `comments` and `commenters` tables. Keys are `(platform, comment_id)` and `(platform, account_url)` respectively, so re-scraping the same posts is a no-op (idempotent).
+
+---
+
+### Stage 2 — classify
+
+Layered classifier — earlier layers are cheaper and more auditable; later layers handle the ambiguous middle.
+
+**Layer 1 — rules** (Phase 1, shipped). Pure-Python pipeline driven by `engagement/classify/phrases.json`. Per comment, a score is summed from:
+
+- generic-praise phrase hits (configurable list of ~45 substrings: "great post", "thanks for sharing", "💯", …)
+- short comment (≤60 chars)
+- no personal token (no `you / your / i / me / my`)
+- emoji-only
+- exact-text duplicate across multiple commenters (template hammer)
+- sub-2-minute reply cadence (commented within 2 min of the post)
+
+Score ≥ `ai_classification_threshold` (default 0.50) → **AI**. Below → **unknown**. Whitelist/blacklist commenters short-circuit the score: their pending comments are reclassified immediately (whitelist → human; blacklist → ai + canned reply pre-filled + status auto-promoted to `approved`).
+
+**Layer 2 — local sklearn model** (Phase 2a, this branch). Logistic regression on `TfidfVectorizer(ngram_range=(1,2))` + `TfidfVectorizer(analyzer='char_wb', ngram_range=(3,5))` + 6 per-comment scalar features (the same ones the rules layer derives). Trained on your accumulated commenter-level whitelist/blacklist labels — every comment by a blacklisted commenter is a positive AI example, every comment by a whitelisted commenter is a negative.
+
+- Runs **only on rows the rules layer left as `unknown`** (layered, not blended — so each verdict carries its provenance).
+- Threshold to upgrade to AI: `local_model_ai_threshold` (default 0.70). Conservative so canned replies aren't wrongly staged.
+- Requires `local_model_min_train_per_class` (default 20) of each class before training is allowed.
+- Persisted as `engagement/classify/local_model.joblib` (gitignored — user-specific artifact). If the file isn't on disk yet, the classify pass is lossless: behaviour is identical to rules-only.
+- The featurizer (`local_model.featurize_one`) re-imports the per-comment helpers from `rules.py`, so train-time and inference-time signals **can't drift**. Tune a rule → retrain the model.
+
+**Layer 3 — LLM fallback** (Phase 3, future). Structured-output call to a small LLM (Gemini Flash-Lite or Haiku 4.5) for the ~10% genuine ambiguous middle, cached by `(commenter_url, comment_hash)`. Not implemented yet.
+
+**Verdict written back** to the `comments` row: `classification` (human/ai/unknown), `confidence` (0-1), `verdict_source` (`rules` / `local` / `whitelist` / `blacklist` / `whitelist_cascade` / `blacklist_cascade`), `verdict_reasons` (jsonb: which rule + weight + probability fired), `suggested_action` (`surface_to_me` / `like_and_thanks` / `ignore`), `suggested_reply` (the canned thanks template for AI rows).
+
+---
+
+### Storage
+
+| table | PK | role |
+|---|---|---|
+| `comments` | `(platform, comment_id)` | one row per scraped comment; carries verdict, status, suggested reply, your already-posted reply (if any) |
+| `commenters` | `(platform, account_url)` | one row per author; carries `classification` (whitelist/blacklist/unknown), `signals` jsonb (future per-account features), free-text `notes` |
+
+Indexes: `(status, classification)` and `(platform, commenter_url)` so the review-UI's filtered queries stay fast.
+
+---
+
+### Why this shape
+
+- **Layered, not blended.** Each layer's verdict carries its provenance — you can always tell which rule (or which model) classified a given comment. Makes `phrases.json` tuning and false-positive triage debuggable.
+- **Bias toward surfacing.** Below-threshold rows stay `unknown` and appear in the real-comments tab. Over-surfacing wastes a glance; wrongly staging a canned reply on a real human comment is worse.
+- **No auto-send, ever.** Approved rows wait in Supabase for your manual copy-paste. This is the load-bearing TOS-compliance decision.
+- **Idempotent everywhere.** Both stages upsert; safe to re-run any time. Reclassifying after tuning `phrases.json` is one command (`classify pending`); it only touches rows still in `status=pending, classification=unknown`.
+"""
+
+
 def _render_run_subtab() -> None:
-    st.subheader("🛡️ engagement — scrape + classify")
-    st.caption(
-        "Scrape comments on your own LinkedIn posts (last N days), then classify each via "
-        "whitelist/blacklist/rules. Both steps are idempotent — safe to re-run."
-    )
+    with st.expander("📚 how this pipeline works", expanded=False):
+        st.markdown(_HOW_IT_WORKS)
 
     cols = st.columns([2, 2, 2, 4])
     with cols[0]:
         days = st.number_input(
-            "scrape days", min_value=1, max_value=30, value=3, step=1,
+            "scrape days", min_value=1, max_value=30, value=5, step=1,
             key="engagement-days",
+            help="Lookback window in calendar days, INCLUDING today. days=5 = today + the four prior days.",
         )
     with cols[1]:
         headless = st.toggle("headless", value=False, key="engagement-headless",
@@ -52,32 +128,30 @@ def _render_run_subtab() -> None:
 
     classify_cmd = [str(VENV_PY), "-m", "engagement.classify.rules"]
 
-    btn_cols = st.columns(3)
-    with btn_cols[0]:
+    # Horizontal container lays the three buttons inline at content width with
+    # a small CSS gap (≈1rem, roughly half a button's height). Wider relative
+    # columns left whitespace inside each column that bloated the visible gap.
+    with st.container(horizontal=True, gap="small"):
         st.button(
             "▶ scrape LinkedIn", key="engagement-scrape-btn", type="primary",
             disabled=is_running(SCRAPE_NAME),
             on_click=start_pipeline, args=(SCRAPE_NAME, scrape_cmd),
         )
-    with btn_cols[1]:
         st.button(
             "🧮 classify pending", key="engagement-classify-btn",
             disabled=is_running(CLASSIFY_NAME),
             on_click=start_pipeline, args=(CLASSIFY_NAME, classify_cmd),
         )
-    with btn_cols[2]:
         st.button(
             "🔄 refresh review data", key="engagement-refresh-data",
             on_click=invalidate_caches,
         )
 
-    st.markdown("**scrape**")
-    render_status_badge(SCRAPE_NAME)
-    render_log_panel(SCRAPE_NAME, height=240)
-
-    st.markdown("**classify**")
-    render_status_badge(CLASSIFY_NAME)
-    render_log_panel(CLASSIFY_NAME, height=160)
+    # One combined log + status block — both subcommands write to it in sequence,
+    # framed by start_pipeline's own "$ ..." / "# started ..." / "# exit code ..."
+    # markers so the boundary between scrape and classify stays readable.
+    render_combined_status_badge([SCRAPE_NAME, CLASSIFY_NAME])
+    render_combined_log_panel([SCRAPE_NAME, CLASSIFY_NAME], height=480)
 
 
 def run() -> None:

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -265,7 +265,7 @@
         ]
     },
     "engagement": {
-        "default_days": 3,
+        "default_days": 5,
         "phrases_path": "engagement/classify/phrases.json",
         "platforms_enabled": ["linkedin"],
         "linkedin": {

--- a/engagement/README.md
+++ b/engagement/README.md
@@ -7,14 +7,16 @@ Fourth pipeline in this repo (sibling to `planning/`, `reporting/`, `newsletter/
 
 **Never auto-sends.** Every action is staged for explicit approval. See issue [#20](https://github.com/ferraroroberto/reporting/issues/20) for the full design + the public-repo defense-mechanism disclaimer.
 
-## Phase 1 MVP — what's here
+## What's here
 
-- LinkedIn only.
+- LinkedIn only (other platforms = Phase 4).
 - Scraper that reads my recent posts from the Notion editorial DB (where `link LI` is set) and walks each one in the existing `planning/linkedin/chrome_user_data` session.
-- Rules-only classifier (whitelist / blacklist / generic-praise / short / no-personal-token / emoji-only / exact-text-duplicate / sub-2-min-after-post). Tunable via `engagement/classify/phrases.json`.
+- **Layered classifier**:
+  1. **Rules** (Phase 1) — whitelist / blacklist / generic-praise / short / no-personal-token / emoji-only / exact-text-duplicate / sub-2-min-after-post. Tunable via `engagement/classify/phrases.json`.
+  2. **Local sklearn model** (Phase 2a) — logistic regression on TF-IDF (word 1-2 + char_wb 3-5) plus six per-comment scalars, trained on accumulated commenter-level whitelist/blacklist labels. Called only on rows the rules layer left as `unknown`. Lossless when not trained yet — pipeline behaves identically to rules-only.
 - Two Supabase tables (`commenters` + `comments`) — see `engagement/db/schema.sql`.
 - Streamlit review app — `engagement/review_app.py`.
-- No auto-posting worker yet. Approved rows sit in Supabase; you paste the suggested reply manually (one click via `st.code`'s built-in copy button). Phase 2 will add a Playwright send worker.
+- **No auto-posting worker, ever.** Approved rows sit in Supabase; you copy the suggested reply via `st.code`'s built-in copy button and paste it into LinkedIn's native composer yourself. The originally-planned Phase 2b send worker is permanently out of scope on TOS grounds (see issue [#20](https://github.com/ferraroroberto/reporting/issues/20)).
 
 ## Workflow
 
@@ -23,7 +25,10 @@ flowchart LR
     A[Notion editorial DB<br/>link LI set<br/>date >= today - N] --> B[engagement.linkedin.scrape_comments]
     B --> C[(Supabase<br/>comments + commenters)]
     C --> D[engagement.classify.rules]
-    D --> C
+    D --> L{score &lt; threshold?}
+    L -- yes --> M[engagement.classify.local_model<br/>logreg, P(AI)]
+    L -- no --> C
+    M --> C
     C --> E[engagement.review_app<br/>Streamlit]
     E -.approve.-> C
     E -.blacklist/whitelist.-> C
@@ -33,9 +38,11 @@ flowchart LR
 
 | Command | Purpose |
 |---|---|
-| `python -m engagement.linkedin.scrape_comments --days 3` | Scrape last 3 days of LI comments → Supabase. Headful by default. |
-| `python -m engagement.linkedin.scrape_comments --days 1 --limit 1 --dry-run` | Smoke test against 1 post; writes `results/engagement/dryrun-*.json` instead of upserting. |
-| `python -m engagement.classify.rules` | Re-classify all `pending` `unknown` rows using current `phrases.json`. |
+| `python -m engagement.linkedin.scrape_comments --days 5` | Scrape last 5 calendar days **including today** of LI comments → Supabase. Headful by default. `--days N` means N total days, so `--days 1` = today only. |
+| `python -m engagement.linkedin.scrape_comments --days 1 --limit 1 --dry-run` | Smoke test against 1 post (today only); writes `results/engagement/dryrun-*.json` instead of upserting. |
+| `python -m engagement.classify.rules` | Re-classify all `pending` `unknown` rows using current `phrases.json`. If a local model is on disk, it runs as a second pass on the rows the rules layer left as `unknown`. |
+| `python -m engagement.classify.local_model train` | Train the local sklearn classifier on accumulated whitelist/blacklist labels. Refuses to train below `rules.local_model_min_train_per_class` per class. Writes `engagement/classify/local_model.joblib` (gitignored) + a metadata sidecar. |
+| `python -m engagement.classify.local_model eval` | 5-fold stratified CV on the same labeled set; prints AUC + precision/recall/F1 at the configured threshold. |
 | `& .\.venv\Scripts\python.exe -m streamlit run engagement\review_app.py` | Launch the review UI on `http://localhost:8501`. |
 
 ## One-time setup
@@ -52,7 +59,9 @@ No new secrets needed — uses `config.supabase.service_role_key` and `config.no
 - **Headful by default.** Headless would be brittle for first-run selector debugging. Use `--headless` once selectors are validated.
 - **Idempotent.** Both tables are upserted on `(platform, comment_id)` and `(platform, account_url)` respectively — safe to re-run on the same posts.
 - **Relative time parsing is approximate.** LinkedIn shows `2h`, `5m`, `1d`. We reconstruct an absolute timestamp from scrape time, so `posted_at` drifts up to ~one tick of the LI display unit. Fine for cadence rules.
-- **Unknown ≠ AI.** Comments that score below the AI threshold stay `unknown` and surface in the real-comments tab by default. Bias is toward human review — better to over-surface than wrongly stage a canned reply.
+- **Unknown ≠ AI.** Comments that score below the AI threshold (and below the local-model threshold, if a model is loaded) stay `unknown` and surface in the real-comments tab by default. Bias is toward human review — better to over-surface than wrongly stage a canned reply.
+- **Local model is lossless when missing.** If `local_model.joblib` isn't on disk yet, the rules pass is the only classifier and the verdict reasons match Phase 1 exactly. Train it by running `python -m engagement.classify.local_model train` once you have ≥20 whitelist + ≥20 blacklist commenters.
+- **Featurizer is the single source of truth.** `local_model.featurize_one` re-imports `_seconds_after`, `_is_emoji_only`, `_generic_praise_hits`, `_has_personal_token` from `rules.py` so train-time and inference-time signals can never drift. If you tune one of those rules in `phrases.json` (or the helper logic), retrain before relying on the model.
 - **Whitelist/blacklist cascades.** Marking a commenter triggers a retroactive reclassification of their pending comments (`cascade_blacklist_pending` / `cascade_whitelist_pending`).
 - **No tests yet.** Single-user pipeline; verification is a real scrape + manual eyeball.
 
@@ -65,8 +74,11 @@ engagement/
 ├── linkedin/
 │   └── scrape_comments.py            # Notion → LI post URLs → comment DOM → Supabase
 ├── classify/
-│   ├── rules.py                      # rule pipeline + verdict writer
-│   └── phrases.json                  # generic-praise list, weights, thresholds, reply templates
+│   ├── rules.py                      # rule pipeline + verdict writer; calls local_model on unknowns
+│   ├── local_model.py                # sklearn logreg, trained on accumulated wl/bl labels
+│   ├── phrases.json                  # generic-praise list, weights, thresholds, reply templates
+│   ├── local_model.joblib            # (gitignored) trained pipeline — user-specific artifact
+│   └── local_model.json              # (gitignored) training metadata sidecar
 ├── db/
 │   ├── client.py                     # supabase-py + notion client + CRUD helpers
 │   └── schema.sql                    # one-time DDL for commenters + comments
@@ -77,7 +89,7 @@ engagement/
 
 ```json
 "engagement": {
-    "default_days": 3,
+    "default_days": 5,
     "phrases_path": "engagement/classify/phrases.json",
     "platforms_enabled": ["linkedin"],
     "linkedin": {
@@ -90,7 +102,8 @@ engagement/
 
 ## Next phases
 
-- **Phase 2** — small sklearn classifier (logreg/gradient boost) trained on accumulated whitelist/blacklist labels; Playwright send worker that posts approved replies with jitter.
-- **Phase 3** — LLM fallback (Gemini Flash-Lite / Haiku 4.5) for the ambiguous middle; rolling reputation_score recomputation.
-- **Phase 4** — Instagram, then Twitter, Threads, Substack.
-- **Phase 5** — cross-platform identity linking + retroactive blacklist propagation.
+- **Phase 2a** ✅ shipped — local sklearn classifier (this section). Train it when you have ≥20 labeled commenters per class.
+- **Phase 2b** ❌ permanently out of scope — auto-send worker. Violates LinkedIn TOS §8.2. The pipeline stays staged + manual copy-paste.
+- **Phase 3** — LLM fallback (Gemini Flash-Lite / Haiku 4.5) for the ambiguous middle; rolling `commenters.signals` recomputation per scrape (cadence, comment-to-original ratio, length variance, …). Once `signals` is populated, the local model can pull per-commenter features for additional lift.
+- **Phase 4** — Instagram, then Twitter, Threads, Substack. Each reuses its sibling `planning/<P>/chrome_user_data`.
+- **Phase 5** — cross-platform identity linking (`commenter_identity` table) + retroactive blacklist propagation across linked accounts.

--- a/engagement/classify/local_model.py
+++ b/engagement/classify/local_model.py
@@ -1,0 +1,276 @@
+"""Local sklearn classifier — Phase 2a.
+
+Logistic regression on TF-IDF (word 1-2 + char_wb 3-5) plus six per-comment
+scalar features. Trained on accumulated commenter-level whitelist/blacklist
+labels (every comment by a blacklisted commenter is AI, every comment by a
+whitelisted commenter is human). Layered after `engagement.classify.rules`:
+called only on rows the rules layer left as `unknown`.
+
+If no model has been trained yet (no `.joblib` on disk), `predict_one` returns
+None and the rules pipeline falls back to the same "unknown / surface_to_me"
+behavior it had pre-Phase-2a. Training is gated by
+`rules.local_model_min_train_per_class` in `phrases.json` so a too-small label
+set never produces a useless model.
+
+The featurizer (`featurize_one`) is the single source of truth, used at both
+train and inference time. It re-uses the per-comment helpers from `rules.py`
+so the two layers can never drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("engagement.classify.local_model")
+
+MODEL_DIR = Path(__file__).resolve().parent
+MODEL_PATH = MODEL_DIR / "local_model.joblib"
+META_PATH = MODEL_DIR / "local_model.json"
+
+SCALAR_COLS = [
+    "text_len",
+    "is_emoji_only",
+    "generic_praise_hits",
+    "has_personal_token",
+    "sub_2_min",
+    "exact_text_duplicate",
+]
+
+
+# ---------- Features ----------
+
+def featurize_one(comment: dict, duplicate_texts: set, phrases: dict) -> dict:
+    """Build one feature row. Uses the rules.py helpers so training and
+    inference use byte-identical derived signals."""
+    from engagement.classify.rules import (
+        _generic_praise_hits,
+        _has_personal_token,
+        _is_emoji_only,
+        _seconds_after,
+    )
+
+    text = (comment.get("text") or "").strip()
+    text_norm = text.lower()
+    secs = _seconds_after(comment.get("post_posted_at"), comment.get("posted_at"))
+    return {
+        "text": text,
+        "text_len": len(text),
+        "is_emoji_only": int(_is_emoji_only(text)),
+        "generic_praise_hits": _generic_praise_hits(text_norm, phrases["generic_praise_substrings"]),
+        "has_personal_token": int(_has_personal_token(text_norm, phrases["personal_tokens"])),
+        "sub_2_min": int(secs is not None and secs <= 120),
+        "exact_text_duplicate": int(bool(text_norm) and text_norm in duplicate_texts),
+    }
+
+
+def _build_pipeline():
+    from sklearn.compose import ColumnTransformer
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    pre = ColumnTransformer(
+        transformers=[
+            ("word", TfidfVectorizer(ngram_range=(1, 2), min_df=2, lowercase=True), "text"),
+            ("char", TfidfVectorizer(analyzer="char_wb", ngram_range=(3, 5), min_df=2, lowercase=True), "text"),
+            ("scalars", StandardScaler(with_mean=False), SCALAR_COLS),
+        ],
+    )
+    return Pipeline(
+        [
+            ("feats", pre),
+            ("clf", LogisticRegression(max_iter=1000, class_weight="balanced", solver="liblinear")),
+        ]
+    )
+
+
+# ---------- Train / Eval ----------
+
+def _prepare_dataset(platform: str):
+    """Fetch labeled rows + return (DataFrame, y, phrases, n_ai, n_human)."""
+    import numpy as np
+    import pandas as pd
+
+    from engagement.classify.rules import _build_duplicate_set, load_phrases
+    from engagement.db.client import fetch_labeled_training_set
+
+    phrases = load_phrases()
+    rows = fetch_labeled_training_set(platform)
+    if not rows:
+        return None, None, phrases, 0, 0
+
+    duplicates = _build_duplicate_set(rows)
+    feats = [featurize_one(r, duplicates, phrases) for r in rows]
+    df = pd.DataFrame(feats)
+    y = np.array([r["_label"] for r in rows])
+    n_ai = int((y == 1).sum())
+    n_human = int((y == 0).sum())
+    return df, y, phrases, n_ai, n_human
+
+
+def train(platform: str = "linkedin") -> dict:
+    df, y, phrases, n_ai, n_human = _prepare_dataset(platform)
+    min_per_class = phrases["rules"]["local_model_min_train_per_class"]
+
+    if df is None:
+        logger.error(
+            "❌ no labeled rows for %s — mark some commenters whitelist/blacklist first",
+            platform,
+        )
+        return {"status": "no_labels", "n_ai": 0, "n_human": 0}
+
+    if n_ai < min_per_class or n_human < min_per_class:
+        logger.error(
+            "❌ insufficient labels (need ≥%d per class); got ai=%d human=%d",
+            min_per_class, n_ai, n_human,
+        )
+        return {
+            "status": "insufficient",
+            "n_ai": n_ai,
+            "n_human": n_human,
+            "min_per_class": min_per_class,
+        }
+
+    from sklearn.model_selection import StratifiedKFold, cross_val_score
+
+    pipeline = _build_pipeline()
+    n_splits = min(5, n_ai, n_human)
+    cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+    auc_scores = cross_val_score(pipeline, df, y, cv=cv, scoring="roc_auc")
+    mean_auc = float(auc_scores.mean())
+
+    pipeline.fit(df, y)
+
+    import joblib
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(pipeline, MODEL_PATH)
+
+    meta = {
+        "trained_at": datetime.now(timezone.utc).isoformat(),
+        "platform": platform,
+        "n_ai": n_ai,
+        "n_human": n_human,
+        "cv_auc_mean": mean_auc,
+        "cv_auc_per_fold": [float(s) for s in auc_scores],
+        "n_splits": n_splits,
+        "threshold": phrases["rules"]["local_model_ai_threshold"],
+        "min_per_class": min_per_class,
+        "scalar_cols": SCALAR_COLS,
+    }
+    META_PATH.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    _load_model_cached.cache_clear()
+    logger.info(
+        "✅ trained local model — n_ai=%d n_human=%d cv_auc=%.3f → %s",
+        n_ai, n_human, mean_auc, MODEL_PATH,
+    )
+    return {"status": "trained", **meta}
+
+
+def evaluate(platform: str = "linkedin") -> dict:
+    df, y, phrases, n_ai, n_human = _prepare_dataset(platform)
+    if df is None:
+        return {"status": "no_labels", "n_ai": 0, "n_human": 0}
+    if n_ai < 2 or n_human < 2:
+        return {"status": "insufficient", "n_ai": n_ai, "n_human": n_human}
+
+    from sklearn.metrics import (
+        confusion_matrix,
+        f1_score,
+        precision_score,
+        recall_score,
+        roc_auc_score,
+    )
+    from sklearn.model_selection import StratifiedKFold, cross_val_predict
+
+    threshold = phrases["rules"]["local_model_ai_threshold"]
+    n_splits = min(5, n_ai, n_human)
+    cv = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+    pipeline = _build_pipeline()
+    probs = cross_val_predict(pipeline, df, y, cv=cv, method="predict_proba")[:, 1]
+    pred = (probs >= threshold).astype(int)
+
+    out = {
+        "status": "ok",
+        "n_ai": n_ai,
+        "n_human": n_human,
+        "n_splits": n_splits,
+        "threshold": threshold,
+        "cv_auc": float(roc_auc_score(y, probs)),
+        "precision_at_threshold": float(precision_score(y, pred, zero_division=0)),
+        "recall_at_threshold": float(recall_score(y, pred, zero_division=0)),
+        "f1_at_threshold": float(f1_score(y, pred, zero_division=0)),
+        "confusion_matrix_at_threshold": confusion_matrix(y, pred).tolist(),
+    }
+    logger.info(
+        "📊 eval — auc=%.3f p=%.3f r=%.3f f1=%.3f (threshold=%.2f, n=%d/%d)",
+        out["cv_auc"], out["precision_at_threshold"], out["recall_at_threshold"],
+        out["f1_at_threshold"], threshold, n_ai, n_human,
+    )
+    return out
+
+
+# ---------- Inference ----------
+
+@lru_cache(maxsize=1)
+def _load_model_cached():
+    """Return the persisted pipeline, or None if no model has been trained.
+    Cached for the lifetime of the process — `train()` clears the cache after
+    overwriting the file."""
+    if not MODEL_PATH.exists():
+        return None
+    try:
+        import joblib
+        return joblib.load(MODEL_PATH)
+    except Exception as err:
+        logger.warning("⚠️ local_model load failed: %s", err)
+        return None
+
+
+def predict_one(comment: dict, duplicate_texts: set, phrases: Optional[dict] = None) -> Optional[float]:
+    """Return P(AI) for one comment, or None if no model is loaded."""
+    model = _load_model_cached()
+    if model is None:
+        return None
+    if phrases is None:
+        from engagement.classify.rules import load_phrases
+        phrases = load_phrases()
+    try:
+        import pandas as pd
+        feat = featurize_one(comment, duplicate_texts, phrases)
+        return float(model.predict_proba(pd.DataFrame([feat]))[0, 1])
+    except Exception as err:
+        logger.warning("⚠️ local_model predict failed: %s", err)
+        return None
+
+
+def model_is_available() -> bool:
+    return _load_model_cached() is not None
+
+
+# ---------- CLI ----------
+
+def main() -> None:  # pragma: no cover
+    parser = argparse.ArgumentParser(description="Train or evaluate the engagement local classifier.")
+    parser.add_argument("action", choices=["train", "eval"], nargs="?", default="train")
+    parser.add_argument("--platform", default="linkedin")
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+    result = train(args.platform) if args.action == "train" else evaluate(args.platform)
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/engagement/classify/phrases.json
+++ b/engagement/classify/phrases.json
@@ -59,7 +59,9 @@
         "emoji_only_weight": 0.40,
         "exact_text_duplicate_weight": 0.60,
         "sub_2_min_weight": 0.20,
-        "ai_classification_threshold": 0.50
+        "ai_classification_threshold": 0.50,
+        "local_model_ai_threshold": 0.70,
+        "local_model_min_train_per_class": 20
     },
     "reply_templates": {
         "like_and_thanks": [

--- a/engagement/classify/rules.py
+++ b/engagement/classify/rules.py
@@ -152,6 +152,17 @@ def classify_pending(platform: str = "linkedin") -> dict:
     cfg = load_engagement_config()
     threshold = phrases["rules"]["ai_classification_threshold"]
 
+    # Local sklearn classifier (Phase 2a) — lazy import to avoid circular deps
+    # (local_model imports the per-comment helpers from this module). Falls
+    # back gracefully if the .joblib file isn't on disk yet.
+    from engagement.classify import local_model
+    local_threshold = phrases["rules"].get("local_model_ai_threshold", 0.70)
+    local_available = local_model.model_is_available()
+    if local_available:
+        logger.info("🤖 local model loaded (threshold=%.2f)", local_threshold)
+    else:
+        logger.debug("local model not trained yet — skipping local pass")
+
     sb = supabase_client()
     pending = (
         sb.table("comments")
@@ -196,6 +207,18 @@ def classify_pending(platform: str = "linkedin") -> dict:
                     "like_and_thanks",
                     _pick_reply("like_and_thanks", c.get("display_name"), phrases),
                 )
+            elif local_available:
+                prob = local_model.predict_one(c, duplicates, phrases)
+                if prob is not None and prob >= local_threshold:
+                    verdict = (
+                        "ai", float(prob), "local",
+                        reasons + [{"rule": "local_model", "prob": float(prob)}],
+                        "like_and_thanks",
+                        _pick_reply("like_and_thanks", c.get("display_name"), phrases),
+                    )
+                else:
+                    extra = [{"rule": "local_model_prob", "prob": float(prob)}] if prob is not None else []
+                    verdict = ("unknown", score, "rules", reasons + extra, "surface_to_me", None)
             else:
                 # Stay unknown so we still surface for review, but record the score.
                 verdict = ("unknown", score, "rules", reasons, "surface_to_me", None)

--- a/engagement/db/client.py
+++ b/engagement/db/client.py
@@ -271,6 +271,50 @@ def mark_replied_as_ignored(platform: str = "linkedin") -> int:
     return len(res.data or [])
 
 
+def fetch_labeled_training_set(platform: str) -> list[dict]:
+    """Return every comment whose commenter has an explicit whitelist/blacklist
+    label, with the label attached as `_label` (1=ai, 0=human). Used by
+    `engagement.classify.local_model.train()`.
+
+    Done in two queries because the `comments` ↔ `commenters` relationship is
+    not modeled as a PostgREST foreign key (composite PK + denormalised text
+    URLs), so embedded selects aren't available.
+    """
+    sb = supabase_client()
+    labeled = (
+        sb.table("commenters")
+        .select("account_url,classification")
+        .eq("platform", platform)
+        .in_("classification", ["whitelist", "blacklist"])
+        .execute()
+        .data
+        or []
+    )
+    if not labeled:
+        return []
+    label_for = {row["account_url"]: row["classification"] for row in labeled}
+    rows = (
+        sb.table("comments")
+        .select("*")
+        .eq("platform", platform)
+        .in_("commenter_url", list(label_for.keys()))
+        .execute()
+        .data
+        or []
+    )
+    out: list[dict] = []
+    for r in rows:
+        cls = label_for.get(r.get("commenter_url"))
+        if cls == "blacklist":
+            r["_label"] = 1
+        elif cls == "whitelist":
+            r["_label"] = 0
+        else:
+            continue
+        out.append(r)
+    return out
+
+
 def cascade_whitelist_pending(platform: str, account_url: str) -> int:
     sb = supabase_client()
     res = (
@@ -320,4 +364,5 @@ __all__ = [
     "cascade_whitelist_pending",
     "mark_replied_as_ignored",
     "migrate_fallback_ids_to_urn",
+    "fetch_labeled_training_set",
 ]

--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -1,7 +1,8 @@
 """Scrape comments from my own LinkedIn posts into Supabase.
 
 Pipeline:
-1. Read editorial DB rows where `date >= today - days` AND `link LI` is set.
+1. Read editorial DB rows where `date >= today - (days-1)` AND `link LI` is
+   set — i.e. a window of N total calendar days including today.
 2. For each post URL, open in the planning/linkedin chrome_user_data session.
 3. Click "Load more comments" until exhausted, expand replies.
 4. Extract per-comment: commenter URL, display name, text, posted_at.
@@ -72,13 +73,15 @@ def _yyyymmdd(d: datetime) -> str:
 
 
 def fetch_recent_li_posts(days: int) -> list[dict]:
-    """Return [{post_url, posted_at, day_yyyymmdd}, ...] for the last N days where `link LI` is set."""
+    """Return [{post_url, posted_at, day_yyyymmdd}, ...] for the last `days`
+    calendar days **including today** where `link LI` is set. `days=1` means
+    just today; `days=5` means today + the four prior days."""
     li_cfg = load_linkedin_config()
     notion = init_notion_client(load_config()["notion"]["api_token"])
     db_id = li_cfg["editorial_db_id"]
     columns = li_cfg["editorial_columns"]
     today = datetime.now(timezone.utc).date()
-    earliest = today - timedelta(days=days)
+    earliest = today - timedelta(days=max(0, days - 1))
 
     title_col = columns["title_day"]
     link_col = columns["post_url"]
@@ -106,7 +109,7 @@ def fetch_recent_li_posts(days: int) -> list[dict]:
                 "day": title or "",
             }
         )
-    logger.info("📰 found %d LI posts in last %d day(s)", len(out), days)
+    logger.info("📰 found %d LI posts in last %d day(s) including today", len(out), days)
     return out
 
 
@@ -689,7 +692,7 @@ def main() -> None:  # pragma: no cover
     logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
 
     cfg = load_config().get("engagement", {})
-    days = args.days if args.days is not None else cfg.get("default_days", 3)
+    days = args.days if args.days is not None else cfg.get("default_days", 5)
     result = run(days=days, headless=args.headless, dry_run=args.dry_run, limit=args.limit)
     print(json.dumps(result, indent=2))
 

--- a/engagement/ui.py
+++ b/engagement/ui.py
@@ -270,6 +270,76 @@ def render_sidebar_filters(*, key_suffix: str = "") -> tuple[str | None, str]:
 _ALL_STATUSES = ("pending", "approved", "sent", "rejected", "ignored")
 
 
+# Per-tab user-manual legends explaining what each action button does and the
+# side-effects (status changes / cascade behaviour). Rendered just below the
+# tabs, above the show filter, so the meaning of the row-level buttons is
+# always one glance away.
+_REAL_LEGEND = """**What each action does:**
+
+- **✓ mark read** — You've read this comment and don't need to reply. Status moves to `ignored`; the row disappears from "show pending" but stays in "show all".
+- **🤖 mark AI** — Wrong verdict, this is actually AI noise. Status moves to `rejected`; the row leaves this tab.
+- **⬇️ whitelist** — Trust this commenter. All their pending comments get reclassified as human and stay surfaced here; future comments by them bypass the AI check.
+- **⛔ blacklist** — Distrust this commenter. All their pending comments are auto-approved with the canned "thanks @first_name" reply (ready to copy-paste in the AI triage tab); future comments by them get the same treatment automatically."""
+
+_AI_LEGEND = """**What each action does:**
+
+- **✅ approve** — The canned reply is good. Status moves to `approved`; copy the reply from the code block above the buttons and paste it into LinkedIn's native composer yourself.
+- **🚫 reject** — Don't leave any reply. Status moves to `rejected`; the row leaves this tab.
+- **🧑 surface** — Wrong verdict, this is actually a real human comment. Reclassifies as human and moves it to the real-comments tab for your personal reply.
+- **⬇️ whitelist** — Trust this commenter. Same effect as in the real-comments tab: pending comments are reclassified as human and surfaced there; future comments bypass the AI check.
+- **⛔ blacklist** — Distrust this commenter. Their pending comments are auto-approved with the canned thanks reply; future ones the same."""
+
+
+def _render_legend(body: str) -> None:
+    """Per-tab user-manual block. Wrapped in an expander so the cards aren't
+    pushed off-screen on small viewports."""
+    with st.expander("ℹ️ what each action does", expanded=False):
+        st.markdown(body)
+
+
+_COMMENTERS_EXPLAINER = """\
+### What this tab is for
+
+A per-commenter pivot view of everyone who's commented on your posts. The point is to **spot patterns over time** that you can't see one comment at a time: who comments daily, who only fires within minutes of every new post, who comments dozens of times but never publishes their own content.
+
+These patterns drive the whitelist / blacklist labels that feed back into both classifier layers:
+
+- **Whitelist hits** short-circuit the classifier — all their pending + future comments stay flagged human.
+- **Blacklist hits** also short-circuit — pending comments get auto-approved with the canned thanks reply.
+- **Both labels** are the training set for the local sklearn model (Phase 2a). Every whitelist commenter contributes their comments as negative (human) examples; every blacklist commenter contributes positives (AI). Retrain after marking a batch.
+
+---
+
+### How to read the table
+
+- **Rows** = commenters. The filter chips at the top scope by `classification` (whitelist / blacklist / unknown).
+- **Columns** = `commenter` · `class` · `total` · then one column per day for the last N days (newest left, dd/mm format).
+- **Totals** are across *all* time, not just the visible day window — so a commenter who hammered you a month ago still sticks out.
+- **Sort** = by total desc, so the heaviest commenters come first.
+- The `days` selector (top right) just changes the daily-column window; it doesn't filter the rows.
+
+**Click a row** to drill into that commenter's individual comments, sorted newest first, with your already-posted replies shown inline (when present). Click again on the same row to deselect.
+
+---
+
+### Signals worth eyeballing
+
+- **Heavy total + no comments-per-day variance** — likely a template-driven bot. The same person who comments on *every* one of your posts within minutes is rarely engaging organically.
+- **Sub-2-minute timestamps repeated across posts** — the rules classifier already catches single-comment cases, but seeing the pattern across many posts is the real signal.
+- **Identical text across multiple commenters** — open both rows; if the texts match verbatim, you've found a coordinated network. Blacklist all of them.
+- **Whitelist drift** — a commenter you whitelisted six months ago who now only leaves generic praise. Demoting (set classification back to unknown via the action buttons in the per-comment cards) un-trusts them without going as far as blacklist.
+
+---
+
+### Technical details
+
+- Data comes from a single Supabase select per table: `comments` (limit 5000, ordered by `posted_at desc`) and `commenters` (limit 5000, ordered by `last_seen desc`). Both are cached for 30 seconds in Streamlit (`@st.cache_data(ttl=30)`); the **🔄 refresh data** button in the engagement filters expander busts the cache.
+- The pivot is built in-memory with pandas — no SQL pivot, no Postgres-side window functions. `_build_commenter_pivot` does `pivot_table(index='commenter_url', columns='day', values='comment_id', aggfunc='count')` then joins on `commenters` for the `classification` + `display_name` columns. Missing days get zero-filled so the day columns are stable.
+- Selection state is managed by `st.dataframe(on_select='rerun', selection_mode='single-row')` — Streamlit's native row-pick API, no callback ceremony.
+- The drill-down rebuilds the comment list from the same in-memory DataFrame, so it doesn't re-query Supabase when you click. Switching tabs *does* trigger a fresh load (within the 30s TTL).
+"""
+
+
 def _view_filter(key: str) -> tuple[str, ...]:
     """Render the `pending / all` view radio; return the status tuple to load."""
     view = st.radio(
@@ -287,6 +357,7 @@ def _commenter_class_map(platform: str | None) -> dict[str, str]:
 
 
 def render_real_tab(platform: str | None, search: str) -> None:
+    _render_legend(_REAL_LEGEND)
     statuses = _view_filter("real-view-filter")
     df = _load_comments(statuses, platform)
     if not df.empty:
@@ -306,6 +377,7 @@ def render_real_tab(platform: str | None, search: str) -> None:
 
 
 def render_ai_tab(platform: str | None, search: str) -> None:
+    _render_legend(_AI_LEGEND)
     statuses = _view_filter("ai-view-filter")
     df = _load_comments(statuses, platform)
     if not df.empty:
@@ -419,6 +491,9 @@ def _render_drill_down(account_url: str, comments_df: pd.DataFrame, platform: st
 
 
 def render_commenters_tab(platform: str | None, search: str) -> None:
+    with st.expander("📚 how to use this tab", expanded=False):
+        st.markdown(_COMMENTERS_EXPLAINER)
+
     comments_df = _load_all_comments(platform)
     commenters_df = _load_all_commenters(platform)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,8 @@ spacy
 supabase==2.10.0
 # Streamlit review UI for the engagement pipeline.
 streamlit
+# Local sklearn classifier (Phase 2a) trained on accumulated whitelist/blacklist
+# labels; runs as a layered pass after rules.py on rows the rules left as 'unknown'.
+# Lower bound = 1.5 (ColumnTransformer + StratifiedKFold API stability); no upper
+# bound — 1.8 is the first release with Python 3.14 wheels for this venv.
+scikit-learn>=1.5


### PR DESCRIPTION
## Summary

Phase 2a of the engagement anti-AI triage pipeline (issue #20). Phase 1 (scrape + rules + Streamlit UI) shipped in PR #22; this builds the local classifier layer on top of it.

- **`engagement/classify/local_model.py`** — logistic regression on TF-IDF (word 1-2 + char_wb 3-5) plus 6 per-comment scalar features (the same ones the rules layer derives — featurizer re-imports from `rules.py` so train-time and inference-time signals can't drift). Trained on accumulated whitelist/blacklist commenter labels. Layered after the rules pass: runs only on rows left as `unknown` (threshold 0.70). Lossless when `local_model.joblib` is absent — pipeline behaves identically to rules-only.
- **`engagement/classify/rules.py`** — `elif local_available:` branch wires the model into `classify_pending`; imports are lazy (inside function body) to avoid circular imports.
- **`engagement/db/client.py`** — `fetch_labeled_training_set(platform)` collects whitelist/blacklist commenter labels + their comments for training.
- **`requirements.txt`** — `scikit-learn>=1.5` (no upper bound; Python 3.14 requires 1.8.0 wheels).
- **`.gitignore`** — `local_model.joblib` + `local_model.json` (user-specific trained artifacts).
- **Scrape window** — `days=N` is now inclusive of today (`earliest = today − (days − 1)`). Default bumped 3 → 5 everywhere.
- **UI** — combined scrape+classify log panel; tight inline button rows via `st.container(horizontal=True, gap="small")`; per-tab action legends (collapsed by default); how-it-works explainer; commenters explainer.
- **Phase 2b permanently dropped** — auto-send reply worker violates LinkedIn TOS §8.2. Decision recorded in issue and README.

Live training result before opening PR: n_ai=23, n_human=21, CV AUC=0.83, OOF AUC=0.79.

## Validation

- `py_compile` on all 7 modified Python files → clean
- `streamlit run app/app.py --server.headless true` → boots on :8501 without errors

Refs #20