### PR TITLE
chore: rename project from reporting to content-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ flowchart LR
 
 ```powershell
 git clone <repository-url>
-cd reporting
+cd content-management
 
 # Create venv and install
 python -m venv .venv

--- a/app/tab_engagement.py
+++ b/app/tab_engagement.py
@@ -29,7 +29,7 @@ _HOW_IT_WORKS = """\
 
 Reads comments on your own LinkedIn posts, classifies each as **human / AI / unknown**, and stages canned acknowledgements for the AI ones so you can batch them through LinkedIn's native composer with one copy-paste per reply.
 
-The pipeline **never auto-sends**. Every reply is a manual copy-paste — by design, because automating reply submission via the web UI violates LinkedIn's User Agreement §8.2 (see [issue #20](https://github.com/ferraroroberto/reporting/issues/20)).
+The pipeline **never auto-sends**. Every reply is a manual copy-paste — by design, because automating reply submission via the web UI violates LinkedIn's User Agreement §8.2 (see [issue #20](https://github.com/ferraroroberto/content-management/issues/20)).
 
 ---
 

--- a/config/README.md
+++ b/config/README.md
@@ -1,6 +1,6 @@
 # Configuration Directory
 
-This directory contains all configuration files for the social media reporting automation system.
+This directory contains all configuration files for the social media content management automation system.
 
 ## Files Overview
 

--- a/engagement/README.md
+++ b/engagement/README.md
@@ -5,7 +5,7 @@ Fourth pipeline in this repo (sibling to `planning/`, `reporting/`, `newsletter/
 1. **Real-comments inbox** — comments worth my personal reply, surfaced in a clean Streamlit view.
 2. **AI-triage queue** — staged canned acknowledgements I one-click approve in a batch.
 
-**Never auto-sends.** Every action is staged for explicit approval. See issue [#20](https://github.com/ferraroroberto/reporting/issues/20) for the full design + the public-repo defense-mechanism disclaimer.
+**Never auto-sends.** Every action is staged for explicit approval. See issue [#20](https://github.com/ferraroroberto/content-management/issues/20) for the full design + the public-repo defense-mechanism disclaimer.
 
 ## What's here
 
@@ -16,7 +16,7 @@ Fourth pipeline in this repo (sibling to `planning/`, `reporting/`, `newsletter/
   2. **Local sklearn model** (Phase 2a) — logistic regression on TF-IDF (word 1-2 + char_wb 3-5) plus six per-comment scalars, trained on accumulated commenter-level whitelist/blacklist labels. Called only on rows the rules layer left as `unknown`. Lossless when not trained yet — pipeline behaves identically to rules-only.
 - Two Supabase tables (`commenters` + `comments`) — see `engagement/db/schema.sql`.
 - Streamlit review app — `engagement/review_app.py`.
-- **No auto-posting worker, ever.** Approved rows sit in Supabase; you copy the suggested reply via `st.code`'s built-in copy button and paste it into LinkedIn's native composer yourself. The originally-planned Phase 2b send worker is permanently out of scope on TOS grounds (see issue [#20](https://github.com/ferraroroberto/reporting/issues/20)).
+- **No auto-posting worker, ever.** Approved rows sit in Supabase; you copy the suggested reply via `st.code`'s built-in copy button and paste it into LinkedIn's native composer yourself. The originally-planned Phase 2b send worker is permanently out of scope on TOS grounds (see issue [#20](https://github.com/ferraroroberto/content-management/issues/20)).
 
 ## Workflow
 

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -5,8 +5,8 @@ tabs in your real Chrome into Notion, normalise article titles to
 sentence case, strip tracking params from URLs, then build the
 ready-to-paste HTML for a specific newsletter number.
 
-Tracks issues: ferraroroberto/reporting#17 (archive step) and
-ferraroroberto/reporting#18 (full pipeline + monorepo migration).
+Tracks issues: ferraroroberto/content-management#17 (archive step) and
+ferraroroberto/content-management#18 (full pipeline + monorepo migration).
 
 ## Workflow
 

--- a/planning/substack/DESIGN.md
+++ b/planning/substack/DESIGN.md
@@ -1,7 +1,7 @@
 # Substack Automation — Playwright + Real Chrome Integration
 
 **Date:** 2026-05-13
-**Issue:** [#7 — feat(substack): automated Note posting + follower count via Playwright](https://github.com/ferraroroberto/reporting/issues/7)
+**Issue:** [#7 — feat(substack): automated Note posting + follower count via Playwright](https://github.com/ferraroroberto/content-management/issues/7)
 **Branch:** `feat/substack-integration`
 
 ---


### PR DESCRIPTION
## Summary

Project rename per #19 — `ferraroroberto/reporting` → `ferraroroberto/content-management`. The repo's scope has outgrown the "reporting" framing: it now runs three pipelines (reporting + planning + newsletter, the last assembled under #17 / #18) plus dedicated Chrome profiles per platform.

Single commit on the branch (`46090f9`) — the heavy work (GitHub repo rename via `gh repo rename`, parent-folder + `.bat` + `.code-workspace` rename, `git remote set-url`) all happens *outside* the repo and is captured in the issue's "Order of operations". This PR is just the in-repo prose sweep.

In-repo changes (commit `46090f9`):

- `config/README.md` — "reporting automation" → "content management automation"
- `README.md` — clone target dir name (`cd reporting` → `cd content-management`)
- `engagement/README.md`, `app/tab_engagement.py`, `newsletter/README.md`, `planning/substack/DESIGN.md` — bump `github.com/ferraroroberto/reporting` issue URLs to `/content-management`

Subdirectory `reporting/`, `reporting_pipeline.py`, and `launch_reporting.bat` intentionally untouched — they name the metrics pipeline, not the project.

## Acceptance checklist (from #19)

- [x] `git status` clean before starting
- [x] No hardcoded `E:\automation\reporting` in code or config (`rg` clean)
- [x] All three launchers (`launch_reporting.bat`, `launch_planning.bat`, `launch_newsletter.bat`) work from inside the renamed folder
- [x] Crons / scheduled tasks pointing at the old path updated — `app-launcher/config/jobs.json` patched (both `reporting-daily` and `linkedin-scrape` job paths); sibling repo prose/docs sweep filed as `ferraroroberto/app-launcher#75` + PR `ferraroroberto/app-launcher#76`
- [x] Workspace file opens cleanly in the new location (`E:\automation\content-management.code-workspace` → `"path": "content-management"`)
- [x] `git push` works against renamed remote (origin = `ferraroroberto/content-management.git`)

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile reporting_pipeline.py planning_pipeline.py newsletter_pipeline.py` — clean
- `<entry>.py --help` on all three — full import graphs resolve cleanly under the new path (no `ModuleNotFoundError`, no path-sensitive imports broken)
- `rg 'E:\automation\reporting'` over tracked source — no matches
- Repo has no pytest/ruff configured (per CLAUDE.md "say so explicitly" rule)

## Follow-ups not in this PR

- `.venv\Scripts\activate*` and PE-launcher shebangs still bake the old absolute path. Cosmetic only — we invoke `& .\.venv\Scripts\python.exe ...` directly, never `activate`, and Windows ignores the baked shebangs when launching via the .exe. Re-creating the venv at the new path would clean this up but isn't required and is out of scope here.

Closes #19