### PR TITLE
fix(reporting): stop doubling link TW/IG/TH in consolidator

### DIFF
--- a/reporting/process/posts_consolidator.sql
+++ b/reporting/process/posts_consolidator.sql
@@ -101,7 +101,10 @@ WITH
         instagram_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://www.instagram.com/p/' || post_id as post_id,
+                -- post_id is already a full post URL from the Playwright
+                -- scraper; do NOT prepend a prefix (issue #86 — that produced
+                -- doubled/malformed link IG).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments
@@ -114,7 +117,8 @@ WITH
         instagram_non_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://www.instagram.com/p/' || post_id as post_id,
+                -- post_id is already a full post URL (see instagram_video).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments
@@ -127,7 +131,10 @@ WITH
         twitter_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://x.com/FerraroRoberto/status/' || post_id as post_id,
+                -- post_id is already a full post URL from the Playwright
+                -- scraper; do NOT prepend a prefix (issue #86 — that produced
+                -- doubled/malformed link TW).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments,
@@ -141,7 +148,8 @@ WITH
         twitter_non_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://x.com/FerraroRoberto/status/' || post_id as post_id,
+                -- post_id is already a full post URL (see twitter_video).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments,
@@ -187,7 +195,10 @@ WITH
         threads_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://www.threads.com/@ferraroroberto/post/' || post_id as post_id,
+                -- post_id is already a full post URL from the Playwright
+                -- scraper; do NOT prepend a prefix (issue #86 — that produced
+                -- doubled/malformed link TH).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments,
@@ -201,7 +212,8 @@ WITH
         threads_non_video AS (
             SELECT DISTINCT ON (date)
                 date::date as date,
-                'https://www.threads.com/@ferraroroberto/post/' || post_id as post_id,
+                -- post_id is already a full post URL (see threads_video).
+                post_id,
                 posted_at::date as posted_at,
                 num_likes,
                 num_comments,


### PR DESCRIPTION
@
## Summary

`posts_consolidator.sql` prepended a domain prefix to `post_id` in the six twitter/instagram/threads CTEs. Since the Playwright scrapers now return **full post URLs** in `post_id`, this produced doubled/malformed, unclickable links in the Notion `link TW` / `link IG` / `link TH` columns.

The fix drops the prefix and selects `post_id` directly, mirroring the LinkedIn CTEs (always correct) and the Substack CTEs (fixed in #84). All affected sources are `playwright` in `config.json`, so all live data is full-URL form — no scraper change needed. The `_video` CTEs carried the identical bug and are fixed the same way; no mapping/behaviour change beyond prefix removal (per the issues out-of-scope note).

## Validation (run live against the cloud DB + Notion)

- **Reproduction (before):** queried `posts` — `link TW/IG/TH` were doubled on every recent row (e.g. `https://x.com/FerraroRoberto/status/https://x.com/FerraroRoberto/status/2061432586325442668`); `link LI`/`link SB` already clean.
- **Ran the consolidator live:** `python -m reporting.process.posts_consolidator` → `✅ SQL executed successfully`.
- **After:** re-queried `posts` — `link TW/IG/TH` now single clean URLs; `link LI`/`link SB` unchanged.
- **Notion backfill:** `python -m reporting.notion.notion_update 2026-06-02 --yes` → the field-update log shows the live transition, e.g. `link TW: …/status/https://…/status/2061432586325442668 → …/status/2061432586325442668`, same for IG and TH; `link LI`/`link SB` unchanged.
- No test suite or verify-before-ship script exists in this repo; the live DB execution + live Notion write are the verification.

## Acceptance criteria

- [x] `link TW` / `link IG` / `link TH` in Notion are single, clean, clickable URLs.
- [x] `link LI` and `link SB` remain correct (no regression).
- [x] Current day backfilled so the row is corrected.

Closes #86
@