### PR TITLE
fix(newsletter): skip Chrome bootstrap by default to stop killing every chrome.exe

### DIFF
--- a/app/tab_newsletter.py
+++ b/app/tab_newsletter.py
@@ -39,18 +39,26 @@ def run() -> None:
     with cols[2]:
         skip_bootstrap = st.toggle(
             "skip Chrome bootstrap",
-            value=False,
+            value=True,
             key="newsletter-skip-bootstrap",
-            help="Skip the chrome.exe kill + relaunch; reuse the existing :9222 instance.",
+            help="On (default): reuse the Chrome already up on :9222 — bring it up "
+                 "yourself with `newsletter\\bootstrap_chrome.bat` in a console first. "
+                 "Off: the pipeline kills every chrome.exe and relaunches the "
+                 "dedicated profile.",
         )
 
     debug = st.toggle("debug", value=False, key="newsletter-debug")
 
+    if skip_bootstrap:
+        st.caption(
+            "ℹ️ Chrome must already be up on :9222 — run "
+            "`newsletter\\bootstrap_chrome.bat` in a console first."
+        )
+
     cmd = [str(VENV_PY), "newsletter_pipeline.py", "--days", str(int(days))]
     if newsletter_number.strip():
         cmd.extend(["--newsletter", newsletter_number.strip()])
-    if skip_bootstrap:
-        cmd.append("--skip-bootstrap")
+    cmd.append("--skip-bootstrap" if skip_bootstrap else "--no-skip-bootstrap")
     if debug:
         cmd.append("--debug")
 

--- a/launch_newsletter.bat
+++ b/launch_newsletter.bat
@@ -5,12 +5,16 @@ REM
 REM Usage:
 REM   launch_newsletter.bat                   - interactive (prompts for # and
 REM                                              "press Enter" between steps)
-REM   launch_newsletter.bat --newsletter 057  - pre-fills the newsletter #
-REM   launch_newsletter.bat --skip-bootstrap  - reuse an already-up Chrome :9222
-REM   launch_newsletter.bat --debug           - verbose logs everywhere
+REM   launch_newsletter.bat --newsletter 057     - pre-fills the newsletter #
+REM   launch_newsletter.bat --no-skip-bootstrap  - let the pipeline kill+relaunch
+REM                                                Chrome (default: bootstrap is
+REM                                                skipped; bring :9222 up yourself
+REM                                                via newsletter\bootstrap_chrome.bat)
+REM   launch_newsletter.bat --debug              - verbose logs everywhere
 REM
 REM Full pipeline:
-REM   1. Bootstrap Chrome on :9222 (kill + relaunch on the dedicated profile)
+REM   1. Use Chrome already up on :9222 (bootstrap skipped by default; run
+REM      newsletter\bootstrap_chrome.bat yourself, or pass --no-skip-bootstrap)
 REM   2. Wait for you to open the newsletter article tabs
 REM   3. Archive each tab to Notion (newsletter.pipeline.run_batch)
 REM   4. Wait, then normalize_names + normalize_url

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -70,8 +70,11 @@ launch_newsletter.bat
 
 That launcher runs `newsletter_pipeline.py`, which walks you through:
 
-1. **Bootstrap Chrome** — kills all `chrome.exe`, relaunches with
-   `--remote-debugging-port=9222 --user-data-dir=newsletter\chrome_user_data`.
+1. **Bootstrap Chrome** — *skipped by default.* Bring Chrome up yourself by
+   running `newsletter\bootstrap_chrome.bat` in a **separate console** (it kills
+   all `chrome.exe`, including your everyday browser, then relaunches with
+   `--remote-debugging-port=9222 --user-data-dir=newsletter\chrome_user_data`).
+   Pass `--no-skip-bootstrap` to let the pipeline run that kill+relaunch for you.
 2. **Wait** — you open the newsletter article tabs in that Chrome window
    (clicking links in Gmail is fine — they'll open there). Press Enter
    when ready.
@@ -90,10 +93,10 @@ That launcher runs `newsletter_pipeline.py`, which walks you through:
 CLI flags pass through to the orchestrator:
 
 ```powershell
-launch_newsletter.bat --newsletter 057     # pre-fill the number
-launch_newsletter.bat --skip-bootstrap     # reuse an already-up Chrome
-launch_newsletter.bat --debug              # verbose everywhere
-launch_newsletter.bat --days 7             # tighter normalise window
+launch_newsletter.bat --newsletter 057      # pre-fill the number
+launch_newsletter.bat --no-skip-bootstrap   # let the pipeline kill+relaunch Chrome
+launch_newsletter.bat --debug               # verbose everywhere
+launch_newsletter.bat --days 7              # tighter normalise window
 ```
 
 ## Running steps in isolation

--- a/newsletter_pipeline.py
+++ b/newsletter_pipeline.py
@@ -2,8 +2,11 @@
 
 Walks the weekly newsletter workflow end-to-end:
 
-1. Bootstrap Chrome on ``:9222`` against the dedicated newsletter profile
-   (kill all chrome.exe + relaunch with `--user-data-dir`).
+1. Ensure Chrome is up on ``:9222`` against the dedicated newsletter profile.
+   Bootstrap is **skipped by default** — bring Chrome up yourself by running
+   ``newsletter/bootstrap_chrome.bat`` in a separate console (it kills every
+   chrome.exe + relaunches with ``--user-data-dir``). Pass ``--no-skip-bootstrap``
+   to let the pipeline run that bootstrap for you.
 2. Wait for you to open your article tabs in that Chrome window.
 3. Archive the tabs into Notion via :func:`newsletter.pipeline.run_batch`.
 4. Wait for the green light to clean up.
@@ -143,9 +146,14 @@ def run_pipeline(*, days: int, newsletter_number: str | None,
         step_bootstrap_chrome()
     else:
         if not _debug_port_up():
-            print("❌ --skip-bootstrap was set but :9222 isn't responding")
+            print("❌ Chrome isn't responding on :9222 — cannot archive tabs.")
+            print("   Bootstrap is skipped by default (it kills every chrome.exe,")
+            print("   including your everyday browser). Open a SEPARATE console and run:")
+            print("       newsletter\\bootstrap_chrome.bat")
+            print("   open your newsletter article tabs in that window, then re-run this")
+            print("   pipeline. To let the pipeline bootstrap for you, pass --no-skip-bootstrap.")
             return 1
-        print("⏭️  Skipping bootstrap (--skip-bootstrap); :9222 already up")
+        print("⏭️  Using the existing Chrome on :9222 (bootstrap skipped by default)")
 
     _wait_for_user(
         ">>> Step 2/5: open every newsletter article tab in the Chrome window, "
@@ -177,8 +185,10 @@ def main() -> int:
         help="Newsletter number (e.g. 057). Prompted if omitted.",
     )
     parser.add_argument(
-        "--skip-bootstrap", action="store_true",
-        help="Skip the Chrome kill/relaunch (use the existing :9222 instance)",
+        "--skip-bootstrap", action=argparse.BooleanOptionalAction, default=True,
+        help="Skip the Chrome kill/relaunch and reuse the existing :9222 instance "
+             "(default). Use --no-skip-bootstrap to let the pipeline kill every "
+             "chrome.exe and relaunch the dedicated newsletter profile.",
     )
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

The newsletter pipeline auto-ran `newsletter/bootstrap_chrome.bat`, which does `taskkill /F /IM chrome.exe` — killing **every** Chrome window (incl. the everyday browser), not just the one bound to the dedicated newsletter profile.

This makes the bootstrap opt-in: it's disruptive enough to be a deliberate, separate-console action rather than something the pipeline does automatically.

### Changes

- **`newsletter_pipeline.py`** — `--skip-bootstrap` is now `BooleanOptionalAction` defaulting to **True**. The pipeline no longer auto-runs the kill+relaunch. When `:9222` is down it stops with an instructive message pointing at `newsletter\bootstrap_chrome.bat`. `--no-skip-bootstrap` restores the old behaviour.
- **`app/tab_newsletter.py`** — "skip Chrome bootstrap" toggle defaults on, passes `--skip-bootstrap`/`--no-skip-bootstrap` explicitly, and shows a reminder to bring `:9222` up first.
- **`newsletter/README.md`** + **`launch_newsletter.bat`** — document skip-by-default and the manual-bootstrap-in-a-separate-console flow.

`bootstrap_chrome.bat` is intentionally left as-is — its `taskkill` is now only ever triggered as an explicit, user-initiated action.

## Validation

- `py_compile` on both `.py` files → OK (Python 3.14.3)
- argparse behaviour confirmed: no flag → `skip=True`; `--skip-bootstrap` → `True`; `--no-skip-bootstrap` → `False`
- `import app.tab_newsletter` → OK

Closes #57
