### PR TITLE
fix: serialize shared Chrome profile access with wait-backoff instead of killing

### DIFF
--- a/config/chrome_profile_lock.py
+++ b/config/chrome_profile_lock.py
@@ -1,0 +1,169 @@
+"""Serialize access to a shared persistent Chrome profile — wait, never kill.
+
+A persistent Chrome profile (``channel="chrome"`` + a dedicated ``user-data-dir``)
+allows only **one live instance**. Several unattended jobs in this suite target the
+*same* profile — e.g. the engagement scrape and the reporting follower-scrape both
+drive ``planning/linkedin/chrome_user_data`` and both fire from the app-launcher
+around the same time. The second job to launch gets Playwright's "Opening in
+existing browser session" error and dies (see issue #54).
+
+The holder is almost always a **legitimately-running sibling job**, not a stale
+zombie, so we must **not** kill it — that would corrupt the sibling's run. Instead
+we wait for the profile to free with exponential backoff, re-attempting the launch
+each cycle, and only raise (never kill) if it is still held after the full schedule.
+A process holding the profile longer than that is genuinely hung and worth
+surfacing.
+
+Note: Chrome's profile lock on Windows is a live-process kernel object, **not** the
+POSIX ``SingletonLock`` / ``SingletonCookie`` / ``SingletonSocket`` files — deleting
+those is a no-op on Windows, which is why the only safe remedy here is to wait for
+the holding process to exit.
+
+Single source of truth: every session module imports
+``launch_persistent_context_with_lock_wait`` from here — never re-inline a
+launch-with-retry in a new module.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Sequence
+
+from playwright.sync_api import BrowserContext, Error as PlaywrightError, Playwright
+
+from config.chrome_launch import stealth_launch_kwargs
+
+# Exponential backoff between launch re-attempts, in seconds (~15 min total).
+DEFAULT_LOCK_BACKOFF_SECONDS = (60, 120, 240, 480)
+
+# Playwright surfaces a locked persistent profile with one of these phrases.
+# Match defensively (lowercased substring) — the wording has drifted between
+# Playwright versions ("Opening in existing browser session" / "already in use").
+_LOCKED_PROFILE_SIGNATURES = (
+    "opening in existing browser session",
+    "already in use",
+    "process singleton",
+)
+
+
+def is_locked_profile_error(err: Exception) -> bool:
+    """True when a Playwright launch error means the profile dir is already in use."""
+    msg = str(err).lower()
+    return any(sig in msg for sig in _LOCKED_PROFILE_SIGNATURES)
+
+
+def pids_holding_profile(user_data_dir: Path) -> list[int]:
+    """Return PIDs of Chrome process(es) bound to **this exact** ``user_data_dir``.
+
+    Matches only Chrome whose command line carries ``--user-data-dir=<this dir>`` so
+    the user's everyday browser (a different profile) is never implicated. Detection
+    is Windows-only for now (this is where the suite runs); other platforms return an
+    empty list. This function only *observes* — it never terminates anything.
+    """
+    if sys.platform != "win32":
+        logger = logging.getLogger("chrome_profile_lock")
+        logger.debug("holder detection is Windows-only — skipping on %s", sys.platform)
+        return []
+    target = str(user_data_dir).replace("'", "''")
+    # PowerShell: list chrome.exe whose CommandLine references our profile dir
+    # (regex-escaped, optional surrounding quote), echoing each matching PID.
+    script = (
+        "$ErrorActionPreference='SilentlyContinue';"
+        f"$t=[regex]::Escape('{target}');"
+        "Get-CimInstance Win32_Process -Filter \"Name='chrome.exe'\" | "
+        "Where-Object { $_.CommandLine -match ('--user-data-dir=\"?' + $t) } | "
+        "ForEach-Object { $_.ProcessId }"
+    )
+    # Use the Windows PowerShell 5.1 absolute path — the `pwsh` on PATH is a
+    # WindowsApps stub that fails when spawned non-interactively.
+    powershell = str(
+        Path(os.environ.get("SystemRoot", r"C:\Windows"))
+        / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
+    )
+    try:
+        proc = subprocess.run(
+            [powershell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError) as err:
+        logging.getLogger("chrome_profile_lock").warning(
+            "⚠️ could not detect Chrome holding the profile: %s", err
+        )
+        return []
+    pids: list[int] = []
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if line.isdigit():
+            pids.append(int(line))
+    return pids
+
+
+def launch_persistent_context_with_lock_wait(
+    playwright: Playwright,
+    user_data_dir: Path,
+    *,
+    headless: bool,
+    logger: logging.Logger,
+    backoff_seconds: Sequence[int] = DEFAULT_LOCK_BACKOFF_SECONDS,
+) -> BrowserContext:
+    """Launch a persistent context, waiting out a sibling that holds the profile.
+
+    On a locked-profile error, log which process holds the profile and wait with
+    exponential backoff (``backoff_seconds``), re-attempting the launch after each
+    wait. Returns the context as soon as the profile frees. Never kills the holder:
+    if the profile is still locked after the whole schedule, raise a precise error
+    (a holder lasting that long is almost certainly hung). Non-lock launch errors
+    propagate unchanged.
+    """
+    kwargs = stealth_launch_kwargs(str(user_data_dir), headless=headless)
+
+    try:
+        return playwright.chromium.launch_persistent_context(**kwargs)
+    except PlaywrightError as err:
+        if not is_locked_profile_error(err):
+            raise
+        last_err: PlaywrightError = err
+
+    for delay in backoff_seconds:
+        pids = pids_holding_profile(user_data_dir)
+        if pids:
+            logger.warning(
+                "⏳ Chrome profile %s is held by live process(es) %s — waiting %ds, then retrying",
+                user_data_dir, pids, delay,
+            )
+        else:
+            logger.warning(
+                "⏳ Chrome profile %s is locked but no live holder was detected "
+                "(teardown race) — waiting %ds, then retrying",
+                user_data_dir, delay,
+            )
+        time.sleep(delay)
+        try:
+            ctx = playwright.chromium.launch_persistent_context(**kwargs)
+            logger.info("✅ profile %s is free — launch succeeded after waiting", user_data_dir)
+            return ctx
+        except PlaywrightError as retry_err:
+            if not is_locked_profile_error(retry_err):
+                raise
+            last_err = retry_err
+
+    held_by = pids_holding_profile(user_data_dir)
+    raise RuntimeError(
+        f"Chrome profile at {user_data_dir} is still locked after waiting "
+        f"{sum(backoff_seconds)}s across {len(backoff_seconds)} backoff steps. "
+        f"Live holder PID(s): {held_by or 'none detected'}. A process holding the "
+        "profile this long is likely hung — close it and re-run."
+    ) from last_err
+
+
+__all__ = [
+    "DEFAULT_LOCK_BACKOFF_SECONDS",
+    "is_locked_profile_error",
+    "pids_holding_profile",
+    "launch_persistent_context_with_lock_wait",
+]

--- a/planning/instagram/instagram_session.py
+++ b/planning/instagram/instagram_session.py
@@ -24,7 +24,8 @@ from typing import Optional
 from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 
 logger = logging.getLogger("instagram_session")
@@ -147,8 +148,8 @@ class InstagramSession:
                 "Run `python -m instagram.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
-        self._context = self._playwright.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(self.user_data_dir), headless=self.headless),
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
         )
         self._context.add_init_script(STEALTH_INIT_SCRIPT)
         self._page = self._context.pages[0] if self._context.pages else self._context.new_page()

--- a/planning/linkedin/linkedin_session.py
+++ b/planning/linkedin/linkedin_session.py
@@ -22,24 +22,16 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import subprocess
 import sys
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from playwright.sync_api import (
-    BrowserContext,
-    Error as PlaywrightError,
-    Page,
-    Playwright,
-    sync_playwright,
-)
+from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 
 logger = logging.getLogger("linkedin_session")
@@ -126,81 +118,6 @@ def _user_data_dir_initialized(user_data_dir: Path) -> bool:
     return user_data_dir.exists() and (user_data_dir / "Default").exists()
 
 
-# Playwright surfaces a locked persistent profile with one of these phrases.
-# Match defensively (lowercased substring) — the wording has drifted between
-# Playwright versions ("Opening in existing browser session" / "already in use").
-_LOCKED_PROFILE_SIGNATURES = (
-    "opening in existing browser session",
-    "already in use",
-    "process singleton",
-)
-
-
-def _is_locked_profile_error(err: Exception) -> bool:
-    """True when a Playwright launch error means the profile dir is already locked."""
-    msg = str(err).lower()
-    return any(sig in msg for sig in _LOCKED_PROFILE_SIGNATURES)
-
-
-def _kill_chrome_holding_profile(user_data_dir: Path) -> int:
-    """Terminate Chrome process(es) bound to **this exact** `user_data_dir`.
-
-    Targets only Chrome whose command line carries `--user-data-dir=<this dir>`,
-    never a blanket `taskkill chrome.exe` — the user's everyday browser runs on a
-    different profile and must not be touched. Windows-only for now (this is where
-    the suite runs); returns the number of processes terminated.
-    """
-    if sys.platform != "win32":
-        logger.warning("⚠️ locked-profile cleanup is Windows-only — skipping kill on %s", sys.platform)
-        return 0
-    target = str(user_data_dir).replace("'", "''")
-    # PowerShell: match chrome.exe whose CommandLine references our profile dir
-    # (regex-escaped, optional surrounding quote) and kill by PID, echoing each PID.
-    script = (
-        "$ErrorActionPreference='SilentlyContinue';"
-        f"$t=[regex]::Escape('{target}');"
-        "Get-CimInstance Win32_Process -Filter \"Name='chrome.exe'\" | "
-        "Where-Object { $_.CommandLine -match ('--user-data-dir=\"?' + $t) } | "
-        "ForEach-Object { Stop-Process -Id $_.ProcessId -Force; $_.ProcessId }"
-    )
-    # Use the Windows PowerShell 5.1 absolute path — the `pwsh` on PATH is a
-    # WindowsApps stub that fails when spawned non-interactively.
-    powershell = str(
-        Path(os.environ.get("SystemRoot", r"C:\Windows"))
-        / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
-    )
-    try:
-        proc = subprocess.run(
-            [powershell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
-            capture_output=True, text=True, timeout=20,
-        )
-    except (OSError, subprocess.SubprocessError) as err:
-        logger.warning("⚠️ could not run Chrome-cleanup helper: %s", err)
-        return 0
-    return len([ln for ln in (proc.stdout or "").splitlines() if ln.strip()])
-
-
-def _clear_stale_singleton_locks(user_data_dir: Path) -> int:
-    """Remove Chrome's profile lock files left behind by a process that's now gone.
-
-    Only call this after `_kill_chrome_holding_profile` — removing these while a
-    live Chrome still holds the profile would corrupt its state. Returns the count
-    of lock files removed.
-    """
-    removed = 0
-    for name in ("SingletonLock", "SingletonCookie", "SingletonSocket"):
-        lock = user_data_dir / name
-        try:
-            # `is_symlink()` catches the dangling-symlink form used on POSIX, where
-            # `exists()` returns False; on Windows these are plain files.
-            if lock.exists() or lock.is_symlink():
-                lock.unlink()
-                removed += 1
-        except OSError as err:
-            logger.debug("could not remove stale lock %s: %s", lock, err)
-    return removed
-
-
 class LinkedInSession:
     """Persistent-context wrapper around real Chrome with a dedicated profile.
 
@@ -237,7 +154,9 @@ class LinkedInSession:
                 "Run `python -m linkedin.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
-        self._context = self._launch_context_with_recovery()
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
+        )
         self._context.add_init_script(STEALTH_INIT_SCRIPT)
         # `launch_persistent_context` opens one default page already.
         self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
@@ -246,46 +165,6 @@ class LinkedInSession:
             self.headless, self.user_data_dir,
         )
         return self
-
-    def _launch_context(self) -> BrowserContext:
-        return self._playwright.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(self.user_data_dir), headless=self.headless),
-        )
-
-    def _launch_context_with_recovery(self) -> BrowserContext:
-        """Launch the persistent context, self-healing a locked profile once.
-
-        A stale/zombie Chrome from a previous run (or an overlapping run) can keep
-        the dedicated profile locked, which Playwright reports as "Opening in
-        existing browser session". Rather than crash the whole run, terminate the
-        stale holder bound to this profile, clear any leftover lock files, and
-        retry the launch exactly once. Non-lock launch errors propagate unchanged.
-        """
-        try:
-            return self._launch_context()
-        except PlaywrightError as err:
-            if not _is_locked_profile_error(err):
-                raise
-            logger.warning(
-                "⚠️ Chrome profile %s is locked — self-healing (kill stale holder + retry)",
-                self.user_data_dir,
-            )
-            killed = _kill_chrome_holding_profile(self.user_data_dir)
-            logger.info("🔪 terminated %d stale Chrome process(es) holding the profile", killed)
-            removed = _clear_stale_singleton_locks(self.user_data_dir)
-            if removed:
-                logger.info("🧹 cleared %d stale lock file(s) from the profile", removed)
-            time.sleep(1.5)
-            try:
-                ctx = self._launch_context()
-            except PlaywrightError as retry_err:
-                raise RuntimeError(
-                    f"Chrome profile at {self.user_data_dir} is still locked after self-heal "
-                    "(killed stale holders + retried once). Close any Chrome window using this "
-                    "profile and re-run."
-                ) from retry_err
-            logger.info("✅ profile lock cleared — launch succeeded on retry")
-            return ctx
 
     def __exit__(self, exc_type, exc, tb) -> None:
         try:

--- a/planning/substack/substack_session.py
+++ b/planning/substack/substack_session.py
@@ -29,7 +29,8 @@ from typing import Optional
 from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 
 logger = logging.getLogger("substack_session")
@@ -161,8 +162,8 @@ class SubstackSession:
                 "Run `python -m substack.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
-        self._context = self._playwright.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(self.user_data_dir), headless=self.headless),
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
         )
         self._context.add_init_script(STEALTH_INIT_SCRIPT)
         # `launch_persistent_context` opens one default page already.

--- a/planning/threads/threads_session.py
+++ b/planning/threads/threads_session.py
@@ -24,7 +24,8 @@ from typing import Optional
 from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 
 logger = logging.getLogger("threads_session")
@@ -137,8 +138,8 @@ class ThreadsSession:
                 "Run `python -m threads.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
-        self._context = self._playwright.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(self.user_data_dir), headless=self.headless),
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
         )
         self._context.add_init_script(STEALTH_INIT_SCRIPT)
         self._page = self._context.pages[0] if self._context.pages else self._context.new_page()

--- a/planning/twitter/twitter_session.py
+++ b/planning/twitter/twitter_session.py
@@ -21,7 +21,8 @@ from typing import Optional
 from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 
 logger = logging.getLogger("twitter_session")
@@ -134,8 +135,8 @@ class TwitterSession:
                 "Run `python -m twitter.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
-        self._context = self._playwright.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(self.user_data_dir), headless=self.headless),
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
         )
         self._context.add_init_script(STEALTH_INIT_SCRIPT)
         self._page = self._context.pages[0] if self._context.pages else self._context.new_page()


### PR DESCRIPTION
## Summary

Make a locked shared Chrome profile **wait its turn** instead of crashing the run — and instead of killing the holder.

Multiple unattended jobs share one persistent profile (the engagement scrape and the reporting follower-scrape both drive `planning/linkedin/chrome_user_data`, both firing from the app-launcher around 06:00). Chrome allows one live instance per profile, so the second to launch gets *"Opening in existing browser session"* and dies.

- New `config/chrome_profile_lock.py` — `launch_persistent_context_with_lock_wait(...)`: on a locked-profile error, detect+log the live holder, then wait with exponential backoff (60 → 120 → 240 → 480 s, ~15 min), re-attempting the launch each cycle. Returns as soon as the profile frees; raises a precise error (naming the dir + holder PIDs) only if still held after the schedule. Non-lock errors propagate unchanged. `backoff_seconds` is injectable for testing.
- All five platform sessions (linkedin, substack, instagram, twitter, threads) now launch through the shared helper from `__enter__`.
- Removed the old kill-based self-heal from `linkedin_session.py`.

## Supersedes the issue's original acceptance criteria

#54 was originally scoped as *kill the holder + retry once*. That approach was proven wrong (see the reopen comment): the holder is a **legitimately-running sibling job**, not a zombie, so killing it would corrupt that run — and its `SingletonLock` clearing was a no-op on Windows (the lock there is a live-process kernel object, not POSIX lock files). This PR therefore intentionally does the opposite — **wait, never kill** — which is the "serialize access to the shared profile" idea the original issue had listed under *Out of scope*. The remaining original criteria hold: only this profile is ever touched, non-lock errors propagate, a clear error is raised on exhaustion, no new dependency, every step logged, fix lives in the shared session class so all callers inherit it.

## Validation

- Verification gate: `py_compile` clean on all 6 changed files (no ruff/pytest/CI configured in this repo).
- Logic smoke (fake Playwright, zero-delay backoff): retry-then-succeed ✅, raise-after-schedule with holder PID in message ✅, non-lock error propagates ✅.
- Import-smoke of all five session modules ✅.

Closes #54
