### PR TITLE
fix(engagement/scrape): read <time datetime> for exact comment timestamps

### DIFF
--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -243,13 +243,24 @@ _JS_EXTRACT_COMMENTS = r"""
 
         const displayName = cleanName(link.innerText || link.getAttribute('aria-label') || '');
 
-        let rel = '';
+        // Prefer the <time datetime="..."> attribute (exact ISO timestamp LinkedIn
+        // embeds for every comment) over the display label ("1d", "2h") which
+        // maps multiple comments to the same coarse bucket. Fall back to label
+        // parsing only when the attribute is absent (e.g. very old comments
+        // rendered without a <time> element).
+        let postedAt = null;
         const candidates = block.querySelectorAll('time, span');
         for (const c of candidates) {
+            if (c.tagName === 'TIME') {
+                const dt = c.getAttribute('datetime');
+                if (dt) { postedAt = dt; break; }
+            }
             const t = (c.innerText || '').trim();
-            if (/^\d+\s*(s|m|h|d|w|mo|y)\b/i.test(t)) { rel = t; break; }
+            if (/^\d+\s*(s|m|h|d|w|mo|y)\b/i.test(t)) {
+                postedAt = parseRelative(t);
+                break;
+            }
         }
-        const postedAt = parseRelative(rel);
 
         // The LinkedIn URN lives on the OUTERMOST per-comment ancestor as
         // componentkey="replaceableComment_urn:li:comment:(urn:li:ugcPost:NNN,COMMENTID)".


### PR DESCRIPTION
## Summary

Two fixes for the engagement comment scraper:

**Fix 1 — exact comment timestamps** ()

LinkedIn embeds a precise ISO timestamp in every `<time datetime="...">` attribute, but the JS extractor was reading only the coarse display label (`"1d"`, `"2h"`). This caused all same-day comments to share an identical `posted_at` (e.g. `Date.now() − 86400000 ms` for every comment labelled `"1d"`), making the date-based sort added in #42 meaningless in practice.

Fix: prefer `time.getAttribute('datetime')` (exact ISO); fall back to `parseRelative(label)` only when the attribute is absent.

**Fix 2 — wider scrape window** (`config.json`, gitignored)

Bumped `engagement.default_days` from 3 → 5 locally. Root cause: the scraper finds posts via Notion `link LI`, which the reporting pipeline writes with a 1-day lag. The 06:00 UTC cron fires before reporting runs, so the previous day's post has no `link LI` yet and is silently missed. With `days=5` the window stays open long enough for subsequent cron runs to catch it once reporting has written the field. `config_example.json` already had 5; the user's local copy is updated on disk.

## Validation

- `py_compile engagement/linkedin/scrape_comments.py` → OK
- `git diff main...HEAD` → 1 file changed, exactly the stated JS block, no scope creep
- No project-level test suite exists

Closes #43