### PR TITLE
fix(linkedin): repair Photo selector, calendar nav, Notion 503 robustness

### DIFF
--- a/planning/linkedin/README.md
+++ b/planning/linkedin/README.md
@@ -229,7 +229,7 @@ LinkedIn's class names are obfuscated (`_6e37ba57`, `_876da3c4`, …) and rotate
 
 | step | selector |
 |------|----------|
-| Open post + file picker (ILL / POST) | `page.get_by_role("button", name=PHOTO_BTN_RE)` on the feed (e.g. EN `^photo$` / ES `^foto$`) |
+| Open post + file picker (ILL / POST) | `page.get_by_role("button", name=PHOTO_BTN_RE)` on the feed. The button's accessible name is its `aria-label` (`"Add a photo"`), not its visible text `"Photo"`, so `PHOTO_BTN_RE` anchors on the trailing noun (`(?:^|\s)(?:photo\|foto)$`) to match `Photo` / `Foto` / `Add a photo` / `Añadir … foto` alike |
 | Upload image | `input[type="file"]` (first; appears in DOM after "Photo" click) |
 | Open ALT dialog | `[role="dialog"] >> get_by_role("button", name=ALT_TEXT_BTN_RE)` |
 | ALT textarea | `textarea[placeholder*="describe this image" i], textarea[placeholder*="imagen" i], [role='dialog'] textarea` (first hit wins) |
@@ -237,7 +237,7 @@ LinkedIn's class names are obfuscated (`_6e37ba57`, `_876da3c4`, …) and rotate
 | Editor → composer (Next) | `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` |
 | Caption editor | `div[role="textbox"][contenteditable="true"]` (then `page.keyboard.type(...)`) |
 | Open Schedule dialog | `get_by_role("button", name=SCHEDULE_POST_BTN_RE)` |
-| Set date | Click `input[name="artdeco-date"]` → click calendar day by `calendar_day_aria_re(target)` (EN `Monday, May 18, 2026.` / ES `lunes, 18 de mayo de 2026.`) |
+| Set date | Click `input[name="artdeco-date"]` → advance to the target month by reading the header `h1.artdeco-calendar__month` (e.g. `May 2026` / `mayo de 2026`) and clicking `aria-label="Next month"` until it matches → click the calendar day by `calendar_day_aria_re(target)` (EN `Monday, May 18, 2026.` / ES `lunes, 18 de mayo de 2026.`). The calendar popover is portaled **outside** `[role="dialog"]`, so the header + day cells are matched document-wide, not scoped to the dialog |
 | Set time | Click `input[name="timepicker"]` → wait for `.artdeco-typeahead__results-list:not([data-count="0"])` → click `li:has-text(<cand>)` for `<cand>` in `time_picker_candidates(hour, minute)` (EN `6:30 AM` / ES 24h `06:30` / ES 12h `6:30 a. m.`) |
 | Schedule sub-dialog → composer | `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` |
 | Final Schedule button | `[role="dialog"] >> get_by_role("button", name=FINAL_SCHEDULE_BTN_RE)` (anchored on `^schedule$` / `^programar$` so it never re-opens the clock-icon's schedule sub-dialog) |
@@ -267,6 +267,7 @@ LinkedIn's class names are obfuscated (`_6e37ba57`, `_876da3c4`, …) and rotate
 - **Carousel "Next" buttons on the feed** behind the modal have `aria-label="Next"` but empty visible text. Scope to `[role="dialog"] button:has-text("Next"), [role="dialog"] button:has-text("Siguiente")` so they don't win the `.first` race.
 - **Don't trust a fixed `wait_for_timeout` + screenshot as success confirmation.** The composer briefly stays open while LinkedIn renders the schedule, then unmounts. Wait for the dialog to actually disappear.
 - **LinkedIn's account-level UI language wins over `Accept-Language`.** If the connected LI account is set to Spanish (Settings → Account preferences → Site Preferences → Language), every page renders in Spanish no matter what `locale="en-US"` and `--lang=en-US` are doing at the Chrome layer — even mid-session LI can flip back after an action. The selectors in [`linkedin_labels.py`](linkedin_labels.py) cover both languages; if you see a brand-new Spanish wording that doesn't match, extend the alternation there, not at the call site.
+- **The schedule calendar popover renders OUTSIDE `[role="dialog"]`.** Its month header is an `<h1 class="artdeco-calendar__month">` (e.g. `May 2026`), not an `h2`/`div`, and it is not a descendant of the composer dialog. Scoping the month-arrival check to `[role="dialog"]` (or matching `h2`/`div`) silently never fires, so the "Next month" loop runs until LinkedIn's ~3-month scheduling limit and overshoots the target month. Read the header document-wide from `h1.artdeco-calendar__month` and click `aria-label="Next month"` until it matches.
 - **First feed action of a fresh session needs a longer click timeout.** LinkedIn redirects `/feed/` → `/` for logged-in users and re-renders the share box client-side; the cold-start race used to time the original 10 s `.click()` out (issue #27). The shared constant `linkedin_composer.FEED_ENTRY_CLICK_TIMEOUT_MS` (30 s) is what every feed-entry helper (`_click_add_photo`, `_click_video_button`, `_click_start_a_post`) uses; warm calls still return in ~1 s because `.click()` returns the instant the button is actionable.
 
 ---

--- a/planning/linkedin/linkedin_labels.py
+++ b/planning/linkedin/linkedin_labels.py
@@ -24,10 +24,18 @@ from datetime import date
 
 # ---------- Feed share box ----------
 
-PHOTO_BTN_RE = re.compile(r"^(?:photo|foto)$", re.I)
+# The share-box buttons render with the noun as VISIBLE text ("Photo"/"Video")
+# but LinkedIn now also sets an aria-label ("Add a photo"/"Add a video"), and
+# the aria-label wins the accessible-name computation. Anchoring on the trailing
+# noun ($) — preceded by start-of-string or whitespace — matches every observed
+# form across this change and across locales: "Photo", "Foto", "Add a photo",
+# "Añadir una foto", "Agregar foto", etc. (issue #60). Do NOT re-anchor with a
+# leading ^ only: that broke the moment LinkedIn prepended "Add a ".
+PHOTO_BTN_RE = re.compile(r"(?:^|\s)(?:photo|foto)$", re.I)
 
 # LinkedIn Spain uses "Vídeo" (with accent); some LATAM builds use "Video".
-VIDEO_BTN_RE = re.compile(r"^(?:video|vídeo)$", re.I)
+# Same trailing-noun anchor to absorb the "Add a video" aria-label.
+VIDEO_BTN_RE = re.compile(r"(?:^|\s)(?:v[ií]deo)$", re.I)
 
 # Two known EN names + two known ES names for the share box's main affordance.
 START_POST_RE = re.compile(

--- a/planning/linkedin/linkedin_posts_body.py
+++ b/planning/linkedin/linkedin_posts_body.py
@@ -39,9 +39,12 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+from notion_client.errors import HTTPResponseError, RequestTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from reporting.notion.editorial import (  # noqa: E402
@@ -49,6 +52,38 @@ from reporting.notion.editorial import (  # noqa: E402
 )
 
 logger = logging.getLogger("linkedin_posts_body")
+
+# Notion intermittently returns a transient 5xx / 429 — most notably a 503
+# "Public API object rendering exceeded the response time budget", whose own
+# remediation text says to retry with exponential backoff. We classify on the
+# HTTP status (the message wording is not stable) and retry a few times before
+# letting the error propagate; the caller's per-row handler then degrades a
+# still-failing read to a single FAIL row instead of aborting the platform.
+_NOTION_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+_NOTION_RETRY_ATTEMPTS = 4
+_NOTION_RETRY_BASE_DELAY = 2.0
+
+
+def _list_children_with_retry(notion, **kwargs) -> dict:
+    """``notion.blocks.children.list`` with bounded exponential backoff on
+    transient Notion errors (5xx / 429 / request timeout)."""
+    for attempt in range(1, _NOTION_RETRY_ATTEMPTS + 1):
+        try:
+            return notion.blocks.children.list(**kwargs)
+        except (HTTPResponseError, RequestTimeoutError) as exc:
+            status = getattr(exc, "status", None)
+            transient = isinstance(exc, RequestTimeoutError) or status in _NOTION_TRANSIENT_STATUS
+            if not transient or attempt == _NOTION_RETRY_ATTEMPTS:
+                raise
+            delay = _NOTION_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+            logger.warning(
+                "⚠️ Notion blocks.children.list transient error (status=%s, attempt %d/%d): "
+                "%s — sleeping %.1fs",
+                status, attempt, _NOTION_RETRY_ATTEMPTS,
+                str(exc).splitlines()[0][:160], delay,
+            )
+            time.sleep(delay)
+    raise RuntimeError("unreachable")  # pragma: no cover — loop always returns or raises
 
 # Notion enforces 2000 chars per rich_text segment's `text.content`.
 # Long LI captions (4k+ chars) must be split across multiple segments
@@ -131,7 +166,7 @@ def first_code_block_text(notion, page_id: str) -> str:
         kwargs: dict = {"block_id": page_id, "page_size": 100}
         if cursor:
             kwargs["start_cursor"] = cursor
-        response = notion.blocks.children.list(**kwargs)
+        response = _list_children_with_retry(notion, **kwargs)
         for block in response.get("results", []):
             if block.get("type") != "code":
                 continue

--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -45,6 +45,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Literal, Optional
 
+from notion_client.errors import HTTPResponseError
 from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
@@ -527,28 +528,32 @@ def _set_schedule_datetime(page: Page, target: date, hour: int, minute: int) -> 
     try:
         di.click(timeout=10000)
         page.wait_for_timeout(600)
-        # If the displayed month/year is wrong, click Next month until it
-        # matches. The header text reads "May 2026" / "mayo de 2026" / etc.
-        header_selector = ", ".join(
-            f'h2:has-text("{h}"), div:has-text("{h}")' for h in header_candidates
-        )
+        # Advance the calendar to the target month. LinkedIn's calendar header
+        # is an ``<h1 class="artdeco-calendar__month">`` (e.g. "May 2026" /
+        # "mayo de 2026"), rendered in the artdeco calendar popover which is
+        # NOT inside ``[role="dialog"]`` — so we read it document-wide. The old
+        # code scoped an ``h2``/``div`` match to the dialog; it never matched
+        # (the header is an h1 outside the dialog), so the loop ran Next-month
+        # straight into LinkedIn's 3-month scheduling limit and overshot the
+        # target. The calendar opens on the current month and we only ever
+        # schedule forward.
+        header_loc = page.locator("h1.artdeco-calendar__month")
+        header_lc = [h.lower() for h in header_candidates]
         for _ in range(18):  # generous safety bound (~1.5 years forward)
             try:
-                hdr = page.locator('[role="dialog"]').last.locator(header_selector)
-                if hdr.count() > 0:
-                    break
+                current = (header_loc.first.inner_text(timeout=2000) or "").strip().lower()
             except Exception:
-                pass
+                current = ""
+            if any(h in current for h in header_lc):
+                break
             try:
-                page.locator('[role="dialog"]').get_by_role(
+                page.get_by_role(
                     "button", name=NEXT_MONTH_BTN_RE
                 ).first.click(timeout=2000)
-                page.wait_for_timeout(200)
+                page.wait_for_timeout(250)
             except Exception:
                 break
-        day_btn = page.locator('[role="dialog"]').get_by_role(
-            "button", name=day_aria_re
-        )
+        day_btn = page.get_by_role("button", name=day_aria_re)
         day_btn.first.click(timeout=10000)
         page.wait_for_timeout(500)
     except Exception as err:
@@ -1144,7 +1149,8 @@ def main() -> tuple[int, list[dict]]:
                 statuses.append(f"{row.day_title}: LOGIN-REQUIRED")
                 results.append({"day": row.day_title, "status": "LOGIN-REQUIRED", "detail": str(err)})
                 break
-            except (FileNotFoundError, RuntimeError, PWTimeoutError) as err:
+            except (FileNotFoundError, RuntimeError, PWTimeoutError,
+                    HTTPResponseError) as err:
                 shot = session.screenshot_failure(f"{row.day_title}-error")
                 logger.error("❌ %s failed: %s (screenshot %s)", row.day_title, err, shot)
                 statuses.append(f"{row.day_title}: FAILED ({err})")


### PR DESCRIPTION
## Summary

Repairs three regressions that broke the LinkedIn leg of the 2026-05-30 planning run (every LinkedIn row failed; the platform then aborted on a Notion hiccup). All three root causes were confirmed by probing the live UI before changing code.

- **Photo/Video share-box selectors** — LinkedIn added `aria-label="Add a photo"` / `"Add a video"` to the feed buttons. The `aria-label` wins the accessible-name computation, so the old exact `^(?:photo|foto)$` match resolved to zero elements and every ILL/POST row timed out. `PHOTO_BTN_RE` / `VIDEO_BTN_RE` now anchor on the trailing noun, matching `Photo` / `Foto` / `Add a photo` / `Añadir … foto` alike.
- **Schedule calendar month navigation** — the calendar popover is portaled *outside* `[role="dialog"]` and its month header is an `<h1 class="artdeco-calendar__month">`, not an `h2`/`div`. The old dialog-scoped header check never matched, so the "Next month" loop ran into LinkedIn's 3-month scheduling limit and overshot the target month (landed on August for a June target). Now reads the header document-wide and stops on the target month.
- **Notion 503 robustness** — `first_code_block_text` retries `notion.blocks.children.list` with bounded exponential backoff on transient 5xx/429 (the 503 *"Public API object rendering exceeded the response time budget"*), and `HTTPResponseError` is added to the per-row `except` so a single page's Notion failure degrades to one FAIL row instead of aborting the whole LinkedIn platform.
- README: documents the Photo accessible-name anchor, the calendar popover living outside the dialog, and the month-nav header.

The Twitter one-off noted in the issue turned out to be a separate, deeper overlay bug — split out to #63 per the issue's "fix only if quick; otherwise separate issue" scoping.

## Validation

- `py_compile` clean on all three changed modules. No test suite / ruff configured in this repo.
- **LinkedIn `--all-wip --dry-run`**: all 7 rows reach the schedule dialog (ILL / POST / CAROUSEL), date lands on the correct day.
- **LinkedIn `--all-wip --live`**: all 7 rows scheduled, WIP-LI unticked in Notion — exercises the full path including the final Schedule step.

Closes #60
