### PR TITLE
feat(newsletter): targeted Chrome bootstrap + split pipeline into independent steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,24 @@ Three pipelines, one repo:
   with a dedicated profile. The Instagram step also clones captions /
   illustrations into the TW/TH/SB Notion columns so the other planners
   and the daily Substack run can consume them.
-- **Newsletter** (`newsletter/`, `newsletter_pipeline.py`) — the full
-  weekly newsletter workflow as one orchestrated run. Step 1 archives
-  the open article tabs in a CDP-attached real Chrome into Notion
-  (readability-lxml extraction → Gemini-Lite topic + 3-line summary →
-  author resolved against the connections DB with exact / fuzzy /
-  LLM-pick-primary / `(not classified)` fallback — never invents → first
-  future newsletter row with `< 8` per topic → write + close tab). Step
-  2 normalises article titles to sentence case while preserving a
-  whitelist of proper names (spaCy PERSON entities optional). Step 3
-  strips tracking query params from each URL except for video / tweet
-  domains. Step 4 prompts for the newsletter number and emits the
-  ready-to-paste HTML at `results/newsletter/N{NNN}.html`, opens it in
-  the browser, and copies the must-read line to the clipboard.
+- **Newsletter** (`newsletter/`, `newsletter_pipeline.py`) — the weekly
+  newsletter workflow, split into independent non-interactive steps
+  (`bootstrap` / `archive` / `normalize` / `build`, plus `create` and
+  `all` composites) so each runs on its own from the app or a console.
+  **Bootstrap** launches the dedicated newsletter Chrome on `:9222`
+  without touching the everyday browser (targeted, idempotent — issue
+  #59). **Archive** walks the open article tabs in that CDP-attached
+  Chrome into Notion (readability-lxml extraction → Gemini-Lite topic +
+  3-line summary → author resolved against the connections DB with exact
+  / fuzzy / LLM-pick-primary / `(not classified)` fallback — never
+  invents → first future newsletter row with `< 8` per topic → write +
+  close tab). **Normalize** rewrites article titles to sentence case
+  (preserving a proper-name whitelist; spaCy PERSON entities optional)
+  and strips tracking query params from each URL except for video /
+  tweet domains. **Build** emits the ready-to-paste HTML at
+  `results/newsletter/N{NNN}.html`, opens it in the browser, and lets you
+  compose the must-read line (interactively in a console, or via the
+  app's picker fed by a topics sidecar).
 
 Both pipelines read from the same Notion editorial database. Each per-folder
 README has its own mermaid flowchart, CLI table, gotchas, and validated
@@ -89,7 +94,7 @@ reporting/                            # repo root
 ├── docs/                             # retrospective changelogs (gitignored locally)
 ├── planning_pipeline.py              # orchestrator: LI → IG → TW → TH (--all-wip)
 ├── reporting_pipeline.py             # orchestrator: APIs → Supabase → Notion → Substack
-├── newsletter_pipeline.py            # orchestrator: archive → normalize → build HTML
+├── newsletter_pipeline.py            # orchestrator: bootstrap/archive/normalize/build subcommands
 ├── launch_planning.bat               # planning launcher (Windows CMD)
 ├── launch_reporting.bat              # reporting launcher (Windows CMD)
 └── launch_newsletter.bat             # newsletter launcher (Windows CMD)

--- a/app/tab_newsletter.py
+++ b/app/tab_newsletter.py
@@ -1,6 +1,15 @@
-"""Newsletter pipeline tab — archive open tabs → normalize → build HTML."""
+"""Newsletter pipeline tab — bootstrap → archive → normalize → build HTML.
+
+Each step is an independent, non-interactive subcommand of
+``newsletter_pipeline.py`` (issue #59). All buttons share the single
+``"newsletter"`` process slot, so the status badge / log panel / sidebar
+status work unchanged. The must-read picker reads the topics sidecar that
+``build`` writes, so it never blocks on stdin.
+"""
 
 from __future__ import annotations
+
+import json
 
 import streamlit as st
 
@@ -18,17 +27,17 @@ PIPELINE_NAME = "newsletter"
 def run() -> None:
     st.subheader("📰 newsletter — weekly archive + build")
     st.caption(
-        "Step 1: archive open Chrome tabs into Notion (readability extract + Gemini topic/summary + author resolve). "
-        "Step 2: normalize titles + URLs. Step 3: render the issue HTML."
+        "① Bootstrap Chrome → open your article tabs → ② Archive into Notion → "
+        "③ Normalize titles + URLs → ④ Build HTML. Run any step alone, or ▶ for ②③④."
     )
 
-    cols = st.columns([2, 2, 2, 4])
+    cols = st.columns([2, 2, 2])
     with cols[0]:
         newsletter_number = st.text_input(
             "newsletter number",
             value="",
             key="newsletter-number",
-            help="e.g. 057 — required for step 3. Leave blank to be prompted on stdin (then the run will hang).",
+            help="e.g. 057 — required for ④ Build and ▶ Run.",
         )
     with cols[1]:
         days = st.number_input(
@@ -37,42 +46,121 @@ def run() -> None:
             key="newsletter-days",
         )
     with cols[2]:
-        skip_bootstrap = st.toggle(
-            "skip Chrome bootstrap",
-            value=True,
-            key="newsletter-skip-bootstrap",
-            help="On (default): reuse the Chrome already up on :9222 — bring it up "
-                 "yourself with `newsletter\\bootstrap_chrome.bat` in a console first. "
-                 "Off: the pipeline kills every chrome.exe and relaunches the "
-                 "dedicated profile.",
-        )
+        debug = st.toggle("debug", value=False, key="newsletter-debug")
 
-    debug = st.toggle("debug", value=False, key="newsletter-debug")
+    num = newsletter_number.strip()
+    has_num = bool(num)
+    running = is_running(PIPELINE_NAME)
 
-    if skip_bootstrap:
-        st.caption(
-            "ℹ️ Chrome must already be up on :9222 — run "
-            "`newsletter\\bootstrap_chrome.bat` in a console first."
-        )
+    base = [str(VENV_PY), "newsletter_pipeline.py"]
+    dbg = ["--debug"] if debug else []
 
-    cmd = [str(VENV_PY), "newsletter_pipeline.py", "--days", str(int(days))]
-    if newsletter_number.strip():
-        cmd.extend(["--newsletter", newsletter_number.strip()])
-    cmd.append("--skip-bootstrap" if skip_bootstrap else "--no-skip-bootstrap")
-    if debug:
-        cmd.append("--debug")
-
-    if not newsletter_number.strip():
-        st.warning("⚠️ no newsletter number set — the pipeline will block on stdin prompt and never finish from here.")
-
+    # ── ① bootstrap ──────────────────────────────────────────────────
     st.button(
-        "▶ run newsletter pipeline",
-        key="newsletter-run",
-        type="primary",
-        disabled=is_running(PIPELINE_NAME) or not newsletter_number.strip(),
+        "① Bootstrap Chrome",
+        key="newsletter-bootstrap",
+        disabled=running,
         on_click=start_pipeline,
-        args=(PIPELINE_NAME, cmd),
+        args=(PIPELINE_NAME, base + ["bootstrap"]),
+        help="Launch the dedicated newsletter Chrome on :9222 without touching "
+             "your everyday browser. Then open your article tabs in that window.",
     )
+    st.caption("→ after bootstrap, open your article tabs in that Chrome window, then run ② (or ▶).")
+
+    # ── ②③④ step buttons ─────────────────────────────────────────────
+    c2, c3, c4 = st.columns(3)
+    with c2:
+        st.button(
+            "② Archive → Notion",
+            key="newsletter-archive",
+            disabled=running,
+            on_click=start_pipeline,
+            args=(PIPELINE_NAME, base + ["archive"] + dbg),
+            width="stretch",
+        )
+    with c3:
+        st.button(
+            "③ Normalize titles+URLs",
+            key="newsletter-normalize",
+            disabled=running,
+            on_click=start_pipeline,
+            args=(PIPELINE_NAME, base + ["normalize", "--days", str(int(days))] + dbg),
+            width="stretch",
+        )
+    with c4:
+        st.button(
+            "④ Build HTML",
+            key="newsletter-build",
+            disabled=running or not has_num,
+            on_click=start_pipeline,
+            args=(PIPELINE_NAME, base + ["build", "--newsletter", num, "--no-must-read"] + dbg),
+            width="stretch",
+        )
+
+    # ── ▶ combo ──────────────────────────────────────────────────────
+    st.button(
+        "▶ Run ②③④ (create newsletter)",
+        key="newsletter-create",
+        type="primary",
+        disabled=running or not has_num,
+        on_click=start_pipeline,
+        args=(PIPELINE_NAME, base + ["create", "--newsletter", num, "--days", str(int(days))] + dbg),
+    )
+
+    if not has_num:
+        st.caption("ℹ️ enter a newsletter number to enable ④ Build and ▶ Run.")
 
     render_status_badge(PIPELINE_NAME)
     render_log_panel(PIPELINE_NAME)
+
+    _render_must_read_picker(num)
+
+
+def _render_must_read_picker(newsletter_number: str) -> None:
+    """Compose the must-read line from the topics sidecar a build wrote.
+
+    Reads ``results/newsletter/N{NNN}.topics.json`` and lets the user pick which
+    of the three top articles is the "must read"; the composed line is shown in
+    a copyable ``st.code`` block. No subprocess, no clipboard — pure UI.
+    """
+    if not newsletter_number:
+        return
+    # Imported here (not at module load) to keep app startup light.
+    from newsletter.build_newsletter import format_must_read_line, topics_sidecar_path
+
+    try:
+        path = topics_sidecar_path(newsletter_number)
+    except ValueError:
+        return  # not a valid number yet (e.g. "59") — nothing to show
+    if not path.exists():
+        return
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        st.warning("⚠️ couldn't read the topics sidecar.")
+        return
+
+    st.divider()
+    st.markdown("**must-read line**")
+
+    top_names = data.get("top_names")
+    if not top_names:
+        st.warning("⚠️ must-read unavailable — a topic has no articles in this issue.")
+        return
+
+    headings = data.get("headings") or []
+    labels = [
+        f"{i + 1}. {(headings[i] if i < len(headings) else f'topic {i + 1}')} — {name}"
+        for i, name in enumerate(top_names)
+    ]
+    options = list(range(1, len(top_names) + 1))
+    choice = st.radio(
+        "which is the must-read?",
+        options=options,
+        format_func=lambda n: labels[n - 1],
+        key=f"newsletter-mustread-{data.get('newsletter')}",
+    )
+    line = format_must_read_line(top_names, int(choice))
+    st.code(line, language=None)
+    st.caption("copy the line above ☝️")

--- a/launch_newsletter.bat
+++ b/launch_newsletter.bat
@@ -1,25 +1,26 @@
 @echo off
-REM Visible launcher for newsletter_pipeline.py — keeps CMD window open until
+REM Visible launcher for the newsletter pipeline — keeps CMD window open until
 REM you've reviewed the final HTML / must-read line.
 REM
-REM Usage:
-REM   launch_newsletter.bat                   - interactive (prompts for # and
-REM                                              "press Enter" between steps)
-REM   launch_newsletter.bat --newsletter 057     - pre-fills the newsletter #
-REM   launch_newsletter.bat --no-skip-bootstrap  - let the pipeline kill+relaunch
-REM                                                Chrome (default: bootstrap is
-REM                                                skipped; bring :9222 up yourself
-REM                                                via newsletter\bootstrap_chrome.bat)
-REM   launch_newsletter.bat --debug              - verbose logs everywhere
+REM Runs the full interactive console sequence (newsletter_pipeline.py "all"):
+REM   1. Bootstrap the dedicated newsletter Chrome on :9222 (targeted — does
+REM      NOT kill your everyday browser; see newsletter\bootstrap_chrome.py)
+REM   2. Wait for you to open the newsletter article tabs in that window
+REM   3. Archive each tab to Notion
+REM   4. normalize_names + normalize_url (last 14 days by default)
+REM   5. Build the HTML at results\newsletter\N{NNN}.html, open it, prompt for
+REM      the must-read topic, copy the composed line to the clipboard
 REM
-REM Full pipeline:
-REM   1. Use Chrome already up on :9222 (bootstrap skipped by default; run
-REM      newsletter\bootstrap_chrome.bat yourself, or pass --no-skip-bootstrap)
-REM   2. Wait for you to open the newsletter article tabs
-REM   3. Archive each tab to Notion (newsletter.pipeline.run_batch)
-REM   4. Wait, then normalize_names + normalize_url
-REM   5. Build newsletter HTML at results\newsletter\N{NNN}.html, open in
-REM      browser, prompt for must-read topic, copy line to clipboard
+REM Usage:
+REM   launch_newsletter.bat                    - full interactive sequence
+REM   launch_newsletter.bat --newsletter 057   - pre-fill the newsletter #
+REM   launch_newsletter.bat --days 7           - tighter normalise window
+REM   launch_newsletter.bat --debug            - verbose logs everywhere
+REM
+REM To run a single step instead, call the subcommand directly, e.g.:
+REM   .venv\Scripts\python.exe newsletter_pipeline.py bootstrap
+REM   .venv\Scripts\python.exe newsletter_pipeline.py archive
+REM   .venv\Scripts\python.exe newsletter_pipeline.py build --newsletter 057
 
 setlocal
 
@@ -37,7 +38,7 @@ echo Starting Newsletter Pipeline
 echo ========================================
 echo.
 
-"%VENV_DIR%\Scripts\python.exe" newsletter_pipeline.py %*
+"%VENV_DIR%\Scripts\python.exe" newsletter_pipeline.py all %*
 set RC=%ERRORLEVEL%
 
 echo.

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -13,7 +13,7 @@ ferraroroberto/content-management#18 (full pipeline + monorepo migration).
 ```mermaid
 flowchart LR
     subgraph S1[1. Bootstrap]
-        A[bootstrap_chrome.bat<br/>kill+relaunch Chrome on :9222<br/>--user-data-dir=newsletter/chrome_user_data]
+        A[bootstrap_chrome.py<br/>targeted: reuse :9222 if up,<br/>else kill only the newsletter-profile<br/>Chrome and relaunch on :9222]
     end
     subgraph S2[2. Archive]
         B[connect_over_cdp] --> C[list tabs<br/>skip gmail/notion/...]
@@ -68,13 +68,14 @@ flowchart LR
 launch_newsletter.bat
 ```
 
-That launcher runs `newsletter_pipeline.py`, which walks you through:
+That launcher runs `newsletter_pipeline.py all` — the full interactive console
+sequence:
 
-1. **Bootstrap Chrome** — *skipped by default.* Bring Chrome up yourself by
-   running `newsletter\bootstrap_chrome.bat` in a **separate console** (it kills
-   all `chrome.exe`, including your everyday browser, then relaunches with
-   `--remote-debugging-port=9222 --user-data-dir=newsletter\chrome_user_data`).
-   Pass `--no-skip-bootstrap` to let the pipeline run that kill+relaunch for you.
+1. **Bootstrap Chrome** — launches the dedicated newsletter Chrome on `:9222`
+   *without touching your everyday browser.* If `:9222` is already up it reuses
+   it (your tabs stay); otherwise it kills only the Chrome bound to
+   `newsletter\chrome_user_data` (if any) and relaunches with
+   `--remote-debugging-port=9222`.
 2. **Wait** — you open the newsletter article tabs in that Chrome window
    (clicking links in Gmail is fine — they'll open there). Press Enter
    when ready.
@@ -94,15 +95,29 @@ CLI flags pass through to the orchestrator:
 
 ```powershell
 launch_newsletter.bat --newsletter 057      # pre-fill the number
-launch_newsletter.bat --no-skip-bootstrap   # let the pipeline kill+relaunch Chrome
 launch_newsletter.bat --debug               # verbose everywhere
 launch_newsletter.bat --days 7              # tighter normalise window
 ```
 
 ## Running steps in isolation
 
+The pipeline is split into independent, non-interactive subcommands (issue #59)
+— the same ones the Streamlit app drives, so nothing is app-only:
+
 | Command | What it does |
 |---|---|
+| `newsletter_pipeline.py bootstrap` | Ensure Chrome is up on `:9222` (targeted — never kills the everyday browser). |
+| `newsletter_pipeline.py archive [--debug]` | Archive every eligible open tab → Notion, write + close. |
+| `newsletter_pipeline.py normalize [--days 14] [--debug]` | normalize_names + normalize_url. |
+| `newsletter_pipeline.py build --newsletter 057 [--no-open] [--must-read 1\|2\|3 \| --no-must-read]` | Render HTML + write the topics sidecar. |
+| `newsletter_pipeline.py create --newsletter 057 [--days 14]` | archive → normalize → build (non-interactive). |
+| `newsletter_pipeline.py all [--newsletter 057] [--days 14]` | Full interactive console sequence (default when no subcommand). |
+
+Lower-level module entry points:
+
+| Command | What it does |
+|---|---|
+| `python -m newsletter.bootstrap_chrome` | The targeted bootstrap itself (what `bootstrap_chrome.bat` wraps). |
 | `python -m newsletter.bootstrap_session` | One-time Gmail / source login into the dedicated Chrome profile. |
 | `python -m newsletter.dry_run --first-non-gmail-tab --no-write` | Archive ONE tab, log only, no Notion writes. |
 | `python -m newsletter.dry_run --single-url <url>` | Pick a specific tab by URL substring. Add `--no-write` for read-only. |
@@ -161,11 +176,15 @@ byline. The fallback exists so the pipeline never invents people.
 
 - **Chrome 136+** silently refuses to bind `--remote-debugging-port`
   against the default profile dir (security policy change to block
-  session-stealing extensions). The bat always launches with
+  session-stealing extensions). Bootstrap always launches with
   `--user-data-dir=newsletter\chrome_user_data\` to work around this.
-- The bat always kills every `chrome.exe` first (logging what it
-  killed) because a single orphan from a parallel Playwright run will
-  otherwise grab the binary and swallow the debug flag.
+- Bootstrap is **targeted and idempotent** (issue #59, supersedes #57): it
+  reuses an existing `:9222` if one is up, and otherwise kills **only** the
+  Chrome whose command line carries `--user-data-dir=<newsletter profile>` (via
+  `config.chrome_profile_lock.pids_holding_profile`) — never `taskkill /IM
+  chrome.exe`. Your everyday browser is never touched. If a *non-debug* Chrome
+  is holding the newsletter profile, relaunching it drops that window's open
+  tabs (logins persist).
 - The pipeline does **not** close Chrome when it disconnects — only the
   tabs whose articles processed successfully are closed.
 - New connections are created with `name` + `topic` only. LinkedIn URLs
@@ -182,7 +201,8 @@ byline. The fallback exists so the pipeline never invents people.
 
 ## Files
 
-- `bootstrap_chrome.bat` — daily Chrome launcher (kill + relaunch on `:9222`).
+- `bootstrap_chrome.py` — targeted, idempotent Chrome launcher on `:9222` (reuse-or-relaunch; never kills the everyday browser).
+- `bootstrap_chrome.bat` — thin wrapper that runs `python -m newsletter.bootstrap_chrome`.
 - `bootstrap_session.py` — one-time Gmail-login flow into the dedicated profile.
 - `chrome_tabs.py` — CDP attach, list, skip filter, tab close.
 - `extractor.py` — Playwright + readability-lxml + meta-tag fallback.
@@ -198,4 +218,4 @@ byline. The fallback exists so the pipeline never invents people.
 - `normalize_names_words.json` — sidecar: proper-name whitelist + special
   cases + common words.
 - `normalize_url.py` — URL query-param stripper with preserve list.
-- `build_newsletter.py` — HTML builder + must-read line copier.
+- `build_newsletter.py` — HTML builder + must-read line; writes the `N{NNN}.topics.json` sidecar the app's must-read picker reads.

--- a/newsletter/bootstrap_chrome.bat
+++ b/newsletter/bootstrap_chrome.bat
@@ -1,74 +1,34 @@
 @echo off
-setlocal enabledelayedexpansion
-
 REM ============================================================
-REM bootstrap_chrome.bat — clean-slate Chrome launcher on :9222
-REM for the newsletter-archive pipeline.
+REM bootstrap_chrome.bat — thin wrapper over the Python bootstrap.
 REM
-REM Always kills every chrome.exe first (and logs what it killed).
-REM A stray Chrome process — even one orphaned by an earlier
-REM Playwright run — will silently swallow the
-REM --remote-debugging-port flag, so a guaranteed clean slate is
-REM the only reliable way.
+REM Launches the dedicated newsletter Chrome on :9222 WITHOUT
+REM killing your everyday browser. All logic lives in
+REM newsletter\bootstrap_chrome.py (single source of truth) so the
+REM Streamlit app and this bat drive the exact same code.
 REM
-REM Then launches Chrome with the debug port + a dedicated
-REM user-data-dir (Chrome 136+ refuses to bind the debug port
-REM against the default profile dir for security reasons), and
-REM polls until the port responds.
-REM
-REM The dedicated profile lives in newsletter\chrome_user_data\
-REM (gitignored). First time you run this, you'll need to sign into
-REM Gmail in the new Chrome window if you want to click newsletter
-REM article links from email — the session will then persist.
+REM Behaviour: if :9222 is already up it reuses it (your tabs stay);
+REM otherwise it kills only the Chrome bound to the newsletter
+REM profile (if any) and relaunches with the debug port.
 REM ============================================================
 
-echo === Chrome processes before bootstrap ===
-tasklist /FI "IMAGENAME eq chrome.exe" /FO TABLE 2>NUL | findstr /I "chrome.exe"
-if errorlevel 1 (
-    echo (none)
-) else (
-    echo Stopping all chrome.exe...
-    taskkill /F /IM chrome.exe >NUL 2>&1
-    REM Wait for the OS to release the user-data-dir lock.
-    timeout /t 2 /nobreak >NUL
-    echo Done.
-)
-echo.
+setlocal
+cd /d "%~dp0.."
 
-set "CHROME_EXE=C:\Program Files\Google\Chrome\Application\chrome.exe"
-if not exist "%CHROME_EXE%" set "CHROME_EXE=C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"
-if not exist "%CHROME_EXE%" (
-    echo Chrome not found at the expected install path.
-    echo Edit this file and set CHROME_EXE to your chrome.exe.
+set VENV_PY=.\.venv\Scripts\python.exe
+if not exist "%VENV_PY%" (
+    echo [ERROR] Virtual environment not found at %VENV_PY%
     pause
     exit /b 1
 )
 
-set "USER_DATA_DIR=%~dp0chrome_user_data"
-if not exist "%USER_DATA_DIR%" mkdir "%USER_DATA_DIR%"
+"%VENV_PY%" -m newsletter.bootstrap_chrome
+set RC=%ERRORLEVEL%
 
-echo Launching Chrome with --remote-debugging-port=9222 ...
-echo   user-data-dir: %USER_DATA_DIR%
-start "" "%CHROME_EXE%" --remote-debugging-port=9222 --user-data-dir="%USER_DATA_DIR%" --no-first-run --no-default-browser-check
-
-REM Poll the debug endpoint until it's ready (~10 s max).
-set TRIES=0
-:waitloop
-set /a TRIES+=1
-powershell -NoProfile -Command "try { Invoke-WebRequest -Uri 'http://127.0.0.1:9222/json/version' -UseBasicParsing -TimeoutSec 1 | Out-Null; exit 0 } catch { exit 1 }"
-if !errorlevel! equ 0 (
+if not %RC%==0 (
     echo.
-    echo Chrome debug port is UP on http://127.0.0.1:9222
-    echo Open your newsletter article tabs in the new Chrome window, then run:
-    echo     .venv\Scripts\python -m newsletter.dry_run --first-non-gmail-tab --no-write
-    exit /b 0
-)
-if !TRIES! geq 10 (
-    echo.
-    echo Chrome debug port did not respond after 10 tries.
-    echo Check that no other chrome.exe is running and try again.
+    echo [ERROR] bootstrap failed (exit %RC%)
     pause
-    exit /b 3
 )
-timeout /t 1 /nobreak >NUL
-goto waitloop
+
+endlocal & exit /b %RC%

--- a/newsletter/bootstrap_chrome.py
+++ b/newsletter/bootstrap_chrome.py
@@ -1,0 +1,154 @@
+"""Targeted, idempotent Chrome bootstrap on :9222 for the newsletter profile.
+
+Ensures a Chrome bound to ``newsletter/chrome_user_data`` is listening on the
+CDP debug port :9222 — **without ever touching the everyday browser**. This
+replaces the old ``bootstrap_chrome.bat`` that did ``taskkill /IM chrome.exe``
+(kill *every* Chrome). Supersedes the stop-gap from issue #57; see issue #59.
+
+Behaviour (idempotent):
+
+* If :9222 already responds → reuse it, do nothing. Honours the fleet rule
+  "never kill a live holder" — your debug Chrome and its open tabs are left
+  alone.
+* Else, if the dedicated newsletter profile is held by a non-debug Chrome →
+  kill **only those PIDs** (via :func:`config.chrome_profile_lock.pids_holding_profile`,
+  which matches only ``--user-data-dir=<this profile>``), then relaunch. The
+  persistent profile (logins) survives; only that window's live tabs are lost.
+* Launch Chrome with the debug port + the dedicated ``--user-data-dir`` and
+  poll until the port responds.
+
+This is the **CDP-attach** mechanism — the archive step connects over CDP via
+``newsletter/chrome_tabs.py``. It is intentionally distinct from
+``launch_persistent_context`` (the Playwright stealth path) and must not be
+folded into it.
+
+Usage:
+    .venv\\Scripts\\python -m newsletter.bootstrap_chrome
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import requests  # noqa: E402
+
+from config.chrome_profile_lock import pids_holding_profile  # noqa: E402
+
+USER_DATA_DIR = Path(__file__).parent / "chrome_user_data"
+DEBUG_PORT = 9222
+DEBUG_URL = f"http://127.0.0.1:{DEBUG_PORT}/json/version"
+
+# Chrome install locations, in probe order (mirrors the old bat).
+_CHROME_CANDIDATES = (
+    Path(r"C:\Program Files\Google\Chrome\Application\chrome.exe"),
+    Path(r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"),
+)
+
+logger = logging.getLogger("newsletter.bootstrap_chrome")
+
+
+def debug_port_up(timeout: float = 1.0) -> bool:
+    """True when Chrome's CDP endpoint answers on :9222."""
+    try:
+        return requests.get(DEBUG_URL, timeout=timeout).status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def _find_chrome_exe() -> Path:
+    for candidate in _CHROME_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        "chrome.exe not found at the expected install paths "
+        f"({', '.join(str(c) for c in _CHROME_CANDIDATES)}). "
+        "Edit _CHROME_CANDIDATES in newsletter/bootstrap_chrome.py."
+    )
+
+
+def _kill_pids(pids: list[int]) -> None:
+    for pid in pids:
+        # /T also kills child processes (Chrome's renderer/GPU helpers).
+        subprocess.run(
+            ["taskkill", "/PID", str(pid), "/F", "/T"],
+            capture_output=True, text=True,
+        )
+
+
+def ensure_chrome(*, timeout_s: int = 15) -> int:
+    """Ensure Chrome is up on :9222 against the newsletter profile.
+
+    Returns 0 on success (already up, or launched and reachable), 3 if the
+    port never came up within ``timeout_s`` seconds.
+    """
+    USER_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    if debug_port_up():
+        logger.info("✅ Chrome already up on :%d — reusing it (open tabs untouched)", DEBUG_PORT)
+        return 0
+
+    held = pids_holding_profile(USER_DATA_DIR)
+    if held:
+        logger.warning(
+            "⚠️ Newsletter profile is held by a non-debug Chrome (PID(s) %s) — "
+            "relaunching it with the debug port. That window's open tabs will "
+            "close; your logins persist.", held,
+        )
+        _kill_pids(held)
+        # Give the OS a moment to release the profile-dir lock.
+        time.sleep(2)
+
+    chrome = _find_chrome_exe()
+    logger.info("🚀 Launching Chrome on :%d  ·  profile %s", DEBUG_PORT, USER_DATA_DIR)
+    subprocess.Popen(
+        [
+            str(chrome),
+            f"--remote-debugging-port={DEBUG_PORT}",
+            f"--user-data-dir={USER_DATA_DIR}",
+            "--no-first-run",
+            "--no-default-browser-check",
+        ],
+        # Detach so Chrome outlives this launcher (and the app subprocess).
+        creationflags=(
+            getattr(subprocess, "DETACHED_PROCESS", 0)
+            | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        ),
+    )
+
+    for _ in range(timeout_s):
+        if debug_port_up():
+            logger.info("✅ Chrome debug port is UP on %s", DEBUG_URL)
+            logger.info("   Open your newsletter article tabs in that window, then archive.")
+            return 0
+        time.sleep(1)
+
+    logger.error("❌ :%d not reachable after %ds — bootstrap failed", DEBUG_PORT, timeout_s)
+    return 3
+
+
+def main() -> int:
+    # Force UTF-8 stdio so emoji log lines don't crash Windows' cp1252 console.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+        except Exception:
+            pass
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stdout)],
+        )
+    return ensure_chrome()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -263,6 +263,34 @@ def format_must_read_line(three_names: Sequence[str], must_read: int) -> str:
     return ". ".join(three_names[i] for i in perm) + "."
 
 
+def topics_sidecar_path(newsletter_number: str) -> Path:
+    """Path of the topics sidecar JSON for a newsletter number (``057``/``N057``)."""
+    return RESULTS_DIR / f"{_normalize_newsletter_number(newsletter_number)}.topics.json"
+
+
+def _write_topics_sidecar(
+    nl_num: str,
+    headings: Sequence[str],
+    top_names: Optional[Sequence[str]],
+) -> Path:
+    """Persist the top article per topic so the Streamlit must-read picker can
+    compose the line without re-querying Notion (the app drives builds as
+    subprocesses, so there is no structured return value to read).
+
+    ``top_names`` is ``None`` when any topic has no articles — the UI then knows
+    the must-read line is unavailable.
+    """
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    path = topics_sidecar_path(nl_num)
+    payload = {
+        "newsletter": nl_num,
+        "headings": list(headings),
+        "top_names": list(top_names) if top_names is not None else None,
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
 def copy_to_clipboard(text: str) -> None:
     if sys.platform == "win32":
         subprocess.run(
@@ -321,8 +349,20 @@ def _normalize_newsletter_number(raw: str) -> str:
 
 
 def run(newsletter_number: str, debug: bool = False, *,
-        interactive_must_read: bool = True, open_browser: bool = True) -> Path:
-    """Build the newsletter end-to-end. Returns the HTML file path written."""
+        interactive_must_read: bool = True, open_browser: bool = True,
+        must_read: Optional[int] = None) -> Path:
+    """Build the newsletter end-to-end. Returns the HTML file path written.
+
+    Always writes a topics sidecar (``N{NNN}.topics.json``) next to the HTML so
+    the Streamlit must-read picker can compose the line without re-querying
+    Notion.
+
+    Must-read handling, in priority order:
+
+    * ``must_read`` (1/2/3) set → compose + copy the line non-interactively.
+    * else ``interactive_must_read`` → prompt on stdin (console flow).
+    * else → write the HTML + sidecar only (the app's non-blocking path).
+    """
     _setup_logging(debug)
     nl_num = _normalize_newsletter_number(newsletter_number)
     builder = NotionNewsletterBuilder()
@@ -334,11 +374,22 @@ def run(newsletter_number: str, debug: bool = False, *,
     out_path.write_text(complete_html, encoding="utf-8")
     logging.info(f"💾 HTML saved to: {out_path}")
 
+    top_names = top_article_names_by_topic(builder.topics, grouped)
+    sidecar = _write_topics_sidecar(nl_num, TOPIC_HEADINGS, top_names)
+    logging.info(f"🗂️ Topics sidecar: {sidecar}")
+
     if open_browser:
         webbrowser.open(f"file://{out_path}")
         logging.info(f"🌐 Opened HTML in browser: {out_path}")
 
-    if interactive_must_read:
+    if must_read is not None:
+        if top_names is None:
+            logging.warning("⚠️ Cannot compose must-read line: a topic has no articles")
+        else:
+            line = format_must_read_line(top_names, must_read)
+            copy_to_clipboard(line)
+            logging.info(f"📋 Must-read line (copied to clipboard): {line}")
+    elif interactive_must_read:
         prompt_must_read_line(builder.topics, grouped)
 
     return out_path

--- a/newsletter_pipeline.py
+++ b/newsletter_pipeline.py
@@ -1,21 +1,28 @@
-"""Newsletter pipeline orchestrator (issue #18).
+"""Newsletter pipeline orchestrator (issues #18, #59).
 
-Walks the weekly newsletter workflow end-to-end:
+The weekly newsletter workflow, split into independent, non-interactive steps
+so each can run on its own and stream cleanly to the Streamlit app. The same
+subcommands back both the app and ``launch_newsletter.bat`` — there is no
+Streamlit-only path.
 
-1. Ensure Chrome is up on ``:9222`` against the dedicated newsletter profile.
-   Bootstrap is **skipped by default** — bring Chrome up yourself by running
-   ``newsletter/bootstrap_chrome.bat`` in a separate console (it kills every
-   chrome.exe + relaunches with ``--user-data-dir``). Pass ``--no-skip-bootstrap``
-   to let the pipeline run that bootstrap for you.
-2. Wait for you to open your article tabs in that Chrome window.
-3. Archive the tabs into Notion via :func:`newsletter.pipeline.run_batch`.
-4. Wait for the green light to clean up.
-5. Run :func:`newsletter.normalize_names.run` (titles → sentence case).
-6. Run :func:`newsletter.normalize_url.run` (strip tracking params).
-7. Prompt for the newsletter number and run
-   :func:`newsletter.build_newsletter.run` — HTML written under
-   ``results/newsletter/N{NNN}.html``, opened in the browser, then prompt
-   for the must-read topic and copy the composed line to the clipboard.
+Subcommands::
+
+    newsletter_pipeline.py bootstrap                         # ensure Chrome on :9222 (targeted)
+    newsletter_pipeline.py archive   [--debug]               # open tabs -> Notion
+    newsletter_pipeline.py normalize [--days 14] [--debug]   # titles + URLs
+    newsletter_pipeline.py build     --newsletter NNN [--debug] [--no-open]
+                                     [--must-read 1|2|3 | --no-must-read]
+    newsletter_pipeline.py create    --newsletter NNN [--days 14] [--debug]
+    newsletter_pipeline.py all       [--newsletter NNN] [--days 14] [--debug]
+
+* ``bootstrap`` launches the dedicated newsletter Chrome on :9222 **without**
+  killing the everyday browser (see ``newsletter/bootstrap_chrome.py``).
+* ``archive`` / ``normalize`` / ``build`` / ``create`` are all non-interactive.
+* ``create`` = archive -> normalize -> build (no must-read prompt), chained.
+* ``all`` is the one sanctioned interactive console flow: bootstrap -> a single
+  "open your tabs, press Enter" pause (you can't archive tabs that aren't open
+  yet) -> archive -> normalize -> build with the interactive must-read prompt.
+* No subcommand defaults to ``all`` so existing muscle memory keeps working.
 
 Mirrors the shape of ``reporting_pipeline.py`` / ``planning_pipeline.py``.
 """
@@ -24,9 +31,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-import subprocess
 import sys
-import time
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
@@ -40,13 +45,9 @@ for _stream in (sys.stdout, sys.stderr):
     except Exception:
         pass
 
-import requests  # noqa: E402
-
+from newsletter import bootstrap_chrome  # noqa: E402
 from newsletter import build_newsletter, normalize_names, normalize_url  # noqa: E402
 from newsletter import pipeline as archive_pipeline  # noqa: E402
-
-BOOTSTRAP_BAT = REPO_ROOT / "newsletter" / "bootstrap_chrome.bat"
-DEBUG_URL = "http://127.0.0.1:9222/json/version"
 
 logger = logging.getLogger("newsletter_pipeline")
 
@@ -63,141 +64,179 @@ def _wait_for_user(prompt: str) -> None:
         raise SystemExit(2)
 
 
-def _debug_port_up(timeout: float = 1.0) -> bool:
-    try:
-        r = requests.get(DEBUG_URL, timeout=timeout)
-        return r.status_code == 200
-    except requests.RequestException:
-        return False
+def _banner(title: str) -> None:
+    print()
+    print("=" * 60)
+    print(f">>> {title}")
+    print("=" * 60)
 
 
 # ---------------------------------------------------------------------- steps
 
 
-def step_bootstrap_chrome() -> None:
-    print("=" * 60)
-    print(">>> Step 1/5: bootstrap Chrome on :9222")
-    print("=" * 60)
-    if not BOOTSTRAP_BAT.exists():
-        raise FileNotFoundError(f"Missing bootstrap_chrome.bat at {BOOTSTRAP_BAT}")
-    # The bat kills every chrome.exe, relaunches with the debug port, and polls
-    # until :9222 responds. We don't capture output — let the user see it.
-    result = subprocess.run([str(BOOTSTRAP_BAT)], shell=True)
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"bootstrap_chrome.bat exited with code {result.returncode}"
-        )
-    # Belt-and-braces — confirm the port is actually reachable from here.
-    for _ in range(10):
-        if _debug_port_up():
-            print("✅ Chrome :9222 is ready")
-            return
-        time.sleep(1)
-    raise RuntimeError(":9222 not reachable after bootstrap")
+def step_bootstrap() -> int:
+    _banner("bootstrap Chrome on :9222 (targeted — everyday browser untouched)")
+    return bootstrap_chrome.ensure_chrome()
 
 
-def step_archive(debug: bool) -> None:
-    print()
-    print("=" * 60)
-    print(">>> Step 3/5: archive open Chrome tabs to Notion")
-    print("=" * 60)
-    rc = archive_pipeline.run_batch(write=True, debug=debug)
-    if rc != 0:
-        raise RuntimeError(f"newsletter archive returned exit code {rc}")
+def step_archive(debug: bool) -> int:
+    _banner("archive open Chrome tabs to Notion")
+    if not bootstrap_chrome.debug_port_up():
+        print("❌ Chrome isn't responding on :9222 — run the bootstrap step first")
+        print("   (the '① Bootstrap Chrome' button, or:")
+        print("       newsletter_pipeline.py bootstrap )")
+        return 1
+    return archive_pipeline.run_batch(write=True, debug=debug)
 
 
-def step_normalize(days: int, debug: bool) -> None:
-    print()
-    print("=" * 60)
-    print(f">>> Step 4a/5: normalize_names (last {days} days)")
-    print("=" * 60)
+def step_normalize(days: int, debug: bool) -> int:
+    _banner(f"normalize_names (last {days} days)")
     normalize_names.run(days=days, dry_run=False, debug=debug)
-
-    print()
-    print("=" * 60)
-    print(f">>> Step 4b/5: normalize_url (last {days} days)")
-    print("=" * 60)
+    _banner(f"normalize_url (last {days} days)")
     normalize_url.run(days=days, dry_run=False, testing_mode=False, debug=debug)
-
-
-def step_build_newsletter(newsletter_number: str | None, debug: bool) -> None:
-    print()
-    print("=" * 60)
-    print(">>> Step 5/5: build newsletter HTML")
-    print("=" * 60)
-    if not newsletter_number:
-        try:
-            newsletter_number = input("Enter newsletter number (e.g. 057): ").strip()
-        except (EOFError, KeyboardInterrupt):
-            raise SystemExit(2)
-    if not newsletter_number:
-        raise SystemExit("❌ newsletter number is required")
-    out_path = build_newsletter.run(newsletter_number, debug=debug)
-    print()
-    print(f"🎉 Newsletter pipeline complete. HTML: {out_path}")
-
-
-# --------------------------------------------------------------- orchestration
-
-
-def run_pipeline(*, days: int, newsletter_number: str | None,
-                 debug: bool, skip_bootstrap: bool) -> int:
-    if not skip_bootstrap:
-        step_bootstrap_chrome()
-    else:
-        if not _debug_port_up():
-            print("❌ Chrome isn't responding on :9222 — cannot archive tabs.")
-            print("   Bootstrap is skipped by default (it kills every chrome.exe,")
-            print("   including your everyday browser). Open a SEPARATE console and run:")
-            print("       newsletter\\bootstrap_chrome.bat")
-            print("   open your newsletter article tabs in that window, then re-run this")
-            print("   pipeline. To let the pipeline bootstrap for you, pass --no-skip-bootstrap.")
-            return 1
-        print("⏭️  Using the existing Chrome on :9222 (bootstrap skipped by default)")
-
-    _wait_for_user(
-        ">>> Step 2/5: open every newsletter article tab in the Chrome window, "
-        "then press Enter…"
-    )
-
-    step_archive(debug=debug)
-
-    _wait_for_user(
-        ">>> Press Enter when you're ready to normalise names + URLs…"
-    )
-
-    step_normalize(days=days, debug=debug)
-
-    step_build_newsletter(newsletter_number, debug=debug)
     return 0
 
 
-def main() -> int:
+def step_build(newsletter_number: str | None, debug: bool, *,
+               interactive_must_read: bool, open_browser: bool,
+               must_read: int | None) -> int:
+    _banner("build newsletter HTML")
+    if not newsletter_number:
+        if interactive_must_read:
+            try:
+                newsletter_number = input("Enter newsletter number (e.g. 057): ").strip()
+            except (EOFError, KeyboardInterrupt):
+                raise SystemExit(2)
+        if not newsletter_number:
+            print("❌ newsletter number is required (--newsletter NNN)")
+            return 1
+    out_path = build_newsletter.run(
+        newsletter_number, debug=debug,
+        interactive_must_read=interactive_must_read,
+        open_browser=open_browser, must_read=must_read,
+    )
+    print(f"🎉 Newsletter HTML: {out_path}")
+    return 0
+
+
+# --------------------------------------------------------------- composite flows
+
+
+def run_create(*, days: int, newsletter_number: str | None, debug: bool) -> int:
+    """archive -> normalize -> build (no must-read prompt). Non-interactive."""
+    if not newsletter_number:
+        print("❌ newsletter number is required for 'create' (--newsletter NNN)")
+        return 1
+    rc = step_archive(debug=debug)
+    if rc != 0:
+        return rc
+    rc = step_normalize(days=days, debug=debug)
+    if rc != 0:
+        return rc
+    return step_build(
+        newsletter_number, debug=debug,
+        interactive_must_read=False, open_browser=True, must_read=None,
+    )
+
+
+def run_all(*, days: int, newsletter_number: str | None, debug: bool) -> int:
+    """Full interactive console sequence with a single manual pause."""
+    rc = step_bootstrap()
+    if rc != 0:
+        return rc
+    _wait_for_user(
+        ">>> Open every newsletter article tab in the Chrome window, then press Enter…"
+    )
+    rc = step_archive(debug=debug)
+    if rc != 0:
+        return rc
+    _wait_for_user(">>> Press Enter when you're ready to normalise names + URLs…")
+    rc = step_normalize(days=days, debug=debug)
+    if rc != 0:
+        return rc
+    return step_build(
+        newsletter_number, debug=debug,
+        interactive_must_read=True, open_browser=True, must_read=None,
+    )
+
+
+# --------------------------------------------------------------------- CLI
+
+
+def _add_days(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--days", type=int, default=14,
+                   help="Look back N days for normalize (default 14)")
+
+
+def _add_newsletter(p: argparse.ArgumentParser, *, required: bool) -> None:
+    p.add_argument("--newsletter", type=str, default=None, required=required,
+                   help="Newsletter number, e.g. 057 or N057")
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Newsletter pipeline: bootstrap → archive → normalize → build."
     )
-    parser.add_argument(
-        "--days", type=int, default=14,
-        help="Look back N days for normalize_names / normalize_url (default 14)",
-    )
-    parser.add_argument(
-        "--newsletter", type=str, default=None,
-        help="Newsletter number (e.g. 057). Prompted if omitted.",
-    )
-    parser.add_argument(
-        "--skip-bootstrap", action=argparse.BooleanOptionalAction, default=True,
-        help="Skip the Chrome kill/relaunch and reuse the existing :9222 instance "
-             "(default). Use --no-skip-bootstrap to let the pipeline kill every "
-             "chrome.exe and relaunch the dedicated newsletter profile.",
-    )
-    parser.add_argument("--debug", action="store_true")
-    args = parser.parse_args()
+    parser.add_argument("--debug", action="store_true",
+                        help="Verbose logs (also accepted per-subcommand)")
+    sub = parser.add_subparsers(dest="cmd")
 
-    return run_pipeline(
-        days=args.days,
-        newsletter_number=args.newsletter,
-        debug=args.debug,
-        skip_bootstrap=args.skip_bootstrap,
+    sub.add_parser("bootstrap", help="Ensure Chrome is up on :9222 (targeted)")
+
+    p_arch = sub.add_parser("archive", help="Archive open Chrome tabs to Notion")
+    p_arch.add_argument("--debug", action="store_true")
+
+    p_norm = sub.add_parser("normalize", help="Normalize article titles + URLs")
+    _add_days(p_norm)
+    p_norm.add_argument("--debug", action="store_true")
+
+    p_build = sub.add_parser("build", help="Build the newsletter HTML")
+    _add_newsletter(p_build, required=False)
+    p_build.add_argument("--debug", action="store_true")
+    p_build.add_argument("--no-open", action="store_true",
+                         help="Don't open the rendered HTML in the browser")
+    mr = p_build.add_mutually_exclusive_group()
+    mr.add_argument("--must-read", type=int, choices=(1, 2, 3), default=None,
+                    help="Compose + copy the must-read line non-interactively")
+    mr.add_argument("--no-must-read", action="store_true",
+                    help="Skip the must-read step entirely (app's non-blocking path)")
+
+    p_create = sub.add_parser("create", help="archive → normalize → build (non-interactive)")
+    _add_newsletter(p_create, required=True)
+    _add_days(p_create)
+    p_create.add_argument("--debug", action="store_true")
+
+    p_all = sub.add_parser("all", help="Full interactive console sequence")
+    _add_newsletter(p_all, required=False)
+    _add_days(p_all)
+    p_all.add_argument("--debug", action="store_true")
+
+    args = parser.parse_args(argv)
+    debug = bool(getattr(args, "debug", False))
+    cmd = args.cmd or "all"
+
+    if cmd == "bootstrap":
+        return step_bootstrap()
+    if cmd == "archive":
+        return step_archive(debug=debug)
+    if cmd == "normalize":
+        return step_normalize(days=args.days, debug=debug)
+    if cmd == "build":
+        # build default (no must-read flags) → interactive prompt.
+        interactive = args.must_read is None and not args.no_must_read
+        return step_build(
+            args.newsletter, debug=debug,
+            interactive_must_read=interactive,
+            open_browser=not args.no_open,
+            must_read=args.must_read,
+        )
+    if cmd == "create":
+        return run_create(days=args.days, newsletter_number=args.newsletter, debug=debug)
+    # "all" (explicit or default)
+    return run_all(
+        days=getattr(args, "days", 14),
+        newsletter_number=getattr(args, "newsletter", None),
+        debug=debug,
     )
 
 


### PR DESCRIPTION
## Summary

Reworks the newsletter workflow so it's app-drivable and stops clobbering the everyday browser (supersedes the #57 stop-gap).

### Changes

- **`newsletter/bootstrap_chrome.py`** (new) — targeted, idempotent bootstrap. Reuses `:9222` if already up (your tabs stay); otherwise kills **only** the Chrome bound to the newsletter profile via `config.chrome_profile_lock.pids_holding_profile` and relaunches detached. Never `taskkill /IM chrome.exe`.
- **`newsletter/bootstrap_chrome.bat`** — reduced to a thin wrapper over `python -m newsletter.bootstrap_chrome` (single source of truth).
- **`newsletter_pipeline.py`** — split into argparse subcommands `bootstrap` / `archive` / `normalize` / `build` / `create` / `all`. Steps are non-interactive (no stdin blocking from the app); `archive` does a friendly `:9222`-down precheck; no subcommand defaults to `all`. Removed `--skip-bootstrap`.
- **`newsletter/build_newsletter.py`** — `run()` always writes an `N{NNN}.topics.json` sidecar and supports non-interactive `must_read=`; added `topics_sidecar_path()`.
- **`app/tab_newsletter.py`** — rewritten: ① Bootstrap + ② ③ ④ step buttons + ▶ run-②③④ combo + a must-read picker fed by the sidecar (copyable `st.code`). Dropped the skip-bootstrap toggle and stdin-hang warning.
- **`launch_newsletter.bat`** — runs the interactive `all` sequence; comments refreshed.
- **`README.md` + `newsletter/README.md`** — new flow, mermaid, subcommand tables, gotchas, files list.

## Validation

- `py_compile` on all touched `.py` → OK (Python 3.14.3)
- New CLI surface confirmed via `--help` (root + `build`)
- Streamlit boots (health 200); `AppTest` renders the newsletter tab with **zero exceptions** — all five buttons present
- No `taskkill /IM chrome.exe` remains in the repo
- Manually validated end-to-end by the author (bootstrap → archive → normalize → build → must-read picker)

Closes #59
