### PR TITLE
chore(engagement): sort real-comments and AI-triage tabs by posted_at desc

### DIFF
--- a/engagement/ui.py
+++ b/engagement/ui.py
@@ -367,6 +367,7 @@ def render_real_tab(platform: str | None, search: str) -> None:
                 df["text"].fillna("").str.lower().str.contains(search)
                 | df["display_name"].fillna("").str.lower().str.contains(search)
             ]
+        df = df.sort_values("posted_at", ascending=False, na_position="last")
     if df.empty:
         st.info("inbox clear — no real comments match the current view.")
         return
@@ -387,7 +388,7 @@ def render_ai_tab(platform: str | None, search: str) -> None:
                 df["text"].fillna("").str.lower().str.contains(search)
                 | df["display_name"].fillna("").str.lower().str.contains(search)
             ]
-        df = df.sort_values(["classification", "confidence"], ascending=[True, False])
+        df = df.sort_values("posted_at", ascending=False, na_position="last")
     if df.empty:
         st.info("triage clear — no AI-flagged comments match the current view.")
         return


### PR DESCRIPTION
## Summary

Both the **Real comments** and **AI triage** tabs now show comments sorted by posted_at descending — freshest comment on top, oldest at the bottom.

**Before:**
- Real comments: ordered by scraped_at DESC (when the scraper collected the comment — not when it was posted).
- AI triage: re-sorted by [classification, confidence], grouping AI vs unknown but losing all date context.

**After:**
- Both tabs: sort_values('posted_at', ascending=False, na_position='last') applied in-memory after filtering. Rows with a null posted_at are pushed to the bottom.

## Validation

- py_compile engagement/ui.py → OK
- git diff main...HEAD → exactly 2 lines changed in ngagement/ui.py, no scope creep
- No project-level test suite exists

Closes #41