### PR TITLE
feat(autoheal): escalate via the fleet-wide Slack bot helper

### DIFF
--- a/.claude/skills/schedule-autoheal/SKILL.md
+++ b/.claude/skills/schedule-autoheal/SKILL.md
@@ -95,11 +95,27 @@ Leave the working tree clean (or the branch un-pushed) and hand off to a human.
 
 ## Step 5 — escalate via Slack, then stop
 
-Read the Slack target from `config/config.json` → `slack.autoheal_channel` (blank → the
-user's self-DM). Send a message with the **Slack MCP** tool
-(`mcp__claude_ai_Slack__slack_send_message`) containing: platform, failing step, the
-screenshot path, the probe's top candidates, and exactly what you need decided. Then
-**stop** — do not commit, push, or merge anything ambiguous.
+Read the Slack target from `config/config.json` → `slack.autoheal_channel`. Send the
+ping through the **fleet-wide Slack bot helper** (provided by `claude-config`, available
+with zero install at `~/.claude/hooks/slack_notify.py`):
+
+```
+& py "$HOME/.claude/hooks/slack_notify.py" --channel <autoheal_channel> --text "<message>"
+```
+
+Pass the bare channel id (the helper also accepts a pasted archive URL). The message must
+contain: platform, failing step, the screenshot path, the probe's top candidates, and
+exactly what you need decided.
+
+Why the bot and not the Slack MCP connector: the MCP connector posts **as the user**, so
+Slack never fires a notification for it and the escalation lands silently — defeating the
+point of an unattended scheduler. The bot posts as a separate identity, which actually
+notifies. The bot token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never
+in this repo; see `claude-config/docs/slack-workflow.md`.
+
+If `autoheal_channel` is blank **or** the helper reports a failure (missing token, API
+error), surface that plainly in the run output and still **stop**. Either way: do not
+commit, push, or merge anything ambiguous.
 
 ## Guardrails (non-negotiable)
 

--- a/docs/self-healing-scheduler.md
+++ b/docs/self-healing-scheduler.md
@@ -72,9 +72,13 @@ follow-up work).
 
 A fix lands end-to-end only when **all** hold: exactly one strong role/text
 candidate, the validating dry-run passes, and the diff is a pure selector-string
-change. Otherwise the skill escalates via the **Slack MCP**
-(`mcp__claude_ai_Slack__slack_send_message`) to the channel in
-`config/config.json` → `slack.autoheal_channel`, and stops.
+change. Otherwise the skill escalates via the **fleet-wide Slack bot helper**
+(`~/.claude/hooks/slack_notify.py`, provided by `claude-config`) to the channel
+in `config/config.json` → `slack.autoheal_channel`, and stops. A bot identity is
+used deliberately: the claude.ai Slack MCP connector posts *as the user*, so Slack
+never fires a notification and the escalation would land silently. The bot token
+lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never in this repo;
+see `claude-config/docs/slack-workflow.md`.
 
 ## The visible-console + tee mechanism
 


### PR DESCRIPTION
## Summary

Rewires the `schedule-autoheal` "not confident" escalation to post through the fleet-wide Slack **bot** helper (`~/.claude/hooks/slack_notify.py`, from `ferraroroberto/claude-config#26`) instead of the claude.ai Slack MCP connector.

The MCP connector posts *as the user*, so Slack never fires a notification and escalation pings landed silently — defeating the point of an unattended scheduler. A bot identity actually notifies. The bot token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never in this public repo.

- `SKILL.md` Step 5: call the helper with the channel from `config/config.json` → `slack.autoheal_channel`; blank channel or helper failure (missing token / API error) is surfaced and the skill still stops.
- `docs/self-healing-scheduler.md`: confidence-gate escalation updated to the bot helper + why.

## Validation

Markdown-only change (`SKILL.md` + a doc); no Python touched, and the repo has no ruff/test/CI config, so no code gate applies. The underlying helper was verified with a live `chat.postMessage` ping (bot-identity message delivered to `#claude` + notification fired). Depends on `claude-config#26`, now merged — the helper is present at `~/.claude/hooks/slack_notify.py`.

Closes #68
