### PR TITLE
fix(logging): make console log sink robust to emoji on cp1252 consoles

### DIFF
--- a/config/logger_config.py
+++ b/config/logger_config.py
@@ -2,6 +2,28 @@ import logging
 import sys
 import os
 
+
+def _force_utf8_stdout():
+    """Reconfigure stdout/stderr to UTF-8 so emoji log lines don't crash on
+    Windows cp1252 consoles.
+
+    On a default Windows console ``sys.stdout`` is cp1252, so any non-cp1252
+    glyph (e.g. an emoji in a log message) raises ``UnicodeEncodeError`` on
+    write and the logging machinery prints a ``--- Logging error ---``
+    traceback instead of the message. Reconfiguring with ``errors="replace"``
+    makes a non-encodable glyph degrade to a replacement char instead of
+    crashing. Guarded with ``hasattr`` because not every stream (e.g. a
+    pytest capture buffer) supports ``reconfigure``.
+    """
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream is not None and hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
 def setup_logger(name, level=logging.INFO, file_logging=True):
     """
     Set up and configure a logger with the given name and level.
@@ -21,7 +43,11 @@ def setup_logger(name, level=logging.INFO, file_logging=True):
     # Clear any existing handlers (to avoid duplicates)
     if logger.hasHandlers():
         logger.handlers.clear()
-    
+
+    # Make the console sink robust to emoji on Windows cp1252 consoles before
+    # attaching the StreamHandler (see _force_utf8_stdout).
+    _force_utf8_stdout()
+
     # Create console handler
     c_handler = logging.StreamHandler(sys.stdout)
     c_handler.setLevel(level)

--- a/planning/instagram/instagram_session.py
+++ b/planning/instagram/instagram_session.py
@@ -34,20 +34,8 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _force_utf8_stdout() -> None:
-    """Force stdout/stderr to UTF-8 so emoji log lines don't crash Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "instagram", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 

--- a/planning/linkedin/linkedin_session.py
+++ b/planning/linkedin/linkedin_session.py
@@ -50,20 +50,8 @@ def normalize_day(date_str: Optional[str]) -> str:
     return datetime.strptime(s, "%Y%m%d").strftime("%Y%m%d")
 
 
-def _force_utf8_stdout() -> None:
-    """Force stdout/stderr to UTF-8 so emoji log lines don't crash Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "linkedin", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 

--- a/planning/substack/substack_session.py
+++ b/planning/substack/substack_session.py
@@ -53,20 +53,8 @@ def normalize_day(date_str: Optional[str]) -> str:
     return datetime.strptime(s, "%Y%m%d").strftime("%Y%m%d")
 
 
-def _force_utf8_stdout() -> None:
-    """Force stdout/stderr to UTF-8 so emoji-laden log lines don't crash on Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "substack", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 

--- a/planning/threads/threads_session.py
+++ b/planning/threads/threads_session.py
@@ -34,20 +34,8 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _force_utf8_stdout() -> None:
-    """Force stdout/stderr to UTF-8 so emoji log lines don't crash Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "threads", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 

--- a/planning/twitter/twitter_session.py
+++ b/planning/twitter/twitter_session.py
@@ -31,20 +31,8 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _force_utf8_stdout() -> None:
-    """Force stdout/stderr to UTF-8 so emoji log lines don't crash Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "twitter", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -72,18 +72,7 @@ class ClipPayload:
     caption_long: str
 
 
-def _force_utf8_stdout() -> None:
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
-
-
 def configure_logger(name: str = "videos", debug: bool = False) -> logging.Logger:
-    _force_utf8_stdout()
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
 


### PR DESCRIPTION
## Summary

The reporting CLIs log with emoji but their console handler writes through `sys.stdout`, which on a default Windows console is cp1252 — so every emoji-bearing log line raised `UnicodeEncodeError` and printed a `--- Logging error ---` traceback instead of the message, burying real warnings/errors.

Fixed centrally in the shared `config/logger_config.py`: `setup_logger` now reconfigures `sys.stdout`/`sys.stderr` to `encoding="utf-8", errors="replace"` (guarded by `hasattr(stream, "reconfigure")`) before attaching the `StreamHandler`. Both reporting CLIs (`social_api_client`, `data_processor`) route through `setup_logger`, so they inherit the fix with no per-CLI change and no need for `PYTHONIOENCODING`.

The six now-redundant per-module `_force_utf8_stdout()` workarounds in `planning/*/*_session.py` (substack, videos, instagram, twitter, linkedin, threads) are removed — they called the same reconfigure immediately before `setup_logger`. The `_force_utf8_stdout()` copies in `engagement/check_review_app.py`, `app/check_control_panel.py`, and `engagement/linkedin/scrape_comments.py` are intentionally kept: they guard direct `print()` of emoji that runs before any `setup_logger` call, so they are load-bearing rather than logger-redundant. The file handler is untouched (still `encoding="utf-8"`).

Convention routed up to the scaffold master: ferraroroberto/project-scaffolding#22.

## Validation

- `python -m py_compile` on all changed files plus the two reporting CLIs → OK.
- Functional cp1252 simulation: swapped `sys.stdout` for a `TextIOWrapper` over a `BytesIO` with `encoding="cp1252"`, called `setup_logger(...).info("🚀 ✅ 💾")` → stdout reconfigured to utf-8, no `UnicodeEncodeError` / `Logging error`, emoji present as UTF-8 bytes.
- No project test suite exists; no ruff config.

Closes #79
