### PR TITLE
feat(planning): autonomous self-healing scheduler with live visible console

### DIFF
--- a/.claude/skills/schedule-autoheal/SKILL.md
+++ b/.claude/skills/schedule-autoheal/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: schedule-autoheal
+description: Run a planning scheduler and autonomously self-heal selector breakage caused by platform UI drift. Runs the scheduler (dry-run or live), classifies any failure, and for UI-drift it probes the live DOM, applies a selector-only fix, re-validates with a dry-run, and — when confident — files an issue, opens a PR, and merges end-to-end. When not confident (ambiguous DOM, login-required, or data errors) it pings the user on Slack and stops for interactive handling. Use when running the weekly planning schedulers unattended, e.g. "/schedule-autoheal all --dry-run", "/schedule-autoheal twitter --live".
+---
+
+# schedule-autoheal
+
+**Goal:** make the weekly planning run *set-and-forget*. Run the scheduler; if it
+just works, say so and stop (minimal tokens). If a step fails because a platform's
+DOM drifted (an `aria-label` appeared, a button was renamed, a header was retyped),
+**self-heal in place** — no human relaunch — and either land the fix end-to-end or
+escalate cleanly.
+
+Invoking this skill is explicit authorization to run the scheduler and, **only when
+the confidence gate below is met**, to commit/push/PR/merge a selector-only fix.
+
+This is a **public repo** — never put secrets, internal identifiers, or private
+project references in issues, PRs, commit messages, or Slack pings.
+
+## Arguments
+
+`<platform|all> [--live|--dry-run] [--debug] [--skip-<platform>] [--from-result <path>]`
+
+- `platform` ∈ `linkedin|instagram|twitter|threads|all`. `all` runs the full pipeline.
+- mode defaults to `--dry-run`. `--live` actually schedules.
+- `--from-result <path>` skips the run and heals from an existing
+  `results/planning/<ts>-result.json` (used when the planning tab already ran it).
+
+## Step 1 — run (unless `--from-result`)
+
+- `all` → `& .\.venv\Scripts\python.exe planning_pipeline.py <mode> [--debug] [--skip-*]`
+- single platform → `& .\.venv\Scripts\python.exe -m planning.<platform>.schedule_<platform>_posts --all-wip <mode> [--debug]`
+
+Then read `results/planning/latest-result.json` (the machine-readable record written
+by `planning_pipeline.py`; see `planning/_failure.py` for the schema fields
+`status`, `detail`, `screenshot`, `failure_kind`).
+
+## Step 2 — triage
+
+- `verdict == "clean"` → **report "✅ it worked", stop.** Do not edit anything.
+- Otherwise collect every row whose `failure_kind != "none"`.
+  - `failure_kind == "ui-drift"` → **heal-eligible** (Step 3).
+  - `login-required` / `data-error` / `other` → **not** heal-eligible → **escalate** (Step 5).
+
+Heal at most **one platform per invocation cycle**; re-run to pick up the next.
+
+## Step 3 — heal a UI-drift failure (selector-only)
+
+1. From the failing row, note the platform, the failing step (in `detail`), and the
+   `screenshot` path. Read the screenshot if helpful.
+2. **Probe the live DOM:** `& .\.venv\Scripts\python.exe -m planning._probe <platform>`
+   (add `--url <page>` to target a specific page). This opens the platform's real-Chrome
+   session (stealth + shared-profile lock-wait are handled by the existing session helper —
+   never re-inline launch args) and prints ranked `role + accessible name` candidates.
+3. **Locate the broken selector:**
+   - LinkedIn → `planning/linkedin/linkedin_labels.py` (centralised regex registry; keep
+     the `EN | ES` alternations).
+   - Twitter / Threads / Instagram → the selector is **inline** in
+     `planning/<platform>/schedule_<platform>_posts.py`. Search for the old accessible
+     name / role call near the failing step.
+4. **Apply a selector-only edit.** Re-anchor the role/text selector on the new accessible
+   name from the probe. Prefer role + name anchors; **never** anchor on a class (the
+   READMEs warn class names rotate). The diff MUST be a pure selector-string change — no
+   control-flow, scheduling-logic, or unrelated edits. A reviewer should read it in seconds.
+5. **Re-validate:** re-run that platform `--dry-run`. Bounded retries — **max 2** heal
+   attempts per row; if still failing, **escalate** (Step 5).
+
+## Step 4 — confidence gate
+
+**Confident** = ALL of:
+- the probe yielded exactly **one** strong role/text candidate for the failing element, AND
+- the post-edit `--dry-run` **passes**, AND
+- the diff is a **pure selector-string** change.
+
+### Confident → land it end-to-end
+
+Mirror the repo's issue/PR conventions. One **separate issue per drift**.
+
+1. `gh issue create --title "fix(<platform>): <one-line drift>" --body "<before/after selector + probe evidence + screenshot path>" --label bug --assignee @me`
+2. Branch: `git checkout -b fix/<issue-n>-<slug>`
+3. Commit (no AI attribution trailer):
+   ```
+   fix(<platform>): re-anchor <selector> after UI drift
+
+   - <old> → <new> accessible name (probe evidence in PR)
+   - dry-run validated
+   ```
+4. `git push -u origin <branch>`
+5. `gh pr create --title "<same>" --body "Closes #<n>\n\n<before/after + probe evidence>"`
+6. Wait for CI green, then merge + delete branch (`gh pr merge --merge --delete-branch`), land on `main`.
+
+### Not confident → escalate (Step 5)
+
+Leave the working tree clean (or the branch un-pushed) and hand off to a human.
+
+## Step 5 — escalate via Slack, then stop
+
+Read the Slack target from `config/config.json` → `slack.autoheal_channel` (blank → the
+user's self-DM). Send a message with the **Slack MCP** tool
+(`mcp__claude_ai_Slack__slack_send_message`) containing: platform, failing step, the
+screenshot path, the probe's top candidates, and exactly what you need decided. Then
+**stop** — do not commit, push, or merge anything ambiguous.
+
+## Guardrails (non-negotiable)
+
+- **Selector-only edits.** Never touch control flow, scheduling logic, or anything outside
+  the selector string / label module on the auto-heal path.
+- **Dry-run must pass before any commit, and before any `--live`.**
+- **Bounded autonomy.** Max 2 heal attempts per row; one platform healed per cycle; hard
+  stop on `login-required`, `data-error`, ambiguous DOM, or anything unexpected.
+- **Anti-bot discipline preserved.** Always go through the existing
+  `planning/<platform>/<platform>_session.py` helpers (real Chrome, stealth, profile
+  lock-wait). Never re-inline launch args.
+- **Human-reviewable trail.** Every landed fix has an issue + PR with before/after selector
+  and probe evidence. Never a silent push to `main` without an issue+PR.
+- **Public repo hygiene.** No secrets / internal refs in any issue, PR, commit, or Slack ping.
+
+## Verification gate (before declaring done)
+
+- `& .\.venv\Scripts\python.exe -m py_compile <edited files>`
+- the validating `--dry-run` for the healed platform passes
+- `ruff check .` if configured

--- a/.gitignore
+++ b/.gitignore
@@ -35,14 +35,9 @@ __pycache__/
 supabase/.temp/cli-latest
 supabase/.branches/_current_branch
 
-# claude code settings
-.claude/
-
-# temp files
-/tmp
-
-# claude code settings
-.claude/
+# claude code settings — ignore local settings, but TRACK project skills
+.claude/*
+!.claude/skills/
 
 # temp files
 /tmp

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ reporting/                            # repo root
 ├── newsletter_pipeline.py            # orchestrator: bootstrap/archive/normalize/build subcommands
 ├── launch_planning.bat               # planning launcher (Windows CMD)
 ├── launch_reporting.bat              # reporting launcher (Windows CMD)
-└── launch_newsletter.bat             # newsletter launcher (Windows CMD)
+├── launch_newsletter.bat             # newsletter launcher (Windows CMD)
+└── launch_autoheal.bat               # self-healing planning run (visible console)
 ```
 
 ### Per-folder READMEs
@@ -189,6 +190,19 @@ rows are skipped (separate manual process). Full table + selectors in
 - Each platform package owns its own dedicated Chrome profile under
   `planning/<P>/chrome_user_data/` (gitignored). One-time bootstrap per
   platform: `python -m planning.<P>.bootstrap_session`.
+
+### Self-healing planning runs
+
+The schedulers drive live platform UIs whose DOM drifts almost weekly, silently
+breaking selectors. The **🔧 run + autoheal** button in the control-panel app's
+planning tab (and `launch_autoheal.bat`) runs the `/schedule-autoheal` skill in a
+**visible console**: it runs the scheduler and, on a UI-drift failure, probes the
+live DOM, applies a selector-only fix, re-validates with a dry-run, and — when
+confident — files an issue, opens a PR, and merges end-to-end. Login / data
+errors instead ping Slack and stop for a human. The run also writes a
+machine-readable `results/planning/latest-result.json`. See
+[`docs/self-healing-scheduler.md`](docs/self-healing-scheduler.md) for the full
+loop, failure classification, and guardrails.
 
 ## Reporting pipeline — overview
 

--- a/app/autoheal_console.py
+++ b/app/autoheal_console.py
@@ -1,0 +1,195 @@
+r"""Visible-console wrapper that runs the ``/schedule-autoheal`` skill headless.
+
+The planning tab spawns this script with ``CREATE_NEW_CONSOLE`` so it owns a
+real, visible window the user can watch. Inside that window it runs::
+
+    claude -p "/schedule-autoheal <args>" --model <m>
+        --permission-mode bypassPermissions --verbose
+
+and **tees** the agent's combined output to BOTH its own console (live, what the
+user watches) and a log file the Streamlit app tails into the in-app panel.
+
+Two details are load-bearing, both learned from the app-launcher sister project
+(``codebase-audit-fleet`` job, ``docs/lessons-launcher-owned-pty.md``):
+
+- ``--verbose`` makes ``claude -p`` stream turn-by-turn activity instead of
+  buffering one silent line until the final result flush — without it the
+  window looks dead for minutes.
+- ``--permission-mode bypassPermissions`` lets the unattended heal edit files,
+  run ``gh``, and call MCP tools with no human at the prompt.
+
+Run standalone via ``launch_autoheal.bat`` or as
+``python -m app.autoheal_console --log <path> --skill-cmd "/schedule-autoheal all --dry-run"``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MODEL = "claude-opus-4-8"
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _compact(value: Any, limit: int = 220) -> str:
+    try:
+        s = json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        s = str(value)
+    return _truncate(s, limit)
+
+
+def _format_event(line: str) -> Optional[str]:
+    """Turn one ``--output-format stream-json`` line into a readable feed line.
+
+    ``claude -p --verbose`` (plain text) block-buffers and flushes everything at
+    exit — the console looks dead the whole run. ``--output-format stream-json``
+    emits one JSON event the instant it happens (init, each assistant
+    thinking/text/tool_use block, each tool_result, the final result), so we get
+    true live progress. We render each event compactly; unrecognised lines are
+    passed through raw so banners / errors still show. Returns ``None`` for
+    events not worth a line (e.g. rate-limit pings).
+    """
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return line  # non-JSON (a banner or an arg error) — show it verbatim
+
+    etype = obj.get("type")
+    if etype == "system" and obj.get("subtype") == "init":
+        return f"▶ claude session {str(obj.get('session_id', ''))[:8]} · model {obj.get('model', '')}"
+    if etype == "assistant":
+        out: list[str] = []
+        for block in obj.get("message", {}).get("content", []):
+            bt = block.get("type")
+            if bt == "thinking":
+                think = block.get("thinking", "").strip()
+                if think:
+                    out.append(f"💭 {_truncate(think, 300)}")
+            elif bt == "text":
+                text = block.get("text", "").strip()
+                if text:
+                    out.append(text)
+            elif bt == "tool_use":
+                out.append(f"🔧 {block.get('name', '?')}({_compact(block.get('input', {}))})")
+        return "\n".join(out) if out else None
+    if etype == "user":
+        out = []
+        for block in obj.get("message", {}).get("content", []):
+            if block.get("type") == "tool_result":
+                content = block.get("content", "")
+                if isinstance(content, list):
+                    content = " ".join(
+                        c.get("text", "") for c in content if isinstance(c, dict)
+                    )
+                content = str(content).strip()
+                if content:
+                    out.append(f"   ↳ {_truncate(content, 300)}")
+        return "\n".join(out) if out else None
+    if etype == "result":
+        dur = obj.get("duration_ms")
+        suffix = f" · {dur} ms" if dur else ""
+        result = (obj.get("result") or "").strip()
+        head = f"✅ result: {obj.get('subtype', '')}{suffix}"
+        return f"{head}\n{result}" if result else head
+    return None
+
+
+def _emit(fh: Any, text: str) -> None:
+    """Write one line to both the log file and this process's console."""
+    data = f"{text}\n".encode("utf-8", "replace")
+    fh.write(data)
+    fh.flush()
+    buf = getattr(sys.stdout, "buffer", None)
+    if buf is not None:
+        try:
+            buf.write(data)
+            buf.flush()
+        except (OSError, ValueError):
+            pass
+
+
+def run(skill_cmd: str, log_path: Path, model: str, claude_exe: str,
+        remote_control: bool = True, remote_name: str = "autoheal") -> int:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    argv = [
+        claude_exe, "-p", skill_cmd,
+        "--model", model,
+        "--permission-mode", "bypassPermissions",
+        # stream-json (requires --verbose) flushes one event per step in realtime,
+        # unlike plain text which buffers until exit. We pretty-print each event.
+        "--output-format", "stream-json",
+        "--verbose",
+    ]
+    if remote_control:
+        # Surfaces the run in the Claude mobile/web app so it can be watched and
+        # driven remotely (e.g. answering the "not confident" escalation from the
+        # phone instead of only via Slack). Optional name makes it findable.
+        argv += ["--remote-control", remote_name]
+    with log_path.open("wb") as fh:
+        _emit(fh, f"$ {' '.join(argv)}")
+        _emit(fh, f"# started {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        _emit(fh, "")
+        try:
+            proc = subprocess.Popen(
+                argv,
+                cwd=str(REPO_ROOT),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+            )
+        except OSError as exc:
+            _emit(fh, f"[autoheal spawn error] {exc} — is the `claude` CLI on PATH?")
+            return 127
+        assert proc.stdout is not None
+        # readline streams each JSON event as claude emits it (no 4 KB buffering).
+        for raw in iter(proc.stdout.readline, b""):
+            text = _format_event(raw.decode("utf-8", "replace").rstrip("\n"))
+            if text:
+                _emit(fh, text)
+        rc = proc.wait()
+        _emit(fh, f"\n# exit code {rc}  ·  {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    return rc
+
+
+def main() -> int:
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+    parser = argparse.ArgumentParser(description="Run /schedule-autoheal headless in a visible console.")
+    parser.add_argument("--skill-cmd", required=True,
+                        help='full slash command, e.g. "/schedule-autoheal all --dry-run"')
+    parser.add_argument("--log", default=None,
+                        help="path to tee the combined output to (default: results/planning/autoheal-<ts>.log)")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--claude-exe", default="claude", help="claude CLI executable (default: on PATH)")
+    parser.add_argument("--no-remote-control", action="store_true",
+                        help="disable Remote Control (default: enabled, so the run is viewable from the Claude mobile app)")
+    parser.add_argument("--remote-name", default="autoheal", help="Remote Control session name")
+    args = parser.parse_args()
+    if args.log:
+        log_path = Path(args.log)
+    else:
+        ts = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+        log_path = REPO_ROOT / "results" / "planning" / f"autoheal-{ts}.log"
+    return run(args.skill_cmd, log_path, args.model, args.claude_exe,
+               remote_control=not args.no_remote_control, remote_name=args.remote_name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -141,6 +141,84 @@ def start_pipeline(name: str, cmd: list[str], *, cwd: Optional[Path] = None) -> 
     threading.Thread(target=_pump, daemon=True, name=f"pump-{name}").start()
 
 
+def start_skill_console(name: str, skill_cmd: str, *, model: str = "claude-opus-4-8") -> None:
+    """Launch the ``/schedule-autoheal`` skill in a **visible, detached console**.
+
+    Unlike :func:`start_pipeline` (which PIPEs the child into an in-app panel),
+    this spawns ``app/autoheal_console.py`` with ``CREATE_NEW_CONSOLE`` so the
+    agent's live ``--verbose`` stream appears in its own OS window — the user
+    watches it directly. We can't also PIPE a new-console child, so the wrapper
+    tees its output to a log file and a background thread tails that file into
+    the same deque ``render_log_panel`` reads, mirroring the window in-app.
+
+    The ``Popen`` handle is kept (detached ≠ untracked) so ``stop_pipeline`` and
+    the status badges keep working.
+    """
+    if is_running(name):
+        logger.warning("skill console %s already running — ignoring start", name)
+        return
+
+    ts = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    log_path = REPO_ROOT / "results" / "planning" / f"autoheal-{ts}.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    wrapper = REPO_ROOT / "app" / "autoheal_console.py"
+    cmd = [
+        str(VENV_PY), str(wrapper),
+        "--skill-cmd", skill_cmd,
+        "--log", str(log_path),
+        "--model", model,
+    ]
+
+    lines = _get_lines(name)
+    lines.clear()
+    lines.append(f"$ {skill_cmd}")
+    lines.append(f"# visible console launched {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"# live output streams in the new window; mirrored here from {log_path.name}")
+    lines.append("")
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    creationflags = 0
+    if sys.platform == "win32":
+        # CREATE_NEW_CONSOLE → a real, visible window that outlives this app.
+        creationflags = subprocess.CREATE_NEW_CONSOLE
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        creationflags=creationflags,
+    )
+    _set_proc(name, proc)
+    _set_meta(name, started_at=datetime.now().isoformat(timespec="seconds"),
+              cmd=cmd, log_path=str(log_path))
+
+    def _tail():
+        # Wait for the wrapper to create the log, then stream new lines into the
+        # deque until the process exits and the file is fully drained.
+        while not log_path.exists() and proc.poll() is None:
+            time.sleep(0.2)
+        try:
+            with log_path.open("r", encoding="utf-8", errors="replace") as fh:
+                while True:
+                    line = fh.readline()
+                    if line:
+                        lines.append(line.rstrip("\n"))
+                        continue
+                    if proc.poll() is not None:
+                        for rest in fh.read().splitlines():
+                            lines.append(rest)
+                        break
+                    time.sleep(0.3)
+        except Exception as err:  # noqa: BLE001 — tail must never crash the app
+            lines.append(f"[tail error] {err}")
+
+    threading.Thread(target=_tail, daemon=True, name=f"tail-{name}").start()
+
+
 def stop_pipeline(name: str) -> None:
     proc = _get_proc(name)
     if proc is None or proc.poll() is not None:

--- a/app/tab_planning.py
+++ b/app/tab_planning.py
@@ -1,6 +1,17 @@
-"""Planning pipeline tab — drives LI/IG/TW/TH/videos schedulers."""
+"""Planning pipeline tab — drives LI/IG/TW/TH/videos schedulers.
+
+Two run paths:
+- **plain run** — the scheduler pipeline streamed into the in-app log panel.
+- **run + autoheal** — launches the ``/schedule-autoheal`` skill in a visible
+  console window (see ``app/autoheal_console.py``); on a UI-drift failure the
+  agent self-heals end-to-end. The tab mirrors the window's output in-app and
+  shows the last run's machine-readable outcome.
+"""
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import streamlit as st
 
@@ -10,9 +21,68 @@ from app.process_runner import (
     render_log_panel,
     render_status_badge,
     start_pipeline,
+    start_skill_console,
 )
 
 PIPELINE_NAME = "planning"
+AUTOHEAL_NAME = "planning-autoheal"
+_ACTIVE_KEY = "planning-active-runner"
+RESULT_PATH = Path(__file__).resolve().parent.parent / "results" / "planning" / "latest-result.json"
+
+
+def _launch_plain(cmd: list[str]) -> None:
+    st.session_state[_ACTIVE_KEY] = PIPELINE_NAME
+    start_pipeline(PIPELINE_NAME, cmd)
+
+
+def _launch_autoheal(skill_cmd: str) -> None:
+    st.session_state[_ACTIVE_KEY] = AUTOHEAL_NAME
+    start_skill_console(AUTOHEAL_NAME, skill_cmd)
+
+_KIND_BADGE = {
+    "ui-drift": "🔧 UI-drift (heal-eligible)",
+    "login-required": "🔑 login required (human)",
+    "data-error": "📝 data error (human)",
+    "other": "❓ unclassified (human)",
+}
+
+
+def _render_last_outcome() -> None:
+    """Show the last run's machine-readable result + per-platform failures."""
+    if not RESULT_PATH.exists():
+        return
+    try:
+        result = json.loads(RESULT_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+
+    st.divider()
+    verdict = result.get("verdict", "?")
+    header = f"last run · {result.get('mode', '?')} · {result.get('finished_at', '')}"
+    if verdict == "clean":
+        st.success(f"✅ {header} — clean, nothing failed.")
+        return
+
+    st.warning(f"⚠️ {header} — failures present.")
+    for plat in result.get("platforms", []):
+        fails = [r for r in plat.get("rows", []) if r.get("failure_kind", "none") != "none"]
+        if not fails:
+            continue
+        st.markdown(f"**{plat['platform']}**")
+        for row in fails:
+            kind = _KIND_BADGE.get(row.get("failure_kind", "other"), row.get("failure_kind", ""))
+            st.markdown(f"- `{row.get('day', '')}` — {kind} — {row.get('detail', '')}")
+            shot = row.get("screenshot", "")
+            if shot and Path(shot).exists():
+                st.image(shot, caption=shot, width="stretch")
+
+
+def _skill_command(mode: str, debug: bool, skips: dict[str, bool]) -> str:
+    parts = ["/schedule-autoheal", "all", f"--{mode}"]
+    if debug:
+        parts.append("--debug")
+    parts.extend(f"--skip-{plat}" for plat, val in skips.items() if val)
+    return " ".join(parts)
 
 
 def run() -> None:
@@ -52,14 +122,37 @@ def run() -> None:
     if mode == "live":
         st.warning("⚠️ LIVE mode will write real schedules into LI/IG/TW/TH. Make sure your WIP-* checkboxes are correct.")
 
-    st.button(
-        "▶ run planning pipeline",
-        key="planning-run",
-        type="primary",
-        disabled=is_running(PIPELINE_NAME),
-        on_click=start_pipeline,
-        args=(PIPELINE_NAME, cmd),
-    )
+    run_cols = st.columns([3, 4])
+    with run_cols[0]:
+        st.button(
+            "▶ run planning pipeline",
+            key="planning-run",
+            type="primary",
+            disabled=is_running(PIPELINE_NAME) or is_running(AUTOHEAL_NAME),
+            on_click=_launch_plain,
+            args=(cmd,),
+        )
+    with run_cols[1]:
+        st.button(
+            "🔧 run + autoheal (console)",
+            key="planning-autoheal-run",
+            disabled=is_running(PIPELINE_NAME) or is_running(AUTOHEAL_NAME),
+            on_click=_launch_autoheal,
+            args=(_skill_command(mode, debug, skips),),
+            help="Opens a visible console running /schedule-autoheal. On a UI-drift failure the agent "
+                 "self-heals end-to-end (issue → fix → dry-run → PR → merge) or pings you on Slack.",
+        )
 
-    render_status_badge(PIPELINE_NAME)
-    render_log_panel(PIPELINE_NAME)
+    # Show the panel for the runner the user last launched (set in the button
+    # callbacks). A running runner always wins, so the live stream is never
+    # hidden; once idle the panel stays put instead of clearing on completion.
+    if is_running(AUTOHEAL_NAME):
+        active = AUTOHEAL_NAME
+    elif is_running(PIPELINE_NAME):
+        active = PIPELINE_NAME
+    else:
+        active = st.session_state.get(_ACTIVE_KEY, PIPELINE_NAME)
+    render_status_badge(active)
+    render_log_panel(active)
+
+    _render_last_outcome()

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -283,5 +283,8 @@
             "expand_settle_ms": 1200,
             "page_settle_ms": 2500
         }
+    },
+    "slack": {
+        "autoheal_channel": ""
     }
 }

--- a/docs/self-healing-scheduler.md
+++ b/docs/self-healing-scheduler.md
@@ -1,0 +1,114 @@
+# Self-healing scheduler
+
+The planning schedulers drive live third-party web UIs (LinkedIn, X, Instagram,
+Threads) whose DOM drifts almost weekly — an `aria-label` appears, a header is
+retyped, a toolbar relocates — silently breaking a selector. This page documents
+the loop that turns that break-and-fix cycle into a set-and-forget operation.
+
+## The flow
+
+1. The **planning tab** (`app/tab_planning.py`) has a **🔧 run + autoheal
+   (console)** button. It launches `app/autoheal_console.py` in a **visible,
+   detached console** (`CREATE_NEW_CONSOLE`) running the `/schedule-autoheal`
+   skill headless. The window shows the live run; the in-app panel mirrors it by
+   tailing the tee'd log file. `launch_autoheal.bat` is the equivalent manual
+   entry point.
+2. The skill runs the scheduler (or `planning_pipeline.py`) and reads the
+   machine-readable result at `results/planning/latest-result.json`.
+3. **Clean run → "it worked", stop.** Minimal tokens, no intervention.
+4. **UI-drift failure → self-heal in place**: probe the live DOM, apply a
+   selector-only fix, re-validate with a dry-run.
+   - **Confident** → file a drift issue, branch, commit, PR (`Closes #N`),
+     merge, delete branch, land on `main` — the whole issue lifecycle,
+     autonomously. One issue per drift.
+   - **Not confident** → ping the user on Slack and stop for interactive
+     handling.
+
+## The machine-readable contract
+
+`planning_pipeline.py` writes, alongside the human-readable markdown summary, a
+structured `results/planning/<ts>-result.json` plus a stable
+`latest-result.json` pointer. Each platform row carries:
+
+| field          | meaning                                                        |
+|----------------|----------------------------------------------------------------|
+| `status`       | scheduler row status (`LIVE`/`DRY`/`FAIL`/`LOGIN-REQUIRED`/…)   |
+| `detail`       | free-text error / status detail                                |
+| `screenshot`   | failure screenshot path, lifted out of `detail`                |
+| `failure_kind` | heal-eligibility class from `planning/_failure.py`             |
+
+## Failure classification — `planning/_failure.py`
+
+`classify(status, detail)` is a pure function imported by **both** the pipeline
+(which stamps `failure_kind`) and the skill (which reads it), so the two can
+never disagree.
+
+| `failure_kind`   | trigger                                          | action            |
+|------------------|--------------------------------------------------|-------------------|
+| `ui-drift`       | Playwright timeout / locator / selector phrasing | **auto-heal**     |
+| `login-required` | session logged out                               | escalate (human)  |
+| `data-error`     | payload / caption / illustration / Notion miss   | escalate (human)  |
+| `other`          | anything unclassified                            | escalate (human)  |
+| `none`           | not a failure (`LIVE`/`DRY`)                      | —                 |
+
+Only `ui-drift` is auto-fixed, and only with **selector-only** edits.
+
+## The probe — `planning/_probe.py`
+
+`python -m planning._probe <platform>` opens the platform's live page through its
+existing `planning/<platform>/<platform>_session.py` helper (real Chrome,
+stealth, shared-profile lock-wait — never re-inlined) and dumps the accessibility
+tree as a ranked list of `role + accessible name` candidates — exactly the shape
+a Playwright `get_by_role(role, name=...)` selector needs. Class-based candidates
+are deliberately omitted: the per-platform READMEs warn class names rotate, so a
+class-anchored fix would re-break next week.
+
+Selector edit targets differ by platform: LinkedIn centralises selectors in
+`planning/linkedin/linkedin_labels.py`; Twitter / Threads / Instagram keep them
+inline in `schedule_<platform>_posts.py` (centralising those is tracked as
+follow-up work).
+
+## The confidence gate
+
+A fix lands end-to-end only when **all** hold: exactly one strong role/text
+candidate, the validating dry-run passes, and the diff is a pure selector-string
+change. Otherwise the skill escalates via the **Slack MCP**
+(`mcp__claude_ai_Slack__slack_send_message`) to the channel in
+`config/config.json` → `slack.autoheal_channel`, and stops.
+
+## The visible-console + tee mechanism
+
+Borrowed from the `app-launcher` sister project (its `codebase-audit-fleet` job;
+see that repo's `docs/lessons-launcher-owned-pty.md`):
+
+- **`--verbose` is load-bearing.** `claude -p` buffers its result without it, so
+  the console looks dead until the very end. With `--verbose` it streams
+  turn-by-turn activity live.
+- **`--permission-mode bypassPermissions`** lets the unattended heal edit files,
+  run `gh`, and call MCP tools with no human at the prompt.
+- **`--output-format stream-json` is what actually streams.** Plain
+  `claude -p --verbose` (text format) **block-buffers** and flushes its whole
+  output at exit — the console looks dead for the entire run, then dumps
+  everything at the end. `--output-format stream-json` (requires `--verbose`)
+  emits one JSON event the instant each step happens (init, each assistant
+  thinking/text/tool_use block, each tool_result, the final result).
+  `app/autoheal_console.py` reads those events with `readline()` and
+  pretty-prints each into a readable live feed (`💭` thinking, `🔧` tool calls,
+  `↳` results), teed to **both** the visible console and a log file the app
+  tails.
+- **Detached ≠ untracked.** The console is spawned `CREATE_NEW_CONSOLE` (visible,
+  independent) but the `Popen` handle is kept so the run stays listable/killable.
+- **Remote Control for mobile.** The invocation adds `--remote-control autoheal`
+  so the run is also viewable/drivable from the Claude mobile/web app — handy for
+  answering a "not confident" escalation from the phone. Toggle off with
+  `--no-remote-control` on `app/autoheal_console.py`.
+
+## Guardrails
+
+- Selector-only edits — never control flow or scheduling logic on the heal path.
+- Dry-run must pass before any commit and before any `--live`.
+- Bounded autonomy — max 2 heal attempts per row, one platform per cycle; hard
+  stop on login / data / ambiguous DOM.
+- Anti-bot discipline preserved — always through the existing session helpers.
+- Human-reviewable trail — every landed fix has an issue + PR with before/after
+  selector and probe evidence; never a silent push to `main`.

--- a/launch_autoheal.bat
+++ b/launch_autoheal.bat
@@ -1,0 +1,49 @@
+@echo off
+REM Visible-console launcher for the self-healing scheduler skill.
+REM Runs /schedule-autoheal headless in THIS window (live --verbose stream),
+REM teeing output to results\planning\autoheal-<ts>.log. On a UI-drift failure
+REM the agent self-heals end-to-end; otherwise it pings Slack and waits.
+REM
+REM Usage:
+REM   launch_autoheal.bat                  - dry-run, all platforms
+REM   launch_autoheal.bat live             - LIVE, all platforms
+REM   launch_autoheal.bat twitter          - dry-run, twitter only
+REM   launch_autoheal.bat twitter live     - LIVE, twitter only
+
+setlocal EnableDelayedExpansion
+set SCOPE=all
+set MODE=--dry-run
+
+:PARSE_ARGS
+if "%~1"=="" goto AFTER_ARGS
+if /I "%~1"=="live"      set MODE=--live
+if /I "%~1"=="--live"    set MODE=--live
+if /I "%~1"=="dry"       set MODE=--dry-run
+if /I "%~1"=="--dry-run" set MODE=--dry-run
+if /I "%~1"=="linkedin"  set SCOPE=linkedin
+if /I "%~1"=="instagram" set SCOPE=instagram
+if /I "%~1"=="twitter"   set SCOPE=twitter
+if /I "%~1"=="threads"   set SCOPE=threads
+if /I "%~1"=="all"       set SCOPE=all
+shift
+goto PARSE_ARGS
+
+:AFTER_ARGS
+cd /d "%~dp0"
+set VENV_DIR=.\.venv
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+    echo [ERROR] Virtual environment not found at %VENV_DIR%
+    goto END
+)
+
+echo ========================================
+echo Self-healing scheduler: /schedule-autoheal %SCOPE% %MODE%
+echo ========================================
+echo.
+"%VENV_DIR%\Scripts\python.exe" app\autoheal_console.py --skill-cmd "/schedule-autoheal %SCOPE% %MODE%"
+
+:END
+echo.
+echo Press any key to close this window...
+pause >nul
+endlocal

--- a/planning/_failure.py
+++ b/planning/_failure.py
@@ -1,0 +1,75 @@
+"""Shared failure classifier for the planning pipeline + the self-heal skill.
+
+A scheduler row records a coarse ``status`` (``LIVE`` / ``DRY`` / ``FAIL`` /
+``LOGIN-REQUIRED`` / ``OTHER``) plus a free-text ``detail``. That is enough for
+a human reading the markdown summary, but the autonomous self-heal loop
+(``/schedule-autoheal``) needs to know *what kind* of failure a row is so it can
+decide whether it is safe to touch:
+
+- **ui-drift** — a selector / locator broke because the platform's DOM changed.
+  This is the ONLY kind the heal loop may auto-fix (selector-only edits).
+- **login-required** — the session is logged out; a human must re-auth.
+- **data-error** — the content/payload could not be resolved (empty caption,
+  missing illustration, Notion lookup miss). A human decision, never auto-fixed.
+- **other** — anything unclassified; treated as human-only.
+- **none** — not a failure (``LIVE`` / ``DRY``).
+
+The classification lives here so the pipeline (which writes ``failure_kind`` into
+the machine-readable result JSON) and the skill (which reads it) can never drift
+apart. Pure function, no side effects — trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+FailureKind = Literal["ui-drift", "login-required", "data-error", "other", "none"]
+
+# Playwright selector/locator breakage phrasing. These are the words Playwright
+# itself emits when a selector stops matching after a DOM change — the exact
+# signature of UI drift (issue #60 surfaced three of these in one run).
+_UI_DRIFT_RE = re.compile(
+    r"timeout|timed out|waiting for|locator|selector|strict mode violation|"
+    r"no element|element is not|not visible|not attached|intercepts pointer|"
+    r"element handle|frame was detached|exceeded.*wait",
+    re.I,
+)
+
+# Content/data resolution failures — a human decision, never a selector fix.
+_DATA_ERROR_RE = re.compile(
+    r"payload|resolution|could not resolve|not found in notion|missing|"
+    r"no rows|empty|caption|illustration|keyerror|nonetype|no such (?:row|page)",
+    re.I,
+)
+
+
+def classify(status: str, detail: str) -> FailureKind:
+    """Map a scheduler row's ``(status, detail)`` to a heal-eligibility class.
+
+    Order matters: login is checked first (most specific), then UI-drift
+    (the heal-eligible class), then data errors, else ``other``. Non-failure
+    statuses short-circuit to ``none``.
+    """
+    status_up = (status or "").upper()
+    if status_up in ("LIVE", "DRY"):
+        return "none"
+    if status_up == "LOGIN-REQUIRED":
+        return "login-required"
+
+    text = detail or ""
+    if _UI_DRIFT_RE.search(text):
+        return "ui-drift"
+    if _DATA_ERROR_RE.search(text):
+        return "data-error"
+    return "other"
+
+
+_SCREENSHOT_RE = re.compile(r"\(screenshot\s+([^)]+)\)")
+
+
+def extract_screenshot(detail: str) -> str:
+    """Pull the screenshot path the schedulers embed as ``(screenshot <path>)``
+    in a row's ``detail`` string. Returns an empty string when absent."""
+    match = _SCREENSHOT_RE.search(detail or "")
+    return match.group(1).strip() if match else ""

--- a/planning/_probe.py
+++ b/planning/_probe.py
@@ -1,0 +1,150 @@
+"""Live-DOM probe for the planning schedulers — shared by the self-heal skill
+and by humans debugging a selector break by hand.
+
+When a platform's UI drifts (an ``aria-label`` appears, a button is renamed, a
+header is retyped), the fix is always to find the element's *new* accessible
+name and re-anchor the role/text selector on it. This module opens the live
+page through the platform's existing session helper (real Chrome, stealth,
+shared-profile lock-wait — never re-inlining launch args) and dumps the
+accessibility tree as a ranked list of ``role + name`` candidates, which is
+exactly the shape a Playwright ``get_by_role(role, name=...)`` selector needs.
+
+Class-based candidates are deliberately not emitted — the per-platform READMEs
+warn that class names rotate, so a fix anchored on a class would re-break next
+week. Role + accessible name is the durable anchor.
+
+CLI::
+
+    python -m planning._probe twitter
+    python -m planning._probe linkedin --url https://www.linkedin.com/feed/
+    python -m planning._probe threads --no-screenshot
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from typing import Optional
+
+# platform -> (module, session-class, config-loader). Lazy-imported so probing
+# one platform never drags in the other three (or Playwright) unnecessarily.
+_REGISTRY: dict[str, tuple[str, str, str]] = {
+    "twitter": ("planning.twitter.twitter_session", "TwitterSession", "load_twitter_config"),
+    "threads": ("planning.threads.threads_session", "ThreadsSession", "load_threads_config"),
+    "instagram": ("planning.instagram.instagram_session", "InstagramSession", "load_instagram_config"),
+    "linkedin": ("planning.linkedin.linkedin_session", "LinkedInSession", "load_linkedin_config"),
+}
+
+# Roles that back a clickable/typeable selector — these are what a heal edit
+# re-anchors on, so they sort to the top of the dump.
+_INTERACTIVE_ROLES = (
+    "button", "link", "textbox", "menuitem", "tab", "checkbox",
+    "combobox", "switch", "radio", "option", "searchbox",
+)
+# Structural roles worth seeing (dialogs / headings frame the failing region).
+_CONTEXT_ROLES = ("dialog", "heading", "alertdialog", "menu", "listbox")
+
+
+def _walk(node: dict, out: list[tuple[str, str]]) -> None:
+    """Depth-first collect ``(role, name)`` pairs from an a11y snapshot."""
+    role = (node.get("role") or "").strip()
+    name = (node.get("name") or "").strip()
+    if role and name:
+        out.append((role, name))
+    for child in node.get("children", []) or []:
+        _walk(child, out)
+
+
+def _format(url: str, title: str, pairs: list[tuple[str, str]]) -> str:
+    interactive = [(r, n) for r, n in pairs if r in _INTERACTIVE_ROLES]
+    context = [(r, n) for r, n in pairs if r in _CONTEXT_ROLES]
+
+    # De-dupe while preserving order.
+    def _dedupe(items: list[tuple[str, str]]) -> list[tuple[str, str]]:
+        seen: set[tuple[str, str]] = set()
+        result: list[tuple[str, str]] = []
+        for item in items:
+            if item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    interactive = _dedupe(interactive)
+    context = _dedupe(context)
+
+    lines = [
+        f"# DOM probe — {url}",
+        f"# title: {title}",
+        f"# {len(interactive)} interactive candidate(s), {len(context)} context node(s)",
+        "",
+        "## Interactive candidates (role + accessible name -> get_by_role)",
+    ]
+    if interactive:
+        for role, name in interactive:
+            lines.append(f'  {role:<10} name={name!r}')
+    else:
+        lines.append("  (none — page may not have loaded the target region yet)")
+    lines.append("")
+    lines.append("## Context nodes (dialogs / headings)")
+    if context:
+        for role, name in context:
+            lines.append(f'  {role:<10} name={name!r}')
+    else:
+        lines.append("  (none)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def probe(platform: str, url: Optional[str] = None, *, save_screenshot: bool = True) -> str:
+    """Open ``platform``'s live page and return a ranked role+name candidate dump.
+
+    ``url`` defaults to the platform's configured ``feed_url`` (the same entry
+    point the scheduler uses). Raises ``KeyError`` for an unknown platform and
+    surfaces the session helper's ``LoginRequiredError`` unchanged so the caller
+    can tell a logged-out session apart from real UI drift.
+    """
+    key = platform.lower()
+    if key not in _REGISTRY:
+        raise KeyError(f"unknown platform {platform!r}; expected one of {sorted(_REGISTRY)}")
+    module_path, cls_name, loader_name = _REGISTRY[key]
+    module = importlib.import_module(module_path)
+    session_cls = getattr(module, cls_name)
+    cfg = getattr(module, loader_name)()
+    target = url or cfg.get("feed_url")
+    if not target:
+        raise RuntimeError(f"no url given and no 'feed_url' in {key} config")
+
+    with session_cls(cfg) as session:
+        session.goto_with_login_check(target)
+        snapshot = session.page.accessibility.snapshot(interesting_only=True)
+        title = session.page.title()
+        pairs: list[tuple[str, str]] = []
+        if snapshot:
+            _walk(snapshot, pairs)
+        if save_screenshot:
+            session.screenshot_failure(f"probe-{key}")
+        return _format(target, title, pairs)
+
+
+def main() -> int:
+    # Force UTF-8 stdout so emoji / em-dash in the dump don't crash a cp1252
+    # Windows console (same guard the session modules use).
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+    parser = argparse.ArgumentParser(description="Dump live-DOM role+name candidates for a planning platform.")
+    parser.add_argument("platform", choices=sorted(_REGISTRY), help="which platform's live page to probe")
+    parser.add_argument("--url", default=None, help="override the page URL (defaults to the platform's feed_url)")
+    parser.add_argument("--no-screenshot", action="store_true", help="skip saving a probe screenshot")
+    args = parser.parse_args()
+    print(probe(args.platform, args.url, save_screenshot=not args.no_screenshot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planning_pipeline.py
+++ b/planning_pipeline.py
@@ -28,6 +28,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 import time
@@ -47,6 +48,7 @@ from typing import Callable, Optional
 
 sys.path.append(str(Path(__file__).parent))
 from config.logger_config import setup_logger  # noqa: E402
+from planning._failure import classify as classify_failure, extract_screenshot  # noqa: E402
 from planning.instagram.clone_to_other_platforms import main as run_clone  # noqa: E402
 from planning.linkedin.schedule_linkedin_posts import main as run_linkedin  # noqa: E402
 from planning.instagram.schedule_instagram_posts import main as run_instagram  # noqa: E402
@@ -305,6 +307,70 @@ def _write_summary(md: str, started_at: datetime) -> Path:
     return out_path
 
 
+def _build_result_json(args: argparse.Namespace,
+                       results: list[PlatformResult],
+                       started_at: datetime,
+                       finished_at: datetime,
+                       exit_code: int,
+                       summary_path: Path) -> dict:
+    """Machine-readable run record consumed by the planning tab + the
+    ``/schedule-autoheal`` skill. Each row is decorated with the screenshot
+    path (lifted out of the inline ``detail`` text) and a ``failure_kind`` from
+    the shared classifier so the heal loop knows which failures are UI-drift
+    (the only kind it may auto-fix)."""
+    if args.live:
+        mode_label = "LIVE"
+    elif args.dry_run:
+        mode_label = "DRY-RUN"
+    else:
+        mode_label = "config default"
+
+    platforms: list[dict] = []
+    for r in results:
+        rows: list[dict] = []
+        for row in r.rows:
+            status = row.get("status", "OTHER")
+            detail = row.get("detail", "") or ""
+            rows.append({
+                "platform": r.name,
+                "day": row.get("day", ""),
+                "status": status,
+                "detail": detail,
+                "screenshot": extract_screenshot(detail),
+                "failure_kind": classify_failure(status, detail),
+            })
+        platforms.append({
+            "platform": r.name,
+            "skipped": r.skipped,
+            "exit_code": r.exit_code,
+            "duration_s": round(r.duration_s, 2),
+            "error": r.error,
+            "rows": rows,
+        })
+
+    return {
+        "started_at": started_at.isoformat(timespec="seconds"),
+        "finished_at": finished_at.isoformat(timespec="seconds"),
+        "mode": mode_label,
+        "exit_code": exit_code,
+        "verdict": "clean" if exit_code == 0 else "failures",
+        "summary_path": str(summary_path),
+        "platforms": platforms,
+    }
+
+
+def _write_result_json(result: dict, started_at: datetime) -> Path:
+    """Write the timestamped result record plus a stable ``latest-result.json``
+    pointer so the app can find the newest run deterministically."""
+    out_dir = Path(__file__).parent / "results" / "planning"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(result, indent=2, ensure_ascii=False)
+    out_path = out_dir / f"{started_at.strftime('%Y-%m-%d-%H%M%S')}-result.json"
+    out_path.write_text(payload, encoding="utf-8")
+    (out_dir / "latest-result.json").write_text(payload, encoding="utf-8")
+    return out_path
+
+
 def main() -> int:
     args = parse_args()
     configure_logger(args.debug)
@@ -343,7 +409,13 @@ def main() -> int:
         not r.skipped and (r.error or any(row["status"] in ("FAIL", "LOGIN-REQUIRED") for row in r.rows))
         for r in results
     )
-    return 0 if not any_fail else 11
+    exit_code = 0 if not any_fail else 11
+
+    result = _build_result_json(args, results, started_at, finished_at, exit_code, out_path)
+    result_path = _write_result_json(result, started_at)
+    logger.info("🧾 Result JSON written to %s", result_path)
+
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@
## Summary

Embeds a set-and-forget self-healing loop into the planning workflow. The planning tab gets a **🔧 run + autoheal (console)** button that launches the new `/schedule-autoheal` skill headless in a **visible console** (also mirrored in-app and to the Claude mobile app via `--remote-control`). The skill runs the scheduler and, on a UI-drift failure, probes the live DOM, applies a **selector-only** fix, re-validates with a dry-run, and — when confident — files an issue, opens a PR, merges, and lands on `main`. Login / data errors instead ping Slack and stop for a human.

Key pieces:
- `planning/_failure.py` — shared failure classifier (`ui-drift` / `login-required` / `data-error` / `other` / `none`); only `ui-drift` is auto-healed.
- `planning_pipeline.py` — writes `results/planning/<ts>-result.json` + `latest-result.json` with per-row `failure_kind` + lifted `screenshot`.
- `planning/_probe.py` — live-DOM `role + accessible name` candidate dumper through the existing per-platform session helpers.
- `.claude/skills/schedule-autoheal/SKILL.md` — the agentic engine (now tracked; `.gitignore` updated to keep local settings ignored).
- `app/autoheal_console.py` — visible-console wrapper. Uses `claude -p --output-format stream-json --verbose` (plain text mode block-buffers and only flushes at exit) and pretty-prints each event into a live feed; `--remote-control` for mobile; `CREATE_NEW_CONSOLE` + tracked `Popen`; teed to a log the app tails.
- `app/process_runner.py` / `app/tab_planning.py` — `start_skill_console` + the run+autoheal button; the panel tracks the last-launched runner so its log persists after completion.
- `docs/self-healing-scheduler.md`, `slack.autoheal_channel` config, `launch_autoheal.bat`.

Follow-up #67 tracks centralising the inline Twitter/Threads/Instagram selectors.

## Validation

- `py_compile` green across all new/changed modules.
- Classifier + pipeline result-JSON wiring unit-tested (ui-drift vs login vs data; screenshot extraction).
- stream-json event formatter verified against a real `claude` run; the full flag combo (`stream-json` + `--verbose` + `--remote-control`) confirmed to stream live without hanging.
- Streamlit boot check: HTTP 200.
- No test suite or ruff configured in this repo.

Closes #64
@