### PR TITLE
chore: pin en_core_web_sm spaCy model in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,10 @@ rapidfuzz
 # Entity detection (PERSON) for newsletter.normalize_names — falls back to
 # the whitelist heuristic if spaCy or its model isn't available.
 spacy
+# The en_core_web_sm model isn't on PyPI — pin the release wheel directly so a
+# fresh venv gets it via `pip install -r requirements.txt` (no separate
+# `spacy download` step). Keep the version aligned with the spaCy 3.8.x line.
+en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 # Supabase REST/PostgREST client for the engagement pipeline (CRUD without psycopg2).
 # Pinned to 2.10.x because storage3>=0.10 transitively pulls pyiceberg, which
 # has no wheel for Python 3.14 and requires MSVC to build from source. We


### PR DESCRIPTION
## Summary

`requirements.txt` listed a bare `spacy` but not its `en_core_web_sm` model — which isn't on PyPI. A fresh `.venv` therefore had spaCy but no model, so `newsletter.normalize_names` logged `⚠️ spaCy failed to load: [E050] Can't find model 'en_core_web_sm'` and fell back to whitelist heuristics.

Pin the 3.8.0 release wheel as a direct URL dependency so `pip install -r requirements.txt` installs it automatically — no separate `spacy download` step.

## Validation

- `pip install -r requirements.txt --dry-run` → resolves the wheel, exit 0
- `spacy.load('en_core_web_sm')` loads and detects PERSON entities
