### PR TITLE
chore(planning): centralise Twitter/Threads/Instagram selectors into per-platform label modules

### DIFF
--- a/planning/instagram/README.md
+++ b/planning/instagram/README.md
@@ -181,6 +181,8 @@ Cross-module dependencies:
 
 Meta's class names are obfuscated and rotate — never anchor on classes. These role/text/input selectors are the ones validated against the live UI during the first end-to-end run.
 
+> **Centralised labels:** the user-facing accessible names and the locale `EN | ES` media-attach unions live in [`instagram_labels.py`](instagram_labels.py) — `NOT_NOW_BTN_RE`, `CLOSE_BTN_RE`, `DISCARD_LEAVE_BTN_RE`, `SET_DATE_TIME_TEXT_RE`, `SCHEDULE_TEXT_RE`, `NEXT_MONTH_BTN_RE`, `NEXT_WEEK_BTN_RE`, `PREV_WEEK_BTN_RE`, `ADD_MEDIA_BTN_SELECTOR`, `UPLOAD_FROM_COMPUTER_SELECTOR`, plus the `day_cell_label()` / `fmt_time_12h()` rendering helpers. When Meta relabels a control or an account flips locale, extend the alternation there — do **not** re-inline it at the call site. Argument-built name regexes (`Schedule post` / `Schedule story`, action buttons, time slots) and structural CSS/JS probes stay inline in the driver.
+
 | step | selector |
 |------|----------|
 | Dismiss 'Get Meta Verified' upsell | `page.get_by_role("button", name=/^not now$/i)` — fires on first navigation only |

--- a/planning/instagram/instagram_labels.py
+++ b/planning/instagram/instagram_labels.py
@@ -1,0 +1,125 @@
+"""Accessible-name + locale label registry for the Instagram/Facebook driver.
+
+The Meta Business planner mixes a few stable structural hooks (data-surface,
+``input[aria-label="hours"]``, etc.) with many user-facing labels the driver
+must match by name: the "Get Meta Verified" upsell dismissals, the week/month
+calendar chevrons, the "Set date and time" toggle, the discard prompt, and the
+"Add photo/video" → "Upload from computer" media path (which Meta ships in both
+English and Spanish, see issues #28 / #60). Those labels are exactly what shifts
+when Meta relabels a control or flips an account's locale, so they are
+centralized here rather than scattered inline through ``schedule_instagram_posts``.
+
+This mirrors ``planning/linkedin/linkedin_labels.py``: the self-healing
+scheduler (issue #64) can scan and patch one small module instead of hunting an
+accessible-name string buried in scheduling logic. When Meta ships a new label
+or locale variant, extend the alternation here — do NOT re-inline a
+``re.compile`` or ``:has-text`` selector at the call site.
+
+Out of scope (stays inline in the driver): dynamic, argument-built name regexes
+(``re.compile(rf"^{re.escape(action)}$", ...)`` for "Schedule post"/"Schedule
+story", action buttons, time slots), structural CSS (``data-surface``,
+``input[placeholder=…]``, ``input[type=checkbox]``), and JS DOM probes — none of
+those are fixed user-facing labels.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+
+
+# ---------- Dialog dismissals ----------
+
+# 'Not now' dismisses the first-load 'Get Meta Verified' upsell modal.
+NOT_NOW_BTN_RE = re.compile(r"^not now$", re.I)
+
+# Dialog-scoped Close (×) fallback for blocking modals.
+CLOSE_BTN_RE = re.compile(r"^close$", re.I)
+
+# 'Discard' / 'Leave' on the composer's unsaved-changes prompt.
+DISCARD_LEAVE_BTN_RE = re.compile(r"^(discard|leave)$", re.I)
+
+
+# ---------- Composer toggles / calendar nav ----------
+
+# The post composer's 'Set date and time' toggle label (the visible text next
+# to the checkbox input).
+SET_DATE_TIME_TEXT_RE = re.compile(r"^set date and time$", re.I)
+
+# Final 'Schedule' action text — also used as a scroll anchor in the composer.
+SCHEDULE_TEXT_RE = re.compile(r"^schedule$", re.I)
+
+# Calendar 'Next month' chevron (not anchored: Meta wraps the text with a glyph).
+NEXT_MONTH_BTN_RE = re.compile(r"next month", re.I)
+
+# Week-view chevrons. Meta gives these the chevron-glyph text "Right"/"Left"
+# (aria-label is empty), so we match either the semantic or the glyph name.
+NEXT_WEEK_BTN_RE = re.compile(r"^(next week|right)$", re.I)
+PREV_WEEK_BTN_RE = re.compile(r"^(previous week|left)$", re.I)
+
+
+# ---------- Media-attach path (locale EN | ES) ----------
+
+# 'Add photo/video' affordance. Meta localizes this (issue #28 / #60), so the
+# selector unions every observed EN + ES wording plus the upload-button surface.
+ADD_MEDIA_BTN_SELECTOR = (
+    'div[role="button"]:has-text("Add photo/video"), '
+    'button:has-text("Add photo/video"), '
+    'div[role="button"]:has-text("Añadir foto/vídeo"), '
+    'button:has-text("Añadir foto/vídeo"), '
+    'div[role="button"]:has-text("Añadir foto"), '
+    'button:has-text("Añadir foto"), '
+    '[data-surface*="upload_button"]'
+)
+
+# Some Meta builds open an intermediate dialog whose 'Upload from computer'
+# button is what actually triggers the file chooser. EN + ES wordings (issue #28).
+UPLOAD_FROM_COMPUTER_SELECTOR = (
+    'div[role="dialog"] div[role="button"]:has-text("Upload from computer"), '
+    'div[role="dialog"] button:has-text("Upload from computer"), '
+    'div[role="dialog"] div[role="button"]:has-text("Upload"), '
+    'div[role="dialog"] button:has-text("Upload"), '
+    'div[role="dialog"] div[role="button"]:has-text("Subir desde el ordenador"), '
+    'div[role="dialog"] button:has-text("Subir desde el ordenador"), '
+    'div[role="dialog"] div[role="button"]:has-text("Subir"), '
+    'div[role="dialog"] button:has-text("Subir")'
+)
+
+
+# ---------- Localized date / time rendering ----------
+
+# The day-cell header in the Meta planner is e.g. "Mon 18". Windows strftime
+# uses "%#d" rather than "%-d" for an unpadded day, so build the label with
+# explicit indexing to stay cross-platform-safe.
+_WEEKDAY_ABBR = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+
+
+def day_cell_label(d: date) -> str:
+    """Return the planner column header text for a day, e.g. ``"Mon 18"``."""
+    return f"{_WEEKDAY_ABBR[d.weekday()]} {d.day}"
+
+
+def fmt_time_12h(hour: int, minute: int) -> str:
+    """Render a 12-hour time slot string as Meta's time picker shows it,
+    e.g. ``"6:30 AM"`` / ``"3:00 PM"``."""
+    suffix = "AM" if hour < 12 else "PM"
+    h12 = hour % 12
+    if h12 == 0:
+        h12 = 12
+    return f"{h12}:{minute:02d} {suffix}"
+
+
+__all__ = [
+    "NOT_NOW_BTN_RE",
+    "CLOSE_BTN_RE",
+    "DISCARD_LEAVE_BTN_RE",
+    "SET_DATE_TIME_TEXT_RE",
+    "SCHEDULE_TEXT_RE",
+    "NEXT_MONTH_BTN_RE",
+    "NEXT_WEEK_BTN_RE",
+    "PREV_WEEK_BTN_RE",
+    "ADD_MEDIA_BTN_SELECTOR",
+    "UPLOAD_FROM_COMPUTER_SELECTOR",
+    "day_cell_label",
+    "fmt_time_12h",
+]

--- a/planning/instagram/schedule_instagram_posts.py
+++ b/planning/instagram/schedule_instagram_posts.py
@@ -38,6 +38,20 @@ from typing import Optional
 from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from planning.instagram.instagram_labels import (  # noqa: E402
+    ADD_MEDIA_BTN_SELECTOR,
+    CLOSE_BTN_RE,
+    DISCARD_LEAVE_BTN_RE,
+    NEXT_MONTH_BTN_RE,
+    NEXT_WEEK_BTN_RE,
+    NOT_NOW_BTN_RE,
+    PREV_WEEK_BTN_RE,
+    SCHEDULE_TEXT_RE,
+    SET_DATE_TIME_TEXT_RE,
+    UPLOAD_FROM_COMPUTER_SELECTOR,
+    day_cell_label,
+    fmt_time_12h,
+)
 from planning.instagram.instagram_session import (  # noqa: E402
     InstagramSession,
     LoginRequiredError,
@@ -82,14 +96,6 @@ def parse_single_date(s: str) -> date:
 
 def date_to_day_title(d: date) -> str:
     return d.strftime("%Y%m%d")
-
-
-def fmt_time_12h(hour: int, minute: int) -> str:
-    suffix = "AM" if hour < 12 else "PM"
-    h12 = hour % 12
-    if h12 == 0:
-        h12 = 12
-    return f"{h12}:{minute:02d} {suffix}"
 
 
 # ---------- Row model ----------
@@ -307,16 +313,6 @@ def resolve_story_payload(notion, cfg: dict, row: ScheduleRow) -> PostPayload:
 
 # ---------- Meta planner UI helpers ----------
 
-# The day-cell header in the Meta planner is e.g. "Mon 18". Windows strftime
-# uses "%#d" rather than "%-d" for an unpadded day. Build the label with
-# explicit indexing to stay cross-platform-safe.
-_WEEKDAY_ABBR = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-
-
-def _day_cell_label(d: date) -> str:
-    return f"{_WEEKDAY_ABBR[d.weekday()]} {d.day}"
-
-
 # JS helper: walk up from the day-header text node until we find an ancestor
 # div that itself contains a "Schedule" button. That ancestor IS the day's
 # calendar column, which we can then hover and from which we can click
@@ -356,7 +352,7 @@ def dismiss_meta_verified_modal(page: Page) -> bool:
     'Not now' button dismisses it. Returns True if it was dismissed.
     """
     try:
-        not_now = page.get_by_role("button", name=re.compile(r"^not now$", re.I))
+        not_now = page.get_by_role("button", name=NOT_NOW_BTN_RE)
         if not_now.count():
             not_now.first.click(timeout=4000)
             page.wait_for_timeout(500)
@@ -367,7 +363,7 @@ def dismiss_meta_verified_modal(page: Page) -> bool:
     # Fallback: dialog-scoped Close (×) button.
     try:
         close = page.locator('[role="dialog"]').get_by_role(
-            "button", name=re.compile(r"^close$", re.I)
+            "button", name=CLOSE_BTN_RE
         )
         if close.count():
             close.first.click(timeout=2000)
@@ -392,7 +388,7 @@ def _open_day_schedule_menu(page: Page, d: date, action: str) -> None:
     column. The hover + click then happen via the bounding-box of that
     ancestor's Schedule button.
     """
-    label = _day_cell_label(d)
+    label = day_cell_label(d)
     logger.debug("🖱  resolving column for day cell %s", label)
 
     # Make a small attempt to dismiss any modal that crept in between actions.
@@ -460,32 +456,6 @@ def _open_day_schedule_menu(page: Page, d: date, action: str) -> None:
         except Exception as err:
             raise RuntimeError(f"Could not click menu item '{action}': {err}")
     page.wait_for_timeout(1000)
-
-
-_ADD_MEDIA_BTN_SELECTOR = (
-    'div[role="button"]:has-text("Add photo/video"), '
-    'button:has-text("Add photo/video"), '
-    'div[role="button"]:has-text("Añadir foto/vídeo"), '
-    'button:has-text("Añadir foto/vídeo"), '
-    'div[role="button"]:has-text("Añadir foto"), '
-    'button:has-text("Añadir foto"), '
-    '[data-surface*="upload_button"]'
-)
-
-# Some Meta planner builds open an intermediate dialog instead of a native
-# file chooser when "Add photo/video" is clicked — the file picker only fires
-# after a second click on an "Upload from computer" affordance inside that
-# dialog. We accept EN + ES wordings to survive locale flips (see issue #28).
-_UPLOAD_FROM_COMPUTER_SELECTOR = (
-    'div[role="dialog"] div[role="button"]:has-text("Upload from computer"), '
-    'div[role="dialog"] button:has-text("Upload from computer"), '
-    'div[role="dialog"] div[role="button"]:has-text("Upload"), '
-    'div[role="dialog"] button:has-text("Upload"), '
-    'div[role="dialog"] div[role="button"]:has-text("Subir desde el ordenador"), '
-    'div[role="dialog"] button:has-text("Subir desde el ordenador"), '
-    'div[role="dialog"] div[role="button"]:has-text("Subir"), '
-    'div[role="dialog"] button:has-text("Subir")'
-)
 
 
 def _dump_upload_debug(page: Page, tag: str) -> Path:
@@ -561,7 +531,7 @@ def _upload_files(page: Page, paths: list[Path], *, is_video: bool = False) -> N
     """
     file_paths = [str(p) for p in paths]
 
-    add_btn = page.locator(_ADD_MEDIA_BTN_SELECTOR).first
+    add_btn = page.locator(ADD_MEDIA_BTN_SELECTOR).first
     try:
         add_btn.wait_for(state="visible", timeout=12000)
     except Exception as err:
@@ -658,7 +628,7 @@ def _upload_files(page: Page, paths: list[Path], *, is_video: bool = False) -> N
         # Re-find: the previous click may have changed the DOM even if no
         # chooser fired. Then JS-click the freshly resolved element.
         page.wait_for_timeout(600)
-        add_btn = page.locator(_ADD_MEDIA_BTN_SELECTOR).first
+        add_btn = page.locator(ADD_MEDIA_BTN_SELECTOR).first
         leg1_chooser = _try_click_for_chooser(_js_click)
 
     if leg1_chooser is not None:
@@ -669,7 +639,7 @@ def _upload_files(page: Page, paths: list[Path], *, is_video: bool = False) -> N
 
     # --- Leg 2: intermediate dialog — click 'Upload from computer' inside it ---
     leg2_chooser = None
-    upload_btn = page.locator(_UPLOAD_FROM_COMPUTER_SELECTOR).first
+    upload_btn = page.locator(UPLOAD_FROM_COMPUTER_SELECTOR).first
     try:
         upload_btn.wait_for(state="visible", timeout=5000)
     except Exception as err:
@@ -951,13 +921,13 @@ def _ensure_set_date_toggle_on(page: Page) -> None:
         pass
     # Fallback: click the visible label text.
     try:
-        page.get_by_text(re.compile(r"^set date and time$", re.I)).first.click(timeout=4000)
+        page.get_by_text(SET_DATE_TIME_TEXT_RE).first.click(timeout=4000)
         page.wait_for_timeout(1200)
     except Exception:
         pass
     # Final scroll so the (now-mounted) date/time row is in viewport.
     try:
-        page.get_by_text(re.compile(r"^schedule$", re.I)).last.scroll_into_view_if_needed(timeout=2000)
+        page.get_by_text(SCHEDULE_TEXT_RE).last.scroll_into_view_if_needed(timeout=2000)
         page.wait_for_timeout(400)
     except Exception:
         pass
@@ -978,7 +948,7 @@ def _click_calendar_day(page: Page, target: date) -> None:
             break
         try:
             next_btn = page.get_by_role(
-                "button", name=re.compile(r"next month", re.I)
+                "button", name=NEXT_MONTH_BTN_RE
             )
             if next_btn.count():
                 next_btn.first.click(timeout=2000)
@@ -1098,7 +1068,7 @@ def _cancel_composer(page: Page) -> None:
             pass
     # Discard confirmation, if Meta asks.
     try:
-        discard = page.get_by_role("button", name=re.compile(r"^(discard|leave)$", re.I))
+        discard = page.get_by_role("button", name=DISCARD_LEAVE_BTN_RE)
         if discard.count():
             discard.first.click(timeout=2000)
             page.wait_for_timeout(500)
@@ -1126,7 +1096,7 @@ def navigate_to_week(page: Page, target: date, *, max_clicks: int = 10) -> None:
     Strategy: try clicking 'Next week' until the target's column appears,
     then 'Previous week' if we overshot.
     """
-    label = _day_cell_label(target)
+    label = day_cell_label(target)
 
     def col_present() -> bool:
         try:
@@ -1139,12 +1109,8 @@ def navigate_to_week(page: Page, target: date, *, max_clicks: int = 10) -> None:
 
     # Meta uses chevron-glyph text "Left" / "Right" as the button label
     # (probed via DOM); aria-label is empty.
-    next_btn = page.get_by_role(
-        "button", name=re.compile(r"^(next week|right)$", re.I)
-    )
-    prev_btn = page.get_by_role(
-        "button", name=re.compile(r"^(previous week|left)$", re.I)
-    )
+    next_btn = page.get_by_role("button", name=NEXT_WEEK_BTN_RE)
+    prev_btn = page.get_by_role("button", name=PREV_WEEK_BTN_RE)
 
     # Try forward first.
     for _ in range(max_clicks):
@@ -1325,7 +1291,7 @@ def _set_all_visible_date_time(
     composer surfaces 1 set (only after 'Set date and time' is on).
     """
     try:
-        page.get_by_text(re.compile(r"^schedule$", re.I)).last.scroll_into_view_if_needed(timeout=2000)
+        page.get_by_text(SCHEDULE_TEXT_RE).last.scroll_into_view_if_needed(timeout=2000)
         page.wait_for_timeout(500)
     except Exception:
         pass

--- a/planning/threads/README.md
+++ b/planning/threads/README.md
@@ -64,6 +64,8 @@ from the IG side of the editorial DB. The scheduler only **reads** these
 
 ## Validated selectors (verified 2026-05-17 against `threads.com`)
 
+> **Centralised labels:** every user-facing accessible name (caption textbox, media-attach, the `Schedule…` menuitem, the calendar `Next month` / `Done` controls, the final `Schedule` action, the cancel / discard prompts) plus the localized calendar header live in [`threads_labels.py`](threads_labels.py) — `WHATS_NEW_TEXTBOX_RE`, `ATTACH_MEDIA_BTN_RE`, `SCHEDULE_MENUITEM_RE`, `SCHEDULE_TEXT_RE`, `NEXT_MONTH_BTN_RE`, `DONE_BTN_RE`, `FINAL_SCHEDULE_BTN_RE`, `CANCEL_DISCARD_BTN_RES`, `DISCARD_BTN_RE`, `calendar_header()`. When Threads relabels a control, extend the alternation there — do **not** re-inline a `re.compile` at the call site. The positional JS pickers and structural selectors below stay inline in the driver.
+
 | Step | Selector | Notes |
 |------|----------|-------|
 | Open composer | `text="What's new?"` on the profile feed | Opens the `New thread` dialog. The placeholder text re-appears inside the dialog too. |

--- a/planning/threads/schedule_threads_posts.py
+++ b/planning/threads/schedule_threads_posts.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import re
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -36,6 +35,18 @@ from typing import Optional
 from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from planning.threads.threads_labels import (  # noqa: E402
+    ATTACH_MEDIA_BTN_RE,
+    CANCEL_DISCARD_BTN_RES,
+    DISCARD_BTN_RE,
+    DONE_BTN_RE,
+    FINAL_SCHEDULE_BTN_RE,
+    NEXT_MONTH_BTN_RE,
+    SCHEDULE_MENUITEM_RE,
+    SCHEDULE_TEXT_RE,
+    WHATS_NEW_TEXTBOX_RE,
+    calendar_header,
+)
 from planning.threads.threads_session import (  # noqa: E402
     LoginRequiredError,
     ThreadsSession,
@@ -246,7 +257,7 @@ def _type_caption(page: Page, caption: str) -> None:
     # The textarea inside the dialog is a contenteditable, anchored by the
     # same "What's new?" placeholder. Anchor by role.
     ta_candidates = [
-        dialog.get_by_role("textbox", name=re.compile(r"what's new", re.I)).first,
+        dialog.get_by_role("textbox", name=WHATS_NEW_TEXTBOX_RE).first,
         dialog.locator('div[contenteditable="true"]').first,
         dialog.locator('[role="textbox"]').first,
     ]
@@ -284,7 +295,7 @@ def _upload_image(page: Page, path: Path) -> None:
     except Exception:
         # Click the first media icon → intercept the FileChooser.
         media_btn_candidates = [
-            dialog.get_by_role("button", name=re.compile(r"^(attach media|add media|attach image|attach photo)$", re.I)).first,
+            dialog.get_by_role("button", name=ATTACH_MEDIA_BTN_RE).first,
             dialog.locator('[aria-label="Attach media" i]').first,
             dialog.locator('[aria-label*="image" i][role="button"]').first,
             # Last-resort positional: the first <svg>-containing button in
@@ -362,9 +373,7 @@ def _open_three_dots_menu(page: Page) -> None:
     page.wait_for_timeout(600)
     # Confirm a Schedule menuitem appeared.
     for _ in range(20):
-        if page.get_by_text(
-            re.compile(r"^schedule(…|\.\.\.)$", re.I)
-        ).count():
+        if page.get_by_text(SCHEDULE_TEXT_RE).count():
             logger.debug("⋯ Opened more-options menu.")
             return
         page.wait_for_timeout(150)
@@ -374,10 +383,8 @@ def _open_three_dots_menu(page: Page) -> None:
 def _click_schedule_menuitem(page: Page) -> None:
     """Click 'Schedule…' from the 3-dots menu (Threads uses U+2026 ellipsis)."""
     candidates = [
-        lambda: page.get_by_role(
-            "menuitem", name=re.compile(r"^schedule(…|\.\.\.)?$", re.I)
-        ),
-        lambda: page.get_by_text(re.compile(r"^schedule(…|\.\.\.)$", re.I)),
+        lambda: page.get_by_role("menuitem", name=SCHEDULE_MENUITEM_RE),
+        lambda: page.get_by_text(SCHEDULE_TEXT_RE),
     ]
     for find in candidates:
         try:
@@ -392,15 +399,9 @@ def _click_schedule_menuitem(page: Page) -> None:
     raise RuntimeError("Could not click 'Schedule…' menuitem.")
 
 
-_MONTH_NAMES = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December",
-]
-
-
 def _navigate_calendar_month(page: Page, target: date) -> None:
     """Click the calendar's '>' until the visible header is `<Month> <Year>`."""
-    target_header = f"{_MONTH_NAMES[target.month - 1]} {target.year}"
+    target_header = calendar_header(target)
     for _ in range(36):  # 3 years forward max
         try:
             if page.get_by_text(target_header, exact=True).count():
@@ -408,7 +409,7 @@ def _navigate_calendar_month(page: Page, target: date) -> None:
         except Exception:
             pass
         next_btn_candidates = [
-            page.get_by_role("button", name=re.compile(r"^next month$", re.I)).first,
+            page.get_by_role("button", name=NEXT_MONTH_BTN_RE).first,
             page.locator('[aria-label="Next month" i]').first,
             page.locator('[aria-label="Next" i]').first,
         ]
@@ -495,7 +496,7 @@ def _click_calendar_day(page: Page, target: date) -> None:
     and next months are also present but greyed out. JS picks the brightest
     cell with matching text (current-month).
     """
-    header_text = f"{_MONTH_NAMES[target.month - 1]} {target.year}"
+    header_text = calendar_header(target)
     day_text = str(target.day)
     try:
         res = page.evaluate(_CLICK_CAL_DAY_JS, {"headerText": header_text, "dayText": day_text})
@@ -538,8 +539,8 @@ def _set_calendar_time(page: Page, hour: int, minute: int) -> None:
 def _click_calendar_done(page: Page) -> None:
     """Click the calendar popup's bottom-right 'Done'."""
     candidates = [
-        lambda: page.get_by_role("button", name=re.compile(r"^done$", re.I)).first,
-        lambda: page.get_by_text(re.compile(r"^done$", re.I)).first,
+        lambda: page.get_by_role("button", name=DONE_BTN_RE).first,
+        lambda: page.get_by_text(DONE_BTN_RE).first,
     ]
     for find in candidates:
         try:
@@ -559,8 +560,8 @@ def _click_final_schedule_action(page: Page) -> None:
     'Schedule'. Click it."""
     dialog = page.locator('[role="dialog"]').last
     candidates = [
-        lambda: dialog.get_by_role("button", name=re.compile(r"^schedule$", re.I)).first,
-        lambda: page.get_by_role("button", name=re.compile(r"^schedule$", re.I)).last,
+        lambda: dialog.get_by_role("button", name=FINAL_SCHEDULE_BTN_RE).first,
+        lambda: page.get_by_role("button", name=FINAL_SCHEDULE_BTN_RE).last,
     ]
     for find in candidates:
         try:
@@ -594,9 +595,9 @@ def _wait_composer_closes(page: Page, timeout_ms: int = 20000) -> bool:
 
 def _cancel_composer(page: Page) -> None:
     """Best-effort: cancel any open Threads composer."""
-    for name_re in (r"^cancel$", r"^discard$"):
+    for name_re in CANCEL_DISCARD_BTN_RES:
         try:
-            btn = page.get_by_role("button", name=re.compile(name_re, re.I))
+            btn = page.get_by_role("button", name=name_re)
             if btn.count():
                 btn.first.click(timeout=2000)
                 page.wait_for_timeout(400)
@@ -650,7 +651,7 @@ def schedule_post(
         # Discard prompt after Cancel.
         for _ in range(3):
             try:
-                btn = page.get_by_role("button", name=re.compile(r"^discard$", re.I))
+                btn = page.get_by_role("button", name=DISCARD_BTN_RE)
                 if btn.count():
                     btn.first.click(timeout=2000)
                     page.wait_for_timeout(400)

--- a/planning/threads/threads_labels.py
+++ b/planning/threads/threads_labels.py
@@ -1,0 +1,93 @@
+"""Accessible-name label registry for the Threads Playwright driver.
+
+The Threads composer exposes almost no stable ``data-testid`` hooks, so the
+driver reaches most affordances by their visible / accessible name: the
+caption textbox, the media-attach button, the 3-dots "Schedule…" menuitem, the
+calendar's "Next month" / "Done" controls, and the final "Schedule" action.
+Those names are exactly what shifts when Threads relabels a control, so they
+are centralized here as compiled regexes rather than scattered inline through
+``schedule_threads_posts``.
+
+This mirrors ``planning/linkedin/linkedin_labels.py``: the self-healing
+scheduler (issue #64) can scan and patch one small module instead of hunting an
+accessible-name string buried in scheduling logic. When Threads ships a new
+label variant, add it to the alternation here — do NOT re-inline a
+``re.compile`` at the call site.
+
+Structural selectors (``role="dialog"``, ``input[type=file]``,
+``[aria-label="…"]`` CSS, ``text="…"`` engine selectors) and the positional JS
+DOM probes deliberately stay inline in the driver: they are DOM-structure
+hooks, not user-facing labels.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Caption contenteditable inside the composer dialog, anchored on the
+# "What's new?" placeholder.
+WHATS_NEW_TEXTBOX_RE = re.compile(r"what's new", re.I)
+
+# First media-row icon that opens the file picker.
+ATTACH_MEDIA_BTN_RE = re.compile(
+    r"^(attach media|add media|attach image|attach photo)$", re.I
+)
+
+# 'Schedule…' entry in the 3-dots more-options menu. Threads renders the
+# U+2026 ellipsis ("Schedule…") but some builds use three dots ("Schedule...").
+# The MENUITEM variant makes the ellipsis optional (the role-name computation
+# occasionally drops it); the TEXT variant — used for the get_by_text
+# confirmation / fallback — keeps it required so it can't match the final
+# "Schedule" action button.
+SCHEDULE_MENUITEM_RE = re.compile(r"^schedule(…|\.\.\.)?$", re.I)
+SCHEDULE_TEXT_RE = re.compile(r"^schedule(…|\.\.\.)$", re.I)
+
+# Calendar 'Next month' chevron.
+NEXT_MONTH_BTN_RE = re.compile(r"^next month$", re.I)
+
+# Calendar popup's bottom-right 'Done'.
+DONE_BTN_RE = re.compile(r"^done$", re.I)
+
+# Composer's primary action once a schedule is attached — reads "Schedule"
+# instead of "Post".
+FINAL_SCHEDULE_BTN_RE = re.compile(r"^schedule$", re.I)
+
+# Cancel / Discard affordances used to back out of the composer. Tried in
+# order; the discard-confirmation pops up after Cancel.
+CANCEL_DISCARD_BTN_RES = (
+    re.compile(r"^cancel$", re.I),
+    re.compile(r"^discard$", re.I),
+)
+
+# Standalone 'Discard' on the post-Cancel confirmation prompt.
+DISCARD_BTN_RE = re.compile(r"^discard$", re.I)
+
+
+# ---------- Localized calendar strings ----------
+
+# The calendar month/year header renders English month names. Centralized here
+# alongside the labels so a future locale variant lives in one place.
+MONTH_NAMES = (
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+)
+
+
+def calendar_header(target) -> str:
+    """Return the ``<Month> <Year>`` header string for the target month."""
+    return f"{MONTH_NAMES[target.month - 1]} {target.year}"
+
+
+__all__ = [
+    "WHATS_NEW_TEXTBOX_RE",
+    "ATTACH_MEDIA_BTN_RE",
+    "SCHEDULE_MENUITEM_RE",
+    "SCHEDULE_TEXT_RE",
+    "NEXT_MONTH_BTN_RE",
+    "DONE_BTN_RE",
+    "FINAL_SCHEDULE_BTN_RE",
+    "CANCEL_DISCARD_BTN_RES",
+    "DISCARD_BTN_RE",
+    "MONTH_NAMES",
+    "calendar_header",
+]

--- a/planning/twitter/README.md
+++ b/planning/twitter/README.md
@@ -63,6 +63,8 @@ successful live run).
 
 ## Validated selectors (verified 2026-05-17 against `x.com/home`)
 
+> **Centralised labels:** every user-facing accessible name (dialog dismissals, the Schedule toolbar, Confirm, the final Schedule action, the discard / cancel prompts) is defined as a compiled regex in [`twitter_labels.py`](twitter_labels.py) — `DISMISS_DIALOG_BTN_RES`, `SCHEDULE_TOOLBAR_BTN_RE`, `CONFIRM_BTN_RE`, `FINAL_SCHEDULE_BTN_RE`, `DISCARD_BTN_RES`, `CANCEL_CLOSE_BTN_RES`. When X relabels a button or A/Bs a wording, extend the alternation there — do **not** re-inline a `re.compile` at the call site. The structural `data-testid` hooks below stay inline in the driver.
+
 | Step | Selector | Notes |
 |------|----------|-------|
 | Open composer | `[data-testid="SideNav_NewTweet_Button"]` | Side-rail Post button; opens a clean modal. |

--- a/planning/twitter/schedule_twitter_posts.py
+++ b/planning/twitter/schedule_twitter_posts.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import re
 import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
@@ -35,6 +34,14 @@ from typing import Optional
 from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from planning.twitter.twitter_labels import (  # noqa: E402
+    CANCEL_CLOSE_BTN_RES,
+    CONFIRM_BTN_RE,
+    DISCARD_BTN_RES,
+    DISMISS_DIALOG_BTN_RES,
+    FINAL_SCHEDULE_BTN_RE,
+    SCHEDULE_TOOLBAR_BTN_RE,
+)
 from planning.twitter.twitter_session import (  # noqa: E402
     LoginRequiredError,
     TwitterSession,
@@ -222,14 +229,14 @@ def _dismiss_blocking_modals(page: Page) -> bool:
     dialog = page.locator('[role="dialog"]')
     if not dialog.count():
         return False
-    for name_re in (r"^not now$", r"^skip for now$", r"^maybe later$", r"^dismiss$", r"^close$"):
+    for name_re in DISMISS_DIALOG_BTN_RES:
         try:
-            btn = dialog.first.get_by_role("button", name=re.compile(name_re, re.I))
+            btn = dialog.first.get_by_role("button", name=name_re)
             if btn.count():
                 btn.first.click(timeout=2500)
                 page.wait_for_timeout(400)
                 dismissed = True
-                logger.info("ℹ️ Dismissed dialog via %r button.", name_re)
+                logger.info("ℹ️ Dismissed dialog via %r button.", name_re.pattern)
                 break
         except Exception:
             pass
@@ -443,7 +450,7 @@ def _click_schedule_toolbar(page: Page) -> None:
     candidates = [
         lambda: page.locator('button[data-testid="scheduleOption"]'),
         lambda: page.locator('[aria-label="Schedule post"]'),
-        lambda: page.get_by_role("button", name=re.compile(r"^schedule(\spost)?$", re.I)),
+        lambda: page.get_by_role("button", name=SCHEDULE_TOOLBAR_BTN_RE),
     ]
     for find in candidates:
         try:
@@ -514,7 +521,7 @@ def _click_confirm_in_modal(page: Page) -> None:
     """Click the bottom-right 'Confirm' in the Schedule modal."""
     candidates = [
         lambda: page.locator('[data-testid="scheduledConfirmationPrimaryAction"]'),
-        lambda: page.get_by_role("button", name=re.compile(r"^confirm$", re.I)),
+        lambda: page.get_by_role("button", name=CONFIRM_BTN_RE),
     ]
     for find in candidates:
         try:
@@ -543,7 +550,7 @@ def _click_final_schedule_action(page: Page) -> None:
     candidates = [
         lambda: page.locator('[data-testid="tweetButton"]'),
         lambda: page.locator('button[data-testid="tweetButtonInline"]'),
-        lambda: page.get_by_role("button", name=re.compile(r"^schedule$", re.I)),
+        lambda: page.get_by_role("button", name=FINAL_SCHEDULE_BTN_RE),
     ]
     for find in candidates:
         try:
@@ -597,9 +604,9 @@ def _cancel_composer(page: Page) -> None:
     except Exception:
         pass
     # If a "Save changes?" / "Discard?" dialog appears, pick Discard.
-    for name_re in (r"^discard$", r"^discard changes$"):
+    for name_re in DISCARD_BTN_RES:
         try:
-            btn = page.get_by_role("button", name=re.compile(name_re, re.I))
+            btn = page.get_by_role("button", name=name_re)
             if btn.count():
                 btn.first.click(timeout=2000)
                 page.wait_for_timeout(400)
@@ -653,9 +660,9 @@ def schedule_post(
             label, shot,
         )
         # Cancel the schedule modal AND the composer to leave clean state.
-        for name_re in (r"^cancel$", r"^close$"):
+        for name_re in CANCEL_CLOSE_BTN_RES:
             try:
-                btn = page.get_by_role("button", name=re.compile(name_re, re.I))
+                btn = page.get_by_role("button", name=name_re)
                 if btn.count():
                     btn.first.click(timeout=2000)
                     page.wait_for_timeout(400)

--- a/planning/twitter/twitter_labels.py
+++ b/planning/twitter/twitter_labels.py
@@ -1,0 +1,69 @@
+"""Accessible-name label registry for the Twitter (X) Playwright driver.
+
+X's native composer is driven mostly via stable ``data-testid`` hooks, but a
+handful of affordances — the onboarding/upsell dialog dismissals, the Schedule
+toolbar button, the modal Confirm, the final Schedule action, and the discard
+prompts — are only reachable by their visible / accessible name. Those names
+are exactly what shifts when X relabels a button or A/Bs the composer, so they
+are centralized here as compiled regexes rather than scattered inline through
+``schedule_twitter_posts``.
+
+This mirrors ``planning/linkedin/linkedin_labels.py``: the self-healing
+scheduler (issue #64) can scan and patch one small module instead of hunting an
+accessible-name string buried in scheduling logic. When X ships a new label
+variant, add it to the alternation here — do NOT re-inline a ``re.compile`` at
+the call site.
+
+Structural selectors (``data-testid``, ``role="dialog"``, ``input[type=file]``,
+``[aria-label="…"]`` CSS, ``text=/…/`` engine selectors) deliberately stay
+inline in the driver: they are DOM-structure hooks, not user-facing labels.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Onboarding / "try premium" dialogs that X intermittently pops over the feed.
+# Tried in order against the dialog's buttons; first match dismisses it.
+DISMISS_DIALOG_BTN_RES = (
+    re.compile(r"^not now$", re.I),
+    re.compile(r"^skip for now$", re.I),
+    re.compile(r"^maybe later$", re.I),
+    re.compile(r"^dismiss$", re.I),
+    re.compile(r"^close$", re.I),
+)
+
+# Composer's calendar-clock toolbar button that opens the Schedule modal. The
+# accessible name is "Schedule" or "Schedule post" depending on the build.
+SCHEDULE_TOOLBAR_BTN_RE = re.compile(r"^schedule(\spost)?$", re.I)
+
+# Bottom-right primary action inside the Schedule modal.
+CONFIRM_BTN_RE = re.compile(r"^confirm$", re.I)
+
+# The composer's primary action once a schedule is attached reads "Schedule"
+# (instead of "Post"). Distinct from SCHEDULE_TOOLBAR_BTN_RE, which we do NOT
+# want to match here.
+FINAL_SCHEDULE_BTN_RE = re.compile(r"^schedule$", re.I)
+
+# Discard prompt shown when closing a composer with unsaved content.
+DISCARD_BTN_RES = (
+    re.compile(r"^discard$", re.I),
+    re.compile(r"^discard changes$", re.I),
+)
+
+# Cancel / Close affordances used to back out of the Schedule modal + composer
+# on a dry-run.
+CANCEL_CLOSE_BTN_RES = (
+    re.compile(r"^cancel$", re.I),
+    re.compile(r"^close$", re.I),
+)
+
+
+__all__ = [
+    "DISMISS_DIALOG_BTN_RES",
+    "SCHEDULE_TOOLBAR_BTN_RE",
+    "CONFIRM_BTN_RE",
+    "FINAL_SCHEDULE_BTN_RE",
+    "DISCARD_BTN_RES",
+    "CANCEL_CLOSE_BTN_RES",
+]


### PR DESCRIPTION
## Summary

Centralises the **role/text selectors** (accessible-name regexes + locale `EN | ES` alternations) for the Twitter, Threads, and Instagram planners into per-platform label modules, mirroring `planning/linkedin/linkedin_labels.py`. This makes the self-healing scheduler's "selector-only edit" guardrail (#64) as clean for these three platforms as it already is for LinkedIn — a heal edits one scan-in-seconds module instead of an accessible-name string buried in scheduling logic.

- New `planning/{twitter,threads,instagram}/<platform>_labels.py` — compiled accessible-name regexes, the locale `EN|ES` media-attach selector unions (IG), and the localized calendar/time helpers.
- Each scheduler now imports from its label module; `import re` dropped from the Twitter and Threads drivers (fully unused after extraction; IG keeps `re` for its dynamic `re.escape(...)` patterns).
- Threads: inline `_MONTH_NAMES` replaced by a `calendar_header()` helper. Instagram: `day_cell_label()` / `fmt_time_12h()` and the `ADD_MEDIA` / `UPLOAD_FROM_COMPUTER` locale selectors moved into the module.
- Each platform README documents its new label module (mirrors the LinkedIn README note).

**Pure selector move — no scheduling-logic change.** Structural `data-testid`/CSS/`[aria-label=…]`/`text=…`/JS-probe selectors and argument-built dynamic regexes deliberately stay inline, matching the LinkedIn precedent.

## Validation

- `py_compile` green on all 6 touched files + the 3 dependent `videos_*.py` + `planning_pipeline.py`.
- Runtime import smoke test green for every label module, scheduler, and `videos_*` importer.
- Author ran a **live dry-run** across multiple work-in-progress rows covering the previously-failing edge cases on all three platforms — all scheduled correctly.

Closes #67