### PR TITLE
refactor: extract PlatformSession base + force_utf8_stdio helper (-588 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ reporting/                            # repo root
 ├── newsletter/                       # weekly newsletter pipeline (archive + normalize + build)
 │                                     # archive=chrome tabs → notion; normalize_names + normalize_url
 │                                     # rewrite titles + clean URLs; build_newsletter renders HTML
-├── config/                           # config.json, mapping.json, logger_config, chrome_launch
+├── config/                           # config.json, mapping.json, logger_config, chrome_launch, console
 ├── results/                          # outputs — planning summaries + raw API JSON
 ├── logs/                             # per-module .log files
 ├── docs/                             # retrospective changelogs (gitignored locally)

--- a/app/autoheal_console.py
+++ b/app/autoheal_console.py
@@ -163,13 +163,8 @@ def run(skill_cmd: str, log_path: Path, model: str, claude_exe: str,
 
 
 def main() -> int:
-    for stream in (sys.stdout, sys.stderr):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if callable(reconfigure):
-            try:
-                reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
 
     parser = argparse.ArgumentParser(description="Run /schedule-autoheal headless in a visible console.")
     parser.add_argument("--skill-cmd", required=True,

--- a/app/check_control_panel.py
+++ b/app/check_control_panel.py
@@ -22,22 +22,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(REPO_ROOT))
 
 from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.console import force_utf8_stdio  # noqa: E402
 
 import os
 
 # Default to 8501 (what `launch_app.bat` uses). Override with APP_URL env var
 # when running parallel to the standalone review_app for dev.
 APP_URL = os.environ.get("APP_URL", "http://localhost:8501")
-
-
-def _force_utf8_stdout() -> None:
-    for s in ("stdout", "stderr"):
-        st_ = getattr(sys, s, None)
-        if st_ is not None and hasattr(st_, "reconfigure"):
-            try:
-                st_.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
 
 
 def _pass(label: str, detail: str = "") -> None:
@@ -87,7 +78,7 @@ def _click_tab(page, label: str) -> bool:
 
 
 def run() -> int:
-    _force_utf8_stdout()
+    force_utf8_stdio()
     out_dir = REPO_ROOT / "results" / "engagement" / "e2e-control" / datetime.now().strftime("%Y%m%d-%H%M%S")
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"📁 screenshots → {out_dir}")

--- a/config/README.md
+++ b/config/README.md
@@ -63,6 +63,16 @@ Python module for setting up logging configuration.
 - Automatic log directory creation
 - UTF-8 encoding support for file logs
 
+### 5. `console.py`
+Single-source helper for forcing UTF-8 stdio on Windows (`cp1252`) consoles so emoji in log output and print statements do not crash the pipeline. Exposes one function:
+
+```python
+from config.console import force_utf8_stdio
+force_utf8_stdio()   # called once at each entry-point module's top level
+```
+
+All entry points (`*_pipeline.py`, `app/*.py`, `newsletter/*.py`, etc.) call this instead of the inline `for _stream in (sys.stdout, sys.stderr): _stream.reconfigure(...)` loop that was previously hand-copied across ~13 modules.
+
 ## Usage
 
 1. Copy `config_example.json` to `config.json`

--- a/config/console.py
+++ b/config/console.py
@@ -1,0 +1,34 @@
+"""Shared console helpers.
+
+Single source of truth for making stdout/stderr safe to write UTF-8 (emoji,
+em-dashes) on a Windows console that defaults to cp1252. Every entry point
+that logs emoji must call :func:`force_utf8_stdio` once at startup instead of
+re-inlining the reconfigure loop.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def force_utf8_stdio() -> None:
+    """Reconfigure ``sys.stdout`` / ``sys.stderr`` to UTF-8 with ``errors="replace"``.
+
+    On a default Windows console ``sys.stdout`` is cp1252, so any non-cp1252
+    glyph (e.g. an emoji in a log message) raises ``UnicodeEncodeError`` on
+    write and the logging machinery prints a ``--- Logging error ---``
+    traceback instead of the message. Reconfiguring with ``errors="replace"``
+    makes a non-encodable glyph degrade to a replacement char instead of
+    crashing. Guarded with ``hasattr`` because not every stream (e.g. a pytest
+    capture buffer) supports ``reconfigure``.
+    """
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        if stream is not None and hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
+__all__ = ["force_utf8_stdio"]

--- a/config/logger_config.py
+++ b/config/logger_config.py
@@ -2,26 +2,7 @@ import logging
 import sys
 import os
 
-
-def _force_utf8_stdout():
-    """Reconfigure stdout/stderr to UTF-8 so emoji log lines don't crash on
-    Windows cp1252 consoles.
-
-    On a default Windows console ``sys.stdout`` is cp1252, so any non-cp1252
-    glyph (e.g. an emoji in a log message) raises ``UnicodeEncodeError`` on
-    write and the logging machinery prints a ``--- Logging error ---``
-    traceback instead of the message. Reconfiguring with ``errors="replace"``
-    makes a non-encodable glyph degrade to a replacement char instead of
-    crashing. Guarded with ``hasattr`` because not every stream (e.g. a
-    pytest capture buffer) supports ``reconfigure``.
-    """
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
+from config.console import force_utf8_stdio
 
 
 def setup_logger(name, level=logging.INFO, file_logging=True):
@@ -45,8 +26,8 @@ def setup_logger(name, level=logging.INFO, file_logging=True):
         logger.handlers.clear()
 
     # Make the console sink robust to emoji on Windows cp1252 consoles before
-    # attaching the StreamHandler (see _force_utf8_stdout).
-    _force_utf8_stdout()
+    # attaching the StreamHandler (see config.console.force_utf8_stdio).
+    force_utf8_stdio()
 
     # Create console handler
     c_handler = logging.StreamHandler(sys.stdout)

--- a/engagement/check_review_app.py
+++ b/engagement/check_review_app.py
@@ -30,19 +30,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(REPO_ROOT))
 
 from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.console import force_utf8_stdio  # noqa: E402
 from engagement.db.client import supabase_client  # noqa: E402
 
 APP_URL = "http://localhost:8501"
-
-
-def _force_utf8_stdout() -> None:
-    for s in ("stdout", "stderr"):
-        st = getattr(sys, s, None)
-        if st is not None and hasattr(st, "reconfigure"):
-            try:
-                st.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
 
 
 def _shot(page: Page, out_dir: Path, label: str) -> Path:
@@ -90,7 +81,7 @@ def _click_tab(page: Page, label: str) -> bool:
 
 
 def run() -> int:
-    _force_utf8_stdout()
+    force_utf8_stdio()
     out_dir = REPO_ROOT / "results" / "engagement" / "e2e" / datetime.now().strftime("%Y%m%d-%H%M%S")
     out_dir.mkdir(parents=True, exist_ok=True)
     print(f"📁 screenshots → {out_dir}")

--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -33,6 +33,7 @@ from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(REPO_ROOT))
 
+from config.console import force_utf8_stdio  # noqa: E402
 from config.logger_config import setup_logger  # noqa: E402
 from engagement.db.client import (  # noqa: E402
     load_config,
@@ -41,17 +42,6 @@ from engagement.db.client import (  # noqa: E402
     upsert_commenters,
     upsert_comments,
 )
-
-
-def _force_utf8_stdout() -> None:
-    """Reconfigure stdout/stderr to UTF-8 so emoji log lines don't crash Windows cp1252 consoles."""
-    for stream_name in ("stdout", "stderr"):
-        stream = getattr(sys, stream_name, None)
-        if stream is not None and hasattr(stream, "reconfigure"):
-            try:
-                stream.reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
 from planning.linkedin.linkedin_session import (  # noqa: E402
     LinkedInSession,
     LoginRequiredError,
@@ -698,7 +688,7 @@ def main() -> None:  # pragma: no cover
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
 
-    _force_utf8_stdout()
+    force_utf8_stdio()
     setup_logger("engagement.linkedin.scrape", level=logging.DEBUG if args.debug else logging.INFO, file_logging=True)
     logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
 

--- a/newsletter/bootstrap_chrome.py
+++ b/newsletter/bootstrap_chrome.py
@@ -136,11 +136,8 @@ def ensure_chrome(*, timeout_s: int = 15) -> int:
 
 def main() -> int:
     # Force UTF-8 stdio so emoji log lines don't crash Windows' cp1252 console.
-    for stream in (sys.stdout, sys.stderr):
-        try:
-            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-        except Exception:
-            pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
     if not logging.getLogger().handlers:
         logging.basicConfig(
             level=logging.INFO,

--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -397,11 +397,8 @@ def run(newsletter_number: str, debug: bool = False, *,
 
 def _setup_logging(debug: bool = False):
     level = logging.DEBUG if debug else logging.INFO
-    for s in (sys.stdout, sys.stderr):
-        try:
-            s.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-        except Exception:
-            pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
     if not logging.getLogger().handlers:
         logging.basicConfig(
             level=level,

--- a/newsletter/dry_run.py
+++ b/newsletter/dry_run.py
@@ -18,11 +18,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 # Console emojis crash on Windows' default cp1252; force UTF-8 stdio.
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-    except Exception:
-        pass
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
 
 from config.logger_config import setup_logger  # noqa: E402
 from newsletter import chrome_tabs, notion_io  # noqa: E402

--- a/newsletter/normalize_names.py
+++ b/newsletter/normalize_names.py
@@ -388,11 +388,8 @@ def run(days: int = 14, dry_run: bool = False, debug: bool = False) -> List[Dict
 def _setup_logging(debug: bool = False):
     level = logging.DEBUG if debug else logging.INFO
     # Re-configure UTF-8 stdio so emoji-bearing log lines don't crash cp1252.
-    for s in (sys.stdout, sys.stderr):
-        try:
-            s.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-        except Exception:
-            pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
     if not logging.getLogger().handlers:
         logging.basicConfig(
             level=level,

--- a/newsletter/normalize_url.py
+++ b/newsletter/normalize_url.py
@@ -210,11 +210,8 @@ def run(days: int = 14, dry_run: bool = False, testing_mode: bool = False,
 
 def _setup_logging(debug: bool = False):
     level = logging.DEBUG if debug else logging.INFO
-    for s in (sys.stdout, sys.stderr):
-        try:
-            s.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-        except Exception:
-            pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
     if not logging.getLogger().handlers:
         logging.basicConfig(
             level=level,

--- a/newsletter/pipeline.py
+++ b/newsletter/pipeline.py
@@ -20,11 +20,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 # Console emojis crash on Windows' default cp1252; force UTF-8 stdio.
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-    except Exception:
-        pass
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
 
 from config.logger_config import setup_logger  # noqa: E402
 from newsletter import (  # noqa: E402

--- a/newsletter_pipeline.py
+++ b/newsletter_pipeline.py
@@ -39,11 +39,8 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 # Force UTF-8 stdio so emoji log lines don't crash Windows' cp1252 console.
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
-    except Exception:
-        pass
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
 
 from newsletter import bootstrap_chrome  # noqa: E402
 from newsletter import build_newsletter, normalize_names, normalize_url  # noqa: E402

--- a/planning/_probe.py
+++ b/planning/_probe.py
@@ -130,13 +130,8 @@ def probe(platform: str, url: Optional[str] = None, *, save_screenshot: bool = T
 def main() -> int:
     # Force UTF-8 stdout so emoji / em-dash in the dump don't crash a cp1252
     # Windows console (same guard the session modules use).
-    for stream in (sys.stdout, sys.stderr):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if callable(reconfigure):
-            try:
-                reconfigure(encoding="utf-8", errors="replace")
-            except Exception:
-                pass
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
     parser = argparse.ArgumentParser(description="Dump live-DOM role+name candidates for a planning platform.")
     parser.add_argument("platform", choices=sorted(_REGISTRY), help="which platform's live page to probe")
     parser.add_argument("--url", default=None, help="override the page URL (defaults to the platform's feed_url)")

--- a/planning/_session_base.py
+++ b/planning/_session_base.py
@@ -1,0 +1,209 @@
+"""Shared Playwright session base for every per-platform planning session.
+
+Each ``planning/<P>/<P>_session.py`` module drives a single social platform
+through **real Chrome** (``channel="chrome"``) with a **dedicated, separate**
+user-data directory. The lifecycle (persistent-context ``__enter__`` /
+``__exit__``), the safety guard that refuses to point at the user's real
+Chrome profile (:func:`_resolve_user_data_dir`), the readiness check, the
+failure-screenshot helper, the logger factory, and :class:`LoginRequiredError`
+are all identical across platforms — they live here, once.
+
+A platform module subclasses :class:`PlatformSession` and declares only what
+actually differs:
+
+* ``platform_name`` — short key (e.g. ``"twitter"``); names the results
+  subdir, the bootstrap module, and the default logger.
+* ``login_markers`` — substrings that, if present in the post-navigation URL,
+  mean the saved session expired.
+* ``session_display`` — human label used in the start/close log lines
+  (defaults to ``platform_name.title()``).
+* ``default_timeout_ms`` — per-platform navigation timeout.
+
+Security note: ``_resolve_user_data_dir`` is the single guard protecting the
+user's real Chrome profile from being opened by automation. It must stay
+single-source here — never re-inline it in a platform module.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Sequence
+
+from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
+
+from config.chrome_launch import STEALTH_INIT_SCRIPT
+from config.chrome_profile_lock import launch_persistent_context_with_lock_wait
+from config.logger_config import setup_logger
+
+# Repo root is two levels up from this file: planning/_session_base.py -> repo.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class LoginRequiredError(RuntimeError):
+    """Raised when a saved platform session is no longer valid.
+
+    Single-source for every platform — modules re-export this name so existing
+    ``from planning.<P>.<P>_session import LoginRequiredError`` imports and
+    ``except LoginRequiredError`` handlers keep working unchanged.
+    """
+
+
+def configure_logger(name: str, debug: bool = False) -> logging.Logger:
+    """Set up a logger using the project-wide pattern."""
+    level = logging.DEBUG if debug else logging.INFO
+    return setup_logger(name, level=level, file_logging=True)
+
+
+def _resolve_user_data_dir(rel_or_abs: str, *, example_subdir: str = "<platform>/chrome_user_data") -> Path:
+    """Resolve ``user_data_dir``; refuse paths that look like the user's real Chrome profile.
+
+    SECURITY-relevant: this is the one guard that stops a mis-configured
+    ``user_data_dir`` from opening (and corrupting) the user's real Chrome
+    profile. Single-source — do not re-inline.
+    """
+    p = Path(rel_or_abs)
+    if not p.is_absolute():
+        p = REPO_ROOT / p
+    resolved = p.resolve() if p.exists() else p
+    danger_substrings = (
+        # Common real-Chrome profile locations across OSes — guard against
+        # accidental config that would point at the user's real profile.
+        "Google/Chrome/User Data",
+        "Google\\Chrome\\User Data",
+        "Chromium/User Data",
+        "Chromium\\User Data",
+        "Library/Application Support/Google/Chrome",
+        ".config/google-chrome",
+    )
+    as_str = str(resolved).replace("\\", "/")
+    for marker in danger_substrings:
+        if marker.replace("\\", "/") in as_str:
+            raise RuntimeError(
+                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
+                "main Chrome profile. Pick a dedicated directory (e.g. "
+                f"'{example_subdir}')."
+            )
+    return p
+
+
+def _user_data_dir_initialized(user_data_dir: Path) -> bool:
+    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
+    return user_data_dir.exists() and (user_data_dir / "Default").exists()
+
+
+class PlatformSession:
+    """Persistent-context wrapper around real Chrome with a dedicated profile.
+
+    Subclasses declare ``platform_name``, ``login_markers`` and (optionally)
+    ``session_display`` / ``default_timeout_ms``. Usage:
+
+        with TwitterSession(cfg) as session:
+            page = session.page
+            session.goto_with_login_check(url)
+    """
+
+    #: Short platform key — names the results subdir, bootstrap module, logger.
+    platform_name: str = ""
+    #: URL substrings that mean the saved session expired (lowercased compare).
+    login_markers: Sequence[str] = ()
+    #: Human label used in the start/close log lines.
+    session_display: Optional[str] = None
+    #: Default navigation timeout in ms for ``goto_with_login_check``.
+    default_timeout_ms: int = 45000
+
+    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
+        if not self.platform_name:
+            raise NotImplementedError("Subclass must set `platform_name`.")
+        self.cfg = cfg
+        self.user_data_dir = _resolve_user_data_dir(
+            cfg["user_data_dir"],
+            example_subdir=f"{self.platform_name}/chrome_user_data",
+        )
+        self.headless = cfg.get("headless", False) if headless is None else headless
+        self.logger = logging.getLogger(f"{self.platform_name}_session")
+        self._playwright: Optional[Playwright] = None
+        self._context: Optional[BrowserContext] = None
+        self._page: Optional[Page] = None
+
+    @property
+    def _display(self) -> str:
+        return self.session_display or self.platform_name.title()
+
+    @property
+    def page(self) -> Page:
+        if self._page is None:
+            raise RuntimeError(
+                f"Session not entered — use `with {type(self).__name__}(cfg) as s:`"
+            )
+        return self._page
+
+    @property
+    def context(self) -> BrowserContext:
+        if self._context is None:
+            raise RuntimeError("Session not entered")
+        return self._context
+
+    def __enter__(self) -> "PlatformSession":
+        if not _user_data_dir_initialized(self.user_data_dir):
+            raise FileNotFoundError(
+                f"Chrome profile at {self.user_data_dir} is empty or missing. "
+                f"Run `python -m {self.platform_name}.bootstrap_session` first."
+            )
+        self._playwright = sync_playwright().start()
+        self._context = launch_persistent_context_with_lock_wait(
+            self._playwright, self.user_data_dir, headless=self.headless, logger=self.logger,
+        )
+        self._context.add_init_script(STEALTH_INIT_SCRIPT)
+        # `launch_persistent_context` opens one default page already.
+        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
+        self.logger.info(
+            "🌐 %s session started (channel=chrome, headless=%s, profile=%s)",
+            self._display, self.headless, self.user_data_dir,
+        )
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # Persistent profile is written to disk automatically; just close cleanly.
+        try:
+            if self._context is not None:
+                self._context.close()
+        finally:
+            if self._playwright is not None:
+                self._playwright.stop()
+            self.logger.info("👋 %s session closed", self._display)
+
+    def goto_with_login_check(self, url: str, *, timeout_ms: Optional[int] = None) -> None:
+        """Navigate to ``url``. Raise :class:`LoginRequiredError` on a login redirect."""
+        self.logger.debug("➡️ Navigating to %s", url)
+        self.page.goto(url, timeout=timeout_ms or self.default_timeout_ms, wait_until="domcontentloaded")
+        current = (self.page.url or "").lower()
+        if any(marker in current for marker in self.login_markers):
+            raise LoginRequiredError(
+                f"{self._display} redirected to login — the saved Chrome profile session "
+                f"expired. Re-run `python -m {self.platform_name}.bootstrap_session` to log in again."
+            )
+
+    def screenshot_failure(self, label: str) -> Path:
+        """Save a debug screenshot under ``results/<platform_name>/``."""
+        out_dir = REPO_ROOT / "results" / self.platform_name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+        path = out_dir / f"{ts}-{label}.png"
+        try:
+            self.page.screenshot(path=str(path), full_page=True)
+            self.logger.warning("📸 Failure screenshot saved → %s", path)
+        except Exception as err:  # pragma: no cover
+            self.logger.error("❌ Could not save failure screenshot: %s", err)
+        return path
+
+
+__all__ = [
+    "REPO_ROOT",
+    "LoginRequiredError",
+    "PlatformSession",
+    "configure_logger",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]

--- a/planning/instagram/instagram_session.py
+++ b/planning/instagram/instagram_session.py
@@ -6,10 +6,15 @@ Drives the Instagram + Facebook scheduling planner at
 configured under ``instagram.user_data_dir``. The user's regular Chrome
 profile is never read or written by anything in this package.
 
-Mirror of ``linkedin/linkedin_session.py`` — see that file for the rationale
-behind real-Chrome + persistent profile + the stealth flags. The only
-substantive difference is the login-detection heuristic: Meta bounces an
-unauthenticated user to ``facebook.com/login.php`` or a checkpoint page.
+Meta bounces an unauthenticated user to ``facebook.com/login.php`` or a
+checkpoint page. Meta is also slower than the other platforms — the SPA fires
+several XHRs before the calendar grid mounts — so this session keeps the base
+class's longer default navigation timeout.
+
+The persistent-context lifecycle, the ``_resolve_user_data_dir`` safety guard,
+the failure-screenshot helper, the logger factory and ``LoginRequiredError``
+all live in :mod:`planning._session_base`; this module only declares what is
+specific to Meta.
 """
 
 from __future__ import annotations
@@ -17,27 +22,34 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
-
-from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
-from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
-from config.logger_config import setup_logger  # noqa: E402
-
-logger = logging.getLogger("instagram_session")
+from planning._session_base import (  # noqa: E402
+    LoginRequiredError,
+    PlatformSession,
+    _resolve_user_data_dir,
+    _user_data_dir_initialized,
+)
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+__all__ = [
+    "InstagramSession",
+    "LoginRequiredError",
+    "configure_logger",
+    "load_instagram_config",
+    "load_clone_config",
+    "load_notion_token",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]
 
 
 def configure_logger(name: str = "instagram", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_instagram_config() -> dict:
@@ -70,127 +82,15 @@ def load_notion_token() -> str:
     return token
 
 
-def _resolve_user_data_dir(rel_or_abs: str) -> Path:
-    """Resolve `user_data_dir`; refuse paths that look like the user's real Chrome profile."""
-    p = Path(rel_or_abs)
-    if not p.is_absolute():
-        p = REPO_ROOT / p
-    resolved = p.resolve() if p.exists() else p
-    danger_substrings = (
-        "Google/Chrome/User Data",
-        "Google\\Chrome\\User Data",
-        "Chromium/User Data",
-        "Chromium\\User Data",
-        "Library/Application Support/Google/Chrome",
-        ".config/google-chrome",
+class InstagramSession(PlatformSession):
+    """Persistent-context Meta (Instagram + Facebook) session — see :class:`PlatformSession`."""
+
+    platform_name = "instagram"
+    session_display = "Instagram (Meta planner)"
+    default_timeout_ms = 45000
+    login_markers = (
+        "facebook.com/login",
+        "/checkpoint",
+        "/two_step_verification",
+        "/recover/",
     )
-    as_str = str(resolved).replace("\\", "/")
-    for marker in danger_substrings:
-        if marker.replace("\\", "/") in as_str:
-            raise RuntimeError(
-                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
-                "main Chrome profile. Pick a dedicated directory (e.g. "
-                "'instagram/chrome_user_data')."
-            )
-    return p
-
-
-def _user_data_dir_initialized(user_data_dir: Path) -> bool:
-    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
-    return user_data_dir.exists() and (user_data_dir / "Default").exists()
-
-
-class InstagramSession:
-    """Persistent-context wrapper around real Chrome with a dedicated profile.
-
-    Usage:
-        with InstagramSession(cfg) as session:
-            page = session.page
-            session.goto_with_login_check(url)
-    """
-
-    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
-        self.cfg = cfg
-        self.user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-        self.headless = cfg.get("headless", False) if headless is None else headless
-        self._playwright: Optional[Playwright] = None
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-
-    @property
-    def page(self) -> Page:
-        if self._page is None:
-            raise RuntimeError("Session not entered — use `with InstagramSession(cfg) as s:`")
-        return self._page
-
-    @property
-    def context(self) -> BrowserContext:
-        if self._context is None:
-            raise RuntimeError("Session not entered")
-        return self._context
-
-    def __enter__(self) -> "InstagramSession":
-        if not _user_data_dir_initialized(self.user_data_dir):
-            raise FileNotFoundError(
-                f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                "Run `python -m instagram.bootstrap_session` first."
-            )
-        self._playwright = sync_playwright().start()
-        self._context = launch_persistent_context_with_lock_wait(
-            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
-        )
-        self._context.add_init_script(STEALTH_INIT_SCRIPT)
-        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
-        logger.info(
-            "🌐 Instagram (Meta planner) session started (channel=chrome, headless=%s, profile=%s)",
-            self.headless, self.user_data_dir,
-        )
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        try:
-            if self._context is not None:
-                self._context.close()
-        finally:
-            if self._playwright is not None:
-                self._playwright.stop()
-            logger.info("👋 Instagram session closed")
-
-    def goto_with_login_check(self, url: str, *, timeout_ms: int = 45000) -> None:
-        """Navigate to `url`. Raise LoginRequiredError if Meta redirected to login.
-
-        Meta is slower than LinkedIn and the planner SPA initialises several
-        XHRs before the calendar grid mounts, so we use a longer default
-        timeout and wait_until='domcontentloaded' rather than networkidle.
-        """
-        logger.debug("➡️ Navigating to %s", url)
-        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-        current = (self.page.url or "").lower()
-        login_markers = (
-            "facebook.com/login",
-            "/checkpoint",
-            "/two_step_verification",
-            "/recover/",
-        )
-        if any(m in current for m in login_markers):
-            raise LoginRequiredError(
-                "Meta redirected to login/checkpoint — the saved Chrome profile session expired. "
-                "Re-run `python -m instagram.bootstrap_session` to log in again."
-            )
-
-    def screenshot_failure(self, label: str) -> Path:
-        """Save a debug screenshot under results/instagram/."""
-        out_dir = REPO_ROOT / "results" / "instagram"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{ts}-{label}.png"
-        try:
-            self.page.screenshot(path=str(path), full_page=True)
-            logger.warning("📸 Failure screenshot saved → %s", path)
-        except Exception as err:
-            logger.error("❌ Could not save failure screenshot: %s", err)
-        return path
-
-
-class LoginRequiredError(RuntimeError):
-    """Raised when the saved Meta session is no longer valid."""

--- a/planning/linkedin/linkedin_session.py
+++ b/planning/linkedin/linkedin_session.py
@@ -3,19 +3,19 @@
 Uses **real Chrome** (channel="chrome") with a **dedicated, separate**
 user-data directory configured under ``linkedin.user_data_dir``. This profile
 is created by the bootstrap script and is completely independent of the user's
-regular Chrome installation:
-
-* Default location is ``linkedin/chrome_user_data/`` inside this repo
-  (gitignored).
-* The user's normal Chrome profile at e.g.
-  ``%LOCALAPPDATA%\\Google\\Chrome\\User Data`` is never opened, read, or
-  written by anything in this package.
+regular Chrome installation — the user's normal Chrome profile is never
+opened, read, or written by anything in this package.
 
 Why real Chrome + persistent profile: Playwright's bundled Chromium is
 trivially fingerprinted by LinkedIn anti-bot checks, which can block sign-in
 and the post composer. Real Chrome with a stable profile presents a normal
 browser environment so the human-driven login at bootstrap actually
 completes, and subsequent automated runs reuse the same session.
+
+The persistent-context lifecycle, the ``_resolve_user_data_dir`` safety guard,
+the failure-screenshot helper, the logger factory and ``LoginRequiredError``
+all live in :mod:`planning._session_base`; this module only declares what is
+specific to LinkedIn.
 """
 
 from __future__ import annotations
@@ -27,17 +27,27 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
-from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
-from config.logger_config import setup_logger  # noqa: E402
-
-logger = logging.getLogger("linkedin_session")
+from planning._session_base import (  # noqa: E402
+    LoginRequiredError,
+    PlatformSession,
+    _resolve_user_data_dir,
+    _user_data_dir_initialized,
+)
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+__all__ = [
+    "LinkedInSession",
+    "LoginRequiredError",
+    "configure_logger",
+    "normalize_day",
+    "load_linkedin_config",
+    "load_notion_token",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]
 
 
 def normalize_day(date_str: Optional[str]) -> str:
@@ -52,8 +62,7 @@ def normalize_day(date_str: Optional[str]) -> str:
 
 def configure_logger(name: str = "linkedin", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_linkedin_config() -> dict:
@@ -76,118 +85,11 @@ def load_notion_token() -> str:
     return token
 
 
-def _resolve_user_data_dir(rel_or_abs: str) -> Path:
-    """Resolve `user_data_dir`; refuse paths that look like the user's real Chrome profile."""
-    p = Path(rel_or_abs)
-    if not p.is_absolute():
-        p = REPO_ROOT / p
-    resolved = p.resolve() if p.exists() else p
-    danger_substrings = (
-        "Google/Chrome/User Data",
-        "Google\\Chrome\\User Data",
-        "Chromium/User Data",
-        "Chromium\\User Data",
-        "Library/Application Support/Google/Chrome",
-        ".config/google-chrome",
-    )
-    as_str = str(resolved).replace("\\", "/")
-    for marker in danger_substrings:
-        if marker.replace("\\", "/") in as_str:
-            raise RuntimeError(
-                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
-                "main Chrome profile. Pick a dedicated directory (e.g. "
-                "'linkedin/chrome_user_data')."
-            )
-    return p
+class LinkedInSession(PlatformSession):
+    """Persistent-context LinkedIn session — see :class:`PlatformSession`."""
 
-
-def _user_data_dir_initialized(user_data_dir: Path) -> bool:
-    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
-    return user_data_dir.exists() and (user_data_dir / "Default").exists()
-
-
-class LinkedInSession:
-    """Persistent-context wrapper around real Chrome with a dedicated profile.
-
-    Usage:
-        with LinkedInSession(cfg) as session:
-            page = session.page
-            session.goto_with_login_check(url)
-    """
-
-    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
-        self.cfg = cfg
-        self.user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-        self.headless = cfg.get("headless", False) if headless is None else headless
-        self._playwright: Optional[Playwright] = None
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-
-    @property
-    def page(self) -> Page:
-        if self._page is None:
-            raise RuntimeError("Session not entered — use `with LinkedInSession(cfg) as s:`")
-        return self._page
-
-    @property
-    def context(self) -> BrowserContext:
-        if self._context is None:
-            raise RuntimeError("Session not entered")
-        return self._context
-
-    def __enter__(self) -> "LinkedInSession":
-        if not _user_data_dir_initialized(self.user_data_dir):
-            raise FileNotFoundError(
-                f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                "Run `python -m linkedin.bootstrap_session` first."
-            )
-        self._playwright = sync_playwright().start()
-        self._context = launch_persistent_context_with_lock_wait(
-            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
-        )
-        self._context.add_init_script(STEALTH_INIT_SCRIPT)
-        # `launch_persistent_context` opens one default page already.
-        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
-        logger.info(
-            "🌐 LinkedIn session started (channel=chrome, headless=%s, profile=%s)",
-            self.headless, self.user_data_dir,
-        )
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        try:
-            if self._context is not None:
-                self._context.close()
-        finally:
-            if self._playwright is not None:
-                self._playwright.stop()
-            logger.info("👋 LinkedIn session closed")
-
-    def goto_with_login_check(self, url: str, *, timeout_ms: int = 30000) -> None:
-        """Navigate to `url`. Raise LoginRequiredError if LinkedIn redirected to login."""
-        logger.debug("➡️ Navigating to %s", url)
-        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-        current = (self.page.url or "").lower()
-        # LinkedIn bounces unauthenticated users to /login, /uas/login, or /checkpoint.
-        if any(s in current for s in ("/login", "/uas/login", "/checkpoint/lg/login")):
-            raise LoginRequiredError(
-                "LinkedIn redirected to login — the saved Chrome profile session expired. "
-                "Re-run `python -m linkedin.bootstrap_session` to log in again."
-            )
-
-    def screenshot_failure(self, label: str) -> Path:
-        """Save a debug screenshot under results/linkedin/."""
-        out_dir = REPO_ROOT / "results" / "linkedin"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{ts}-{label}.png"
-        try:
-            self.page.screenshot(path=str(path), full_page=True)
-            logger.warning("📸 Failure screenshot saved → %s", path)
-        except Exception as err:  # pragma: no cover
-            logger.error("❌ Could not save failure screenshot: %s", err)
-        return path
-
-
-class LoginRequiredError(RuntimeError):
-    """Raised when the saved LinkedIn session is no longer valid."""
+    platform_name = "linkedin"
+    session_display = "LinkedIn"
+    default_timeout_ms = 30000
+    # LinkedIn bounces unauthenticated users to /login, /uas/login, or /checkpoint.
+    login_markers = ("/login", "/uas/login", "/checkpoint/lg/login")

--- a/planning/substack/substack_session.py
+++ b/planning/substack/substack_session.py
@@ -3,18 +3,20 @@
 Uses **real Chrome** (channel="chrome") with a **dedicated, separate**
 user-data directory configured under ``substack.user_data_dir``. This profile
 is created by the bootstrap script and is completely independent of the user's
-regular Chrome installation:
-
-* Default location is ``substack/chrome_user_data/`` inside this repo
-  (gitignored).
-* The user's normal Chrome profile at e.g.
-  ``%LOCALAPPDATA%\\Google\\Chrome\\User Data`` is never opened, read, or
-  written by anything in this package.
+regular Chrome installation — the user's normal Chrome profile is never
+opened, read, or written by anything in this package.
 
 Why real Chrome + persistent profile: Playwright's bundled Chromium is
 trivially fingerprinted by reCAPTCHA, which blocks the sign-in flow. Real
 Chrome with a stable profile presents a normal browser environment so the
-human-driven login at bootstrap actually completes.
+human-driven login at bootstrap actually completes. No browser binary
+download is required — Playwright drives the user's already-installed Chrome
+via ``channel="chrome"``.
+
+The persistent-context lifecycle, the ``_resolve_user_data_dir`` safety guard,
+the failure-screenshot helper, the logger factory and ``LoginRequiredError``
+all live in :mod:`planning._session_base`; this module only declares what is
+specific to Substack.
 """
 
 from __future__ import annotations
@@ -26,17 +28,27 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
-from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
-from config.logger_config import setup_logger  # noqa: E402
-
-logger = logging.getLogger("substack_session")
+from planning._session_base import (  # noqa: E402
+    LoginRequiredError,
+    PlatformSession,
+    _resolve_user_data_dir,
+    _user_data_dir_initialized,
+)
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+__all__ = [
+    "SubstackSession",
+    "LoginRequiredError",
+    "configure_logger",
+    "normalize_day",
+    "load_substack_config",
+    "load_notion_token",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]
 
 
 def normalize_day(date_str: Optional[str]) -> str:
@@ -55,8 +67,7 @@ def normalize_day(date_str: Optional[str]) -> str:
 
 def configure_logger(name: str = "substack", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_substack_config() -> dict:
@@ -79,123 +90,10 @@ def load_notion_token() -> str:
     return token
 
 
-def _resolve_user_data_dir(rel_or_abs: str) -> Path:
-    """Resolve `user_data_dir`; refuse paths that look like the user's real Chrome profile."""
-    p = Path(rel_or_abs)
-    if not p.is_absolute():
-        p = REPO_ROOT / p
-    resolved = p.resolve() if p.exists() else p
-    danger_substrings = (
-        # Common real-Chrome profile locations across OSes — guard against
-        # accidental config that would point at the user's real profile.
-        "Google/Chrome/User Data",
-        "Google\\Chrome\\User Data",
-        "Chromium/User Data",
-        "Chromium\\User Data",
-        "Library/Application Support/Google/Chrome",
-        ".config/google-chrome",
-    )
-    as_str = str(resolved).replace("\\", "/")
-    for marker in danger_substrings:
-        if marker.replace("\\", "/") in as_str:
-            raise RuntimeError(
-                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
-                "main Chrome profile. Pick a dedicated directory (e.g. "
-                "'substack/chrome_user_data')."
-            )
-    return p
+class SubstackSession(PlatformSession):
+    """Persistent-context Substack session — see :class:`PlatformSession`."""
 
-
-def _user_data_dir_initialized(user_data_dir: Path) -> bool:
-    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
-    return user_data_dir.exists() and (user_data_dir / "Default").exists()
-
-
-class SubstackSession:
-    """Persistent-context wrapper around real Chrome with a dedicated profile.
-
-    Usage:
-        with SubstackSession(cfg) as session:
-            page = session.page
-            session.goto_with_login_check(url)
-
-    No browser binary download is required — Playwright drives the user's
-    already-installed Chrome via ``channel="chrome"``.
-    """
-
-    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
-        self.cfg = cfg
-        self.user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-        self.headless = cfg.get("headless", False) if headless is None else headless
-        self._playwright: Optional[Playwright] = None
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-
-    @property
-    def page(self) -> Page:
-        if self._page is None:
-            raise RuntimeError("Session not entered — use `with SubstackSession(cfg) as s:`")
-        return self._page
-
-    @property
-    def context(self) -> BrowserContext:
-        if self._context is None:
-            raise RuntimeError("Session not entered")
-        return self._context
-
-    def __enter__(self) -> "SubstackSession":
-        if not _user_data_dir_initialized(self.user_data_dir):
-            raise FileNotFoundError(
-                f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                "Run `python -m substack.bootstrap_session` first."
-            )
-        self._playwright = sync_playwright().start()
-        self._context = launch_persistent_context_with_lock_wait(
-            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
-        )
-        self._context.add_init_script(STEALTH_INIT_SCRIPT)
-        # `launch_persistent_context` opens one default page already.
-        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
-        logger.info(
-            "🌐 Substack session started (channel=chrome, headless=%s, profile=%s)",
-            self.headless, self.user_data_dir,
-        )
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        # Persistent profile is written to disk automatically; just close cleanly.
-        try:
-            if self._context is not None:
-                self._context.close()
-        finally:
-            if self._playwright is not None:
-                self._playwright.stop()
-            logger.info("👋 Substack session closed")
-
-    def goto_with_login_check(self, url: str, *, timeout_ms: int = 30000) -> None:
-        """Navigate to `url`. Raise LoginRequiredError if Substack redirected to sign-in."""
-        logger.debug("➡️ Navigating to %s", url)
-        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-        current = self.page.url or ""
-        if "sign-in" in current.lower():
-            raise LoginRequiredError(
-                "Substack redirected to sign-in — the saved Chrome profile session expired. "
-                "Re-run `python -m substack.bootstrap_session` to log in again."
-            )
-
-    def screenshot_failure(self, label: str) -> Path:
-        """Save a debug screenshot under results/substack/."""
-        out_dir = REPO_ROOT / "results" / "substack"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{ts}-{label}.png"
-        try:
-            self.page.screenshot(path=str(path), full_page=True)
-            logger.warning("📸 Failure screenshot saved → %s", path)
-        except Exception as err:  # pragma: no cover
-            logger.error("❌ Could not save failure screenshot: %s", err)
-        return path
-
-
-class LoginRequiredError(RuntimeError):
-    """Raised when the saved Substack session is no longer valid."""
+    platform_name = "substack"
+    session_display = "Substack"
+    default_timeout_ms = 30000
+    login_markers = ("sign-in",)

--- a/planning/threads/threads_session.py
+++ b/planning/threads/threads_session.py
@@ -6,10 +6,13 @@ Drives the Threads composer + native scheduler at
 configured under ``threads.user_data_dir``. The user's regular Chrome
 profile is never read or written by anything in this package.
 
-Mirror of ``instagram/instagram_session.py`` — see that file for the
-rationale behind real-Chrome + persistent profile + the stealth flags.
 Threads authenticates via Instagram, so login redirects may bounce through
 ``instagram.com/accounts/login`` as well as ``threads.com/login``.
+
+The persistent-context lifecycle, the ``_resolve_user_data_dir`` safety guard,
+the failure-screenshot helper, the logger factory and ``LoginRequiredError``
+all live in :mod:`planning._session_base`; this module only declares what is
+specific to Threads.
 """
 
 from __future__ import annotations
@@ -17,27 +20,33 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
-
-from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
-from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
-from config.logger_config import setup_logger  # noqa: E402
-
-logger = logging.getLogger("threads_session")
+from planning._session_base import (  # noqa: E402
+    LoginRequiredError,
+    PlatformSession,
+    _resolve_user_data_dir,
+    _user_data_dir_initialized,
+)
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+__all__ = [
+    "ThreadsSession",
+    "LoginRequiredError",
+    "configure_logger",
+    "load_threads_config",
+    "load_notion_token",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]
 
 
 def configure_logger(name: str = "threads", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_threads_config() -> dict:
@@ -60,122 +69,15 @@ def load_notion_token() -> str:
     return token
 
 
-def _resolve_user_data_dir(rel_or_abs: str) -> Path:
-    """Resolve `user_data_dir`; refuse paths that look like the user's real Chrome profile."""
-    p = Path(rel_or_abs)
-    if not p.is_absolute():
-        p = REPO_ROOT / p
-    resolved = p.resolve() if p.exists() else p
-    danger_substrings = (
-        "Google/Chrome/User Data",
-        "Google\\Chrome\\User Data",
-        "Chromium/User Data",
-        "Chromium\\User Data",
-        "Library/Application Support/Google/Chrome",
-        ".config/google-chrome",
+class ThreadsSession(PlatformSession):
+    """Persistent-context Threads session — see :class:`PlatformSession`."""
+
+    platform_name = "threads"
+    session_display = "Threads"
+    default_timeout_ms = 45000
+    login_markers = (
+        "threads.com/login",
+        "threads.net/login",
+        "instagram.com/accounts/login",
+        "/accounts/login",
     )
-    as_str = str(resolved).replace("\\", "/")
-    for marker in danger_substrings:
-        if marker.replace("\\", "/") in as_str:
-            raise RuntimeError(
-                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
-                "main Chrome profile. Pick a dedicated directory (e.g. "
-                "'threads/chrome_user_data')."
-            )
-    return p
-
-
-def _user_data_dir_initialized(user_data_dir: Path) -> bool:
-    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
-    return user_data_dir.exists() and (user_data_dir / "Default").exists()
-
-
-class ThreadsSession:
-    """Persistent-context wrapper around real Chrome with a dedicated profile.
-
-    Usage:
-        with ThreadsSession(cfg) as session:
-            page = session.page
-            session.goto_with_login_check(url)
-    """
-
-    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
-        self.cfg = cfg
-        self.user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-        self.headless = cfg.get("headless", False) if headless is None else headless
-        self._playwright: Optional[Playwright] = None
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-
-    @property
-    def page(self) -> Page:
-        if self._page is None:
-            raise RuntimeError("Session not entered — use `with ThreadsSession(cfg) as s:`")
-        return self._page
-
-    @property
-    def context(self) -> BrowserContext:
-        if self._context is None:
-            raise RuntimeError("Session not entered")
-        return self._context
-
-    def __enter__(self) -> "ThreadsSession":
-        if not _user_data_dir_initialized(self.user_data_dir):
-            raise FileNotFoundError(
-                f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                "Run `python -m threads.bootstrap_session` first."
-            )
-        self._playwright = sync_playwright().start()
-        self._context = launch_persistent_context_with_lock_wait(
-            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
-        )
-        self._context.add_init_script(STEALTH_INIT_SCRIPT)
-        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
-        logger.info(
-            "🌐 Threads session started (channel=chrome, headless=%s, profile=%s)",
-            self.headless, self.user_data_dir,
-        )
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        try:
-            if self._context is not None:
-                self._context.close()
-        finally:
-            if self._playwright is not None:
-                self._playwright.stop()
-            logger.info("👋 Threads session closed")
-
-    def goto_with_login_check(self, url: str, *, timeout_ms: int = 45000) -> None:
-        """Navigate to `url`. Raise LoginRequiredError if Threads redirected to login."""
-        logger.debug("➡️ Navigating to %s", url)
-        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-        current = (self.page.url or "").lower()
-        login_markers = (
-            "threads.com/login",
-            "threads.net/login",
-            "instagram.com/accounts/login",
-            "/accounts/login",
-        )
-        if any(m in current for m in login_markers):
-            raise LoginRequiredError(
-                "Threads redirected to login — the saved Chrome profile session expired. "
-                "Re-run `python -m threads.bootstrap_session` to log in again."
-            )
-
-    def screenshot_failure(self, label: str) -> Path:
-        """Save a debug screenshot under results/threads/."""
-        out_dir = REPO_ROOT / "results" / "threads"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{ts}-{label}.png"
-        try:
-            self.page.screenshot(path=str(path), full_page=True)
-            logger.warning("📸 Failure screenshot saved → %s", path)
-        except Exception as err:
-            logger.error("❌ Could not save failure screenshot: %s", err)
-        return path
-
-
-class LoginRequiredError(RuntimeError):
-    """Raised when the saved Threads session is no longer valid."""

--- a/planning/twitter/twitter_session.py
+++ b/planning/twitter/twitter_session.py
@@ -5,8 +5,10 @@ Uses **real Chrome** (channel="chrome") with a **dedicated, separate**
 user-data directory configured under ``twitter.user_data_dir``. The user's
 regular Chrome profile is never read or written by anything in this package.
 
-Mirror of ``instagram/instagram_session.py`` — see that file for the
-rationale behind real-Chrome + persistent profile + the stealth flags.
+The persistent-context lifecycle, the ``_resolve_user_data_dir`` safety guard,
+the failure-screenshot helper, the logger factory and ``LoginRequiredError``
+all live in :mod:`planning._session_base`; this module only declares what is
+specific to X.
 """
 
 from __future__ import annotations
@@ -14,27 +16,35 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Optional
-
-from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwright
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT  # noqa: E402
-from config.chrome_profile_lock import launch_persistent_context_with_lock_wait  # noqa: E402
-from config.logger_config import setup_logger  # noqa: E402
-
-logger = logging.getLogger("twitter_session")
+from planning._session_base import (  # noqa: E402
+    LoginRequiredError,
+    PlatformSession,
+    _resolve_user_data_dir,
+    _user_data_dir_initialized,
+)
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Re-exported so callers' `except LoginRequiredError` / `_resolve_user_data_dir`
+# / `_user_data_dir_initialized` imports keep resolving against this module.
+__all__ = [
+    "TwitterSession",
+    "LoginRequiredError",
+    "configure_logger",
+    "load_twitter_config",
+    "load_notion_token",
+    "_resolve_user_data_dir",
+    "_user_data_dir_initialized",
+]
 
 
 def configure_logger(name: str = "twitter", debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_twitter_config() -> dict:
@@ -57,122 +67,15 @@ def load_notion_token() -> str:
     return token
 
 
-def _resolve_user_data_dir(rel_or_abs: str) -> Path:
-    """Resolve `user_data_dir`; refuse paths that look like the user's real Chrome profile."""
-    p = Path(rel_or_abs)
-    if not p.is_absolute():
-        p = REPO_ROOT / p
-    resolved = p.resolve() if p.exists() else p
-    danger_substrings = (
-        "Google/Chrome/User Data",
-        "Google\\Chrome\\User Data",
-        "Chromium/User Data",
-        "Chromium\\User Data",
-        "Library/Application Support/Google/Chrome",
-        ".config/google-chrome",
+class TwitterSession(PlatformSession):
+    """Persistent-context X session — see :class:`PlatformSession`."""
+
+    platform_name = "twitter"
+    session_display = "Twitter (x.com)"
+    default_timeout_ms = 45000
+    login_markers = (
+        "x.com/i/flow/login",
+        "twitter.com/i/flow/login",
+        "x.com/login",
+        "twitter.com/login",
     )
-    as_str = str(resolved).replace("\\", "/")
-    for marker in danger_substrings:
-        if marker.replace("\\", "/") in as_str:
-            raise RuntimeError(
-                f"Refusing to use user_data_dir={resolved!r} — it looks like the "
-                "main Chrome profile. Pick a dedicated directory (e.g. "
-                "'twitter/chrome_user_data')."
-            )
-    return p
-
-
-def _user_data_dir_initialized(user_data_dir: Path) -> bool:
-    """A persistent-profile directory is 'ready' once Chrome has written its Default subdir."""
-    return user_data_dir.exists() and (user_data_dir / "Default").exists()
-
-
-class TwitterSession:
-    """Persistent-context wrapper around real Chrome with a dedicated profile.
-
-    Usage:
-        with TwitterSession(cfg) as session:
-            page = session.page
-            session.goto_with_login_check(url)
-    """
-
-    def __init__(self, cfg: dict, *, headless: Optional[bool] = None):
-        self.cfg = cfg
-        self.user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-        self.headless = cfg.get("headless", False) if headless is None else headless
-        self._playwright: Optional[Playwright] = None
-        self._context: Optional[BrowserContext] = None
-        self._page: Optional[Page] = None
-
-    @property
-    def page(self) -> Page:
-        if self._page is None:
-            raise RuntimeError("Session not entered — use `with TwitterSession(cfg) as s:`")
-        return self._page
-
-    @property
-    def context(self) -> BrowserContext:
-        if self._context is None:
-            raise RuntimeError("Session not entered")
-        return self._context
-
-    def __enter__(self) -> "TwitterSession":
-        if not _user_data_dir_initialized(self.user_data_dir):
-            raise FileNotFoundError(
-                f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                "Run `python -m twitter.bootstrap_session` first."
-            )
-        self._playwright = sync_playwright().start()
-        self._context = launch_persistent_context_with_lock_wait(
-            self._playwright, self.user_data_dir, headless=self.headless, logger=logger,
-        )
-        self._context.add_init_script(STEALTH_INIT_SCRIPT)
-        self._page = self._context.pages[0] if self._context.pages else self._context.new_page()
-        logger.info(
-            "🌐 Twitter (x.com) session started (channel=chrome, headless=%s, profile=%s)",
-            self.headless, self.user_data_dir,
-        )
-        return self
-
-    def __exit__(self, exc_type, exc, tb) -> None:
-        try:
-            if self._context is not None:
-                self._context.close()
-        finally:
-            if self._playwright is not None:
-                self._playwright.stop()
-            logger.info("👋 Twitter session closed")
-
-    def goto_with_login_check(self, url: str, *, timeout_ms: int = 45000) -> None:
-        """Navigate to `url`. Raise LoginRequiredError if x.com redirected to login."""
-        logger.debug("➡️ Navigating to %s", url)
-        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
-        current = (self.page.url or "").lower()
-        login_markers = (
-            "x.com/i/flow/login",
-            "twitter.com/i/flow/login",
-            "x.com/login",
-            "twitter.com/login",
-        )
-        if any(m in current for m in login_markers):
-            raise LoginRequiredError(
-                "X redirected to login — the saved Chrome profile session expired. "
-                "Re-run `python -m twitter.bootstrap_session` to log in again."
-            )
-
-    def screenshot_failure(self, label: str) -> Path:
-        """Save a debug screenshot under results/twitter/."""
-        out_dir = REPO_ROOT / "results" / "twitter"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        path = out_dir / f"{ts}-{label}.png"
-        try:
-            self.page.screenshot(path=str(path), full_page=True)
-            logger.warning("📸 Failure screenshot saved → %s", path)
-        except Exception as err:
-            logger.error("❌ Could not save failure screenshot: %s", err)
-        return path
-
-
-class LoginRequiredError(RuntimeError):
-    """Raised when the saved X session is no longer valid."""

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.logger_config import setup_logger  # noqa: E402
+from planning._session_base import configure_logger as _configure_logger  # noqa: E402
 from reporting.notion.editorial import (  # noqa: E402
     get_field,
     get_page_body_text,
@@ -73,8 +73,7 @@ class ClipPayload:
 
 
 def configure_logger(name: str = "videos", debug: bool = False) -> logging.Logger:
-    level = logging.DEBUG if debug else logging.INFO
-    return setup_logger(name, level=level, file_logging=True)
+    return _configure_logger(name, debug=debug)
 
 
 def load_videos_config() -> dict:

--- a/planning_pipeline.py
+++ b/planning_pipeline.py
@@ -32,21 +32,15 @@ import json
 import logging
 import sys
 import time
-
-# Console can be cp1252 on Windows; force UTF-8 so emoji in summaries don't blow up.
-for _stream in (sys.stdout, sys.stderr):
-    reconfigure = getattr(_stream, "reconfigure", None)
-    if callable(reconfigure):
-        try:
-            reconfigure(encoding="utf-8", errors="replace")
-        except Exception:
-            pass
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Optional
 
 sys.path.append(str(Path(__file__).parent))
+# Console can be cp1252 on Windows; force UTF-8 so emoji in summaries don't blow up.
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
 from config.logger_config import setup_logger  # noqa: E402
 from planning._failure import classify as classify_failure, extract_screenshot  # noqa: E402
 from planning.instagram.clone_to_other_platforms import main as run_clone  # noqa: E402

--- a/reporting/notion/next_relation_check.py
+++ b/reporting/notion/next_relation_check.py
@@ -19,12 +19,10 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
-if hasattr(sys.stdout, "reconfigure"):
-    sys.stdout.reconfigure(encoding="utf-8")
-    sys.stderr.reconfigure(encoding="utf-8")
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.logger_config import setup_logger
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
+from config.logger_config import setup_logger  # noqa: E402
 from reporting.notion import notion_update as _nu
 from reporting.notion.notion_update import (
     format_database_id,

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -18,18 +18,12 @@ import logging
 from pathlib import Path
 from datetime import datetime, timedelta
 
-# Console can be cp1252 on Windows; force UTF-8 so emoji in logs don't blow up.
-for _stream in (sys.stdout, sys.stderr):
-    reconfigure = getattr(_stream, "reconfigure", None)
-    if callable(reconfigure):
-        try:
-            reconfigure(encoding="utf-8", errors="replace")
-        except Exception:
-            pass
-
 # Add the current directory to the Python path
 sys.path.append(str(Path(__file__).parent))
-from config.logger_config import setup_logger
+# Console can be cp1252 on Windows; force UTF-8 so emoji in logs don't blow up.
+from config.console import force_utf8_stdio  # noqa: E402
+force_utf8_stdio()
+from config.logger_config import setup_logger  # noqa: E402
 from reporting.social_client.social_api_client import (
     main as run_social_api_client,
     configure_logger as configure_social_logger,


### PR DESCRIPTION
## Summary

- Extracts a `PlatformSession` base class into `planning/_session_base.py` carrying the full persistent-context lifecycle, the security-relevant `_resolve_user_data_dir` guard (now single-source — was byte-for-byte identical across 6 session modules), `screenshot_failure`, `configure_logger`, and `LoginRequiredError`.
- Each of the 5 platform session modules (`instagram`, `linkedin`, `substack`, `threads`, `twitter`) becomes a thin subclass declaring only `platform_name`, `login_markers`, `session_display`, and `default_timeout_ms`. All existing `from planning.<P>.<P>_session import ...` import sites remain unchanged — the symbols are re-exported from each module.
- Adds `config/console.py` with a single `force_utf8_stdio()` helper, replacing ~13 identical inline `for _stream in (sys.stdout, sys.stderr): _stream.reconfigure(...)` loops hand-copied across entry points.
- Net: -588 lines, 0 behavior changes.

## Validation

Gate: `py_compile` on all 26 changed files — PASS.

Import smoke + behavioral checks via project venv:
- 5 session modules import cleanly
- Each subclass has `platform_name`, `login_markers`, `default_timeout_ms`, `goto_with_login_check`
- `_resolve_user_data_dir` raises `RuntimeError` on a real-Chrome-profile path (guard still blocks)
- Safe path (dedicated `chrome_user_data/`) resolves without error

Closes #52