### PR TITLE
fix(reporting): wire Substack follower count (follow SB) to Notion

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -209,8 +209,7 @@
             "title_day": "day",
             "text_body": "text SB",
             "image_filename": "ill (copy)",
-            "post_url": "link SB",
-            "follower_count": "follow SB"
+            "post_url": "link SB"
         },
         "headless": false,
         "dry_run_default": false

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -65,7 +65,7 @@ substack/
 | `user_data_dir` | Dedicated Chrome profile directory (gitignored; defaults to `substack/chrome_user_data`). Must NOT point at your real Chrome profile — the session refuses to start if it does. |
 | `illustrations_folder` | Absolute folder containing the daily image. Joined with `image_filename`. |
 | `editorial_db_id` | Notion editorial database id. |
-| `notion_columns` | Role-to-column map. Roles: `title_day`, `text_body`, `image_filename`, `post_url`. The `follower_count` column is populated via the reporting pipeline (`reporting/scrape_client/substack.py::fetch_profile` writes through `data_processor` → `notion_update`). |
+| `notion_columns` | Role-to-column map. Roles: `title_day`, `text_body`, `image_filename`, `post_url`. The `follow SB` follower column is **not** in this map — it is populated by the reporting pipeline (`reporting/scrape_client/substack.py::fetch_profile` → `data_processor` → `notion_update`, mapped from `profile.num_followers_substack`) like every other platform's follower count. |
 | `headless` | Optional bool (default `false`). |
 | `dry_run_default` | Optional bool (default `false`). When `true`, step 1 always runs as a dry-run unless `--force` is passed. |
 


### PR DESCRIPTION
## Summary

The reporting Notion update never wrote the Substack follower count (`follow SB`) to the editorial row, because the reporting follower config listed only the other four platforms. This wires `follow SB` through exactly like the others.

- **Live `config.json` (gitignored):** added `"follow SB"` to `update_fields_followers` and `"follow SB": "profile.num_followers_substack"` to `update_field_mapping_followers`. This is the operative runtime fix.
- **`config_example.json`:** the followers wiring was already present in the template; removed the now-dead `substack.notion_columns.follower_count` key (the planning pipeline no longer scrapes SB followers).
- **`planning/substack/README.md`:** clarified that `follow SB` is populated by the reporting pipeline (mapped from `profile.num_followers_substack`), not via the substack `notion_columns` map.

`profile.num_followers_substack` already exists in the aggregated `profile` table (`reporting/process/profile_aggregator.sql`). Confirmed `planning/substack/post_substack_note.py` never reads the `follower_count` role, so removing it is safe.

## Validation

- **JSON validity:** both `config.json` and `config_example.json` parse (`json.load`). ✅
- **Behavioural probe** (real `config.json` + real `reporting.notion.notion_update.map_supabase_to_notion_fields`):
  - `update_fields_followers` → `['follow LI', 'follow TW', 'follow IG', 'follow TH', 'follow SB']` (was 4, now 5 — the issue's "Number of follower fields to extract: 4" symptom is resolved)
  - `follow SB` maps to `14630` from `profile.num_followers_substack`; the other four counts unaffected
  - dead `follower_count` key confirmed absent ✅
- **Tests/CI:** the project has no test suite and no GitHub Actions workflows; there is no automated gate beyond the above.

## Remaining manual step (out of YOLO scope)

The "backfill the current day" acceptance item requires a **live Notion write** via `reporting/notion/notion_update.py <date> -y` (it also touches the previous-day posts row + Supabase logging) — external API state beyond the YOLO local boundary. Run it as part of the normal reporting pipeline to correct today's row.

Closes #87