### PR TITLE
feat(substack): native HTTP API path — follower count (default) + manual archive/create [P1 of #91]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ reporting/process/.env
 # nothing to do with the user's regular ~/Chrome User Data profile.
 planning/substack/chrome_user_data/
 planning/linkedin/chrome_user_data/
+# Native Substack API session cache (live auth cookies + UA) — never commit.
+/planning/substack/api_session.json
 planning/twitter/chrome_user_data/
 planning/threads/chrome_user_data/
 planning/instagram/chrome_user_data/

--- a/README.md
+++ b/README.md
@@ -287,8 +287,19 @@ Copy-Item config\config_example.json config\config.json
 Each `<platform>_<data_type>` block in `config/config.json` carries a
 `"source"` key. The dispatcher in
 `reporting/social_client/social_api_client.py::get_api_data` reads it and
-either makes the HTTP call (`"rapidapi"`) or delegates to the matching
-`reporting.scrape_client.<platform>.fetch_<data_type>` (`"playwright"`).
+either makes the HTTP call (`"rapidapi"`), delegates to the matching
+`reporting.scrape_client.<platform>.fetch_<data_type>` (`"playwright"`), or
+delegates to `reporting.scrape_client.<platform>_native.fetch_<data_type>`
+(`"native"` — the platform's own HTTP API with cookie auth, no browser).
+
+**Substack native API:** `substack_profile.source` defaults to `"native"`,
+fetching the follower count via a single authenticated GET instead of a headed
+Chrome scrape. It needs a one-time cookie harvest
+(`python -m planning.substack.extract_session`, re-run ~quarterly when the
+cookie expires); flip back to `"playwright"` to use the browser scrape. See
+[`docs/substack-native-api.md`](docs/substack-native-api.md) and
+[`planning/substack/README.md`](planning/substack/README.md). `"native"` is
+Substack-only for now (the follower count); other platforms use rapidapi/playwright.
 
 The downstream pipeline is source-agnostic — `data_processor` reads the
 JSON envelope from `results/raw/<platform>_<data_type>_<YYYY-MM-DD>.json`

--- a/docs/substack-native-api.md
+++ b/docs/substack-native-api.md
@@ -1,0 +1,106 @@
+# Substack native HTTP API integration
+
+How this repo talks to Substack over its private HTTP API (cookie-auth) instead
+of driving a browser, and why. Companion to `planning/substack/DESIGN.md` (the
+Playwright integration, which is **kept** as an alternative path — this does not
+replace it). Originated from the spike in issue #91.
+
+## Why a native path
+
+The Playwright integration works but is fragile: DOM selectors, a persistent
+real-Chrome profile (single-instance lock, serialized access), reCAPTCHA at
+sign-in, and a headed browser launch per run. Substack's *official* Developer API
+is a single profile-search endpoint — it cannot read posts, write posts, or read
+the follower count, so it covers nothing we need.
+
+Everything we actually want is reachable through the private endpoints the
+Substack web app itself calls, authenticated with **our own session cookie**.
+This is authenticated HTTP to our own account — no captcha bypass and no
+fingerprint spoofing (a different, lighter category than the anti-bot concerns in
+`DESIGN.md`). Functionally it is *more* robust than the Playwright path: no DOM
+selectors, no reCAPTCHA, no shared-profile lock, no headed launch. The trade-off
+is that these endpoints are **undocumented and can change without notice**.
+
+## Authentication: cookie harvest, not password
+
+We never store a Substack password. The session cookie is harvested from the
+dedicated Chrome profile that `bootstrap_session` already logs in:
+
+1. `extract_session.py` launches that profile via `SubstackSession` (real Chrome),
+   confirms the login is still valid, then reads `context.cookies()` and the
+   browser User-Agent, and writes `planning/substack/api_session.json` (gitignored).
+2. `api_client.py::load_session` builds a `requests.Session` from those cookies +
+   UA for every subsequent call — **no browser launch** until the cookie expires.
+
+### Cookies that matter
+
+| Cookie | Role | Observed lifetime |
+| --- | --- | --- |
+| `substack.sid` | The session auth cookie (httpOnly). | ~89 days |
+| `substack.lli` | Login companion. | ~89 days |
+| `cf_clearance` | Cloudflare bot-clearance token. | ~1 year |
+| `__cf_bm` | Cloudflare bot-management, short-lived. | ~30 min |
+
+Two practical consequences:
+
+- **The User-Agent must match.** `cf_clearance` is bound to the UA that solved
+  Cloudflare's challenge, so the HTTP session presents the same UA captured at
+  harvest time. A mismatched UA risks a Cloudflare block.
+- **Re-harvest cadence is ~quarterly.** `substack.sid` lives ~89 days — much
+  longer than the Playwright README implied. On 401/403 the client raises
+  `SessionExpiredError`, the signal to re-run `extract_session` (same cadence as
+  re-running `bootstrap_session`).
+
+## Endpoint map (what the spike proved)
+
+All under `https://substack.com/api/v1` unless noted. Write/pull beyond the
+follower count goes through the `python-substack` library (it owns publication
+resolution and the ProseMirror body builder); the follower count is a direct GET
+to avoid the library's construction-time round-trips.
+
+| Capability | Route | Notes |
+| --- | --- | --- |
+| Follower count | `GET /user/profile/self` → `followerCount` | Same integer the Playwright "Total followers (N)" scrape reads. Daily path. |
+| List published posts | `GET /<pub>/post_management/published` | Returns an envelope `{posts, total, …}`; posts carry `title`/`slug`/`post_date`/`type`/`audience` but **no** body or `canonical_url`. |
+| Full post body | `GET /<pub>/posts/by-id/{id}` | Adds `body_html` + `canonical_url`. One extra GET per post (`--with-body`). |
+| Create draft | `POST /<pub>/drafts` | Private; emails no one. |
+| Edit draft | `PUT /<pub>/drafts/{id}` | |
+| Pre-publish validate | `GET /<pub>/drafts/{id}/prepublish` | Returns `{errors, suggestions}`; does not publish. |
+| Publish | `POST /<pub>/drafts/{id}/publish` | **Irreversible** — emails the whole list. Gated behind explicit `--confirm`; never in the cron. |
+
+## How it wires into the reporting pipeline
+
+`reporting/social_client/social_api_client.py::get_api_data` dispatches on a
+`source` field per config block:
+
+- `"playwright"` → `reporting/scrape_client/<platform>.py`
+- `"native"` → `reporting/scrape_client/<platform>_native.py` (new)
+- otherwise → RapidAPI
+
+`substack_profile.source = "native"` routes the daily follower count to
+`substack_native.fetch_profile`, which returns the identical `{"num_followers": N}`
+envelope, so `save_results` → `data_processor` → `profile_aggregator` →
+`notion_update` are all unchanged. Flip the flag back to `"playwright"` to fall
+back to the browser scrape. The block keeps its `api_url`/`api_key` keys because
+the endpoint loop only iterates blocks that have an `api_url`.
+
+## Known fragility (be honest)
+
+- Endpoints are undocumented and can change without notice. Concrete example: the
+  `python-substack` helper `get_publication_subscriber_count` is already stale —
+  it reads a `subscriberCount` key the endpoint no longer returns (it now returns
+  a `subscribers` *list*). We don't rely on that helper.
+- The library's `get_published_posts` returns the raw envelope; callers must
+  unwrap `["posts"]` (`SubstackAPI.list_published` does this).
+- Notes (the daily Note posting + note-engagement scrape) use a different endpoint
+  family that the spike did **not** reverse-engineer; those stay on Playwright for
+  now.
+- No rate limiting was observed across the spike's calls, but it is unmeasured at
+  daily-cron scale.
+
+## Scope today vs. follow-ups
+
+Shipped: native follower count (daily default) + manual archive pull + manual
+draft create/edit/prepublish/publish. Deferred: wiring create/publish to the
+Notion editorial database; migrating Note posting + note-engagement off Playwright;
+"like" support. Tracked on issue #91.

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -24,6 +24,60 @@ refuses to start if `user_data_dir` resolves to a path that looks like a real
 Chrome profile location (`Google/Chrome/User Data`, `Library/Application
 Support/Google/Chrome`, etc.).
 
+## Native HTTP API path (cookie-auth) — preferred for the follower count
+
+Alongside the Playwright automation above, this package also talks to Substack's
+private HTTP API directly with the session cookie (no browser, no DOM selectors,
+no reCAPTCHA, no profile lock). It is the **default source for the daily follower
+count** and provides manual tools to pull an archive and create/publish editions.
+The Playwright path is **kept** as an alternative source — nothing here removes it.
+See `docs/substack-native-api.md` for the design, endpoint map, and fragility notes.
+
+Modules:
+
+```
+api_client.py        — session loader + fetch_follower_count() + SubstackAPI (pull/create/publish)
+extract_session.py   — harvest cookies+UA from the Chrome profile → api_session.json (gitignored)
+api_pull.py          — manual CLI: dump a post archive to JSON
+api_create.py        — manual CLI: create a draft edition (publish only with --confirm)
+```
+
+One-time / once-per-~89-days setup (the `substack.sid` cookie lives ~89 days):
+
+```powershell
+# After bootstrap_session has logged the dedicated profile in:
+& .\.venv\Scripts\python.exe -m planning.substack.extract_session
+```
+
+This writes `planning/substack/api_session.json` (gitignored: live auth cookies +
+the browser User-Agent that `cf_clearance` is bound to). When the cookie expires
+the API returns 401/403 and the helpers raise `SessionExpiredError` telling you to
+re-run `extract_session`.
+
+### Daily follower count via the API
+
+Set `substack_profile.source` to `"native"` in `config.json` (leave the other
+keys — the endpoint loop still needs `api_url` present). The reporting pipeline
+then routes the follower count through
+`reporting/scrape_client/substack_native.py::fetch_profile`, which returns the
+same `{"num_followers": N}` envelope as the Playwright scraper. Flip back to
+`"playwright"` to use the browser scrape. (`substack_posts` / note engagement
+stays on Playwright — the Notes endpoints aren't reverse-engineered yet.)
+
+### Manual archive + create
+
+```powershell
+# Pull the latest published posts into results/substack/archive_<date>.json
+& .\.venv\Scripts\python.exe -m planning.substack.api_pull [--limit N] [--with-body]
+
+# Create a private DRAFT edition (does NOT email anyone); validate it; print the edit URL
+& .\.venv\Scripts\python.exe -m planning.substack.api_create --title "..." --subtitle "..." --body "para" [--image p.png]
+# Add --confirm ONLY when you intend to publish + email the whole subscriber list (irreversible).
+```
+
+`api_create` defaults to draft + pre-publish validation and never publishes
+without `--confirm`; it is never wired into the daily cron.
+
 ## Module layout
 
 ```

--- a/planning/substack/api_client.py
+++ b/planning/substack/api_client.py
@@ -1,0 +1,247 @@
+"""Native Substack HTTP API client (cookie-auth).
+
+Talks to Substack's private (reverse-engineered) endpoints over HTTP, using the
+session cookie harvested from the dedicated Chrome profile by
+:mod:`planning.substack.extract_session`. This is a lighter, more robust path
+than the Playwright automation: no DOM selectors, no reCAPTCHA, no shared-profile
+lock, no headed-browser launch per run.
+
+This module is the single source for the native path:
+
+* :func:`load_session` — build an authenticated ``requests.Session`` from the
+  cached cookies + User-Agent.
+* :func:`fetch_follower_count` — the daily follower number (``followerCount``
+  from ``/user/profile/self``); this is what the reporting pipeline uses when
+  ``substack_profile.source == "native"``.
+* :class:`SubstackAPI` — pull/archive + draft create/edit/publish, built on the
+  ``python-substack`` library (which owns the publication resolution and the
+  ProseMirror body builder).
+
+The Playwright integration (``reporting/scrape_client/substack.py`` and the rest
+of ``planning/substack/``) is intentionally **kept** as an alternative ``source``
+— this module does not remove or modify it.
+
+Cookie lifetime: ``substack.sid`` lives ~89 days, so the harvest step is a
+once-per-quarter chore (the same cadence as the Playwright ``bootstrap_session``
+re-login). When the cookie expires the API returns 401/403 and the helpers raise
+:class:`SessionExpiredError` telling the operator to re-run ``extract_session``.
+
+SECURITY: ``api_session.json`` holds live auth cookies — it is gitignored and
+must never be committed (public repo).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from substack import Api
+from substack.post import Post, parse_inline
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+SESSION_FILE = PACKAGE_DIR / "api_session.json"
+BASE_URL = "https://substack.com/api/v1"
+
+# Fallback only — the real UA that solved Cloudflare's challenge is stored in the
+# session file and paired with cf_clearance; this is used if that is absent.
+DEFAULT_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+)
+
+logger = logging.getLogger("substack_api")
+
+__all__ = [
+    "SessionExpiredError",
+    "load_session",
+    "fetch_follower_count",
+    "SubstackAPI",
+    "SESSION_FILE",
+]
+
+
+class SessionExpiredError(RuntimeError):
+    """Raised when the cached Substack cookie is missing or rejected (401/403).
+
+    The fix is always the same: re-run ``python -m planning.substack.extract_session``.
+    """
+
+
+def load_session(session_file: Path = SESSION_FILE) -> tuple[requests.Session, dict]:
+    """Build an authenticated ``requests.Session`` from the cached cookies + UA."""
+    if not session_file.exists():
+        raise SessionExpiredError(
+            f"No Substack API session at {session_file}. Run "
+            "`python -m planning.substack.extract_session` to harvest the cookie."
+        )
+    meta = json.loads(session_file.read_text(encoding="utf-8"))
+    cookies = meta.get("cookies") or {}
+    if "substack.sid" not in cookies:
+        raise SessionExpiredError(
+            "Cached session is missing 'substack.sid' — re-run "
+            "`python -m planning.substack.extract_session`."
+        )
+    session = requests.Session()
+    session.cookies.update(cookies)
+    session.headers.update({"User-Agent": meta.get("user_agent") or DEFAULT_UA})
+    return session, meta
+
+
+def _check(resp: requests.Response) -> requests.Response:
+    """Raise :class:`SessionExpiredError` on auth failure, else ``raise_for_status``."""
+    if resp.status_code in (401, 403):
+        raise SessionExpiredError(
+            f"Substack API auth failed ({resp.status_code}) — the session cookie "
+            "likely expired. Re-run `python -m planning.substack.extract_session`."
+        )
+    resp.raise_for_status()
+    return resp
+
+
+def fetch_follower_count(session_file: Path = SESSION_FILE) -> int:
+    """Return the profile follower count (the daily number).
+
+    Equivalent to the Playwright scrape of "Total followers (N)" but via a single
+    authenticated GET. ``followerCount`` is the same integer that page renders.
+    """
+    session, _ = load_session(session_file)
+    resp = _check(session.get(f"{BASE_URL}/user/profile/self", timeout=30))
+    data = resp.json()
+    count = data.get("followerCount")
+    if not isinstance(count, int):
+        raise RuntimeError(
+            "Unexpected /user/profile/self shape — no integer 'followerCount' "
+            f"(got {type(count).__name__}). Endpoint may have changed."
+        )
+    return count
+
+
+class SubstackAPI:
+    """Authenticated wrapper over ``python-substack`` for pull + write.
+
+    Used by the manual archive/create CLIs (not the daily cron). The follower
+    count does *not* go through here — it uses :func:`fetch_follower_count` to
+    avoid the publication-resolution round-trips the library does at construction.
+    """
+
+    def __init__(
+        self,
+        publication_url: Optional[str] = None,
+        *,
+        session_file: Path = SESSION_FILE,
+    ) -> None:
+        _, meta = load_session(session_file)
+        cookies = meta.get("cookies") or {}
+        user_agent = meta.get("user_agent") or DEFAULT_UA
+
+        # python-substack authenticates from a {name: value} cookies *file*.
+        # Write a throwaway temp file (auth happens at construction, then the
+        # cookies live in the library's own session, so the file can go away).
+        tmp = tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        try:
+            json.dump(cookies, tmp)
+            tmp.close()
+            self._api = Api(cookies_path=tmp.name, publication_url=publication_url)
+        finally:
+            os.unlink(tmp.name)
+
+        # Present the same browser UA on every request (Cloudflare + heuristics).
+        self._api._session.headers.update({"User-Agent": user_agent})
+        self.user_id = self._api.get_user_id()
+
+    # ---- pull / archive -------------------------------------------------
+
+    def list_published(self, limit: int = 50) -> list[dict]:
+        """Return published posts (newest first). Unwraps the ``{posts: [...]}`` envelope."""
+        resp = self._api.get_published_posts(limit=limit)
+        posts = resp.get("posts", resp) if isinstance(resp, dict) else resp
+        return posts if isinstance(posts, list) else []
+
+    def build_archive(self, limit: int = 50, with_body: bool = False) -> list[dict]:
+        """Build an archive of published posts.
+
+        ``with_body=True`` fetches each post's full body (one extra GET per post
+        via ``/posts/by-id/{id}``) — the list endpoint omits the body.
+        """
+        archive: list[dict] = []
+        for post in self.list_published(limit=limit):
+            entry = {
+                "id": post.get("id"),
+                "uuid": post.get("uuid"),
+                "title": post.get("title"),
+                "slug": post.get("slug"),
+                "post_date": post.get("post_date"),
+                "audience": post.get("audience"),
+                "type": post.get("type"),
+            }
+            if with_body:
+                full = self._get_post_by_id(post.get("id"))
+                entry["canonical_url"] = full.get("canonical_url")
+                entry["body_html"] = full.get("body_html")
+            archive.append(entry)
+        return archive
+
+    def _get_post_by_id(self, post_id: int) -> dict:
+        resp = self._api._session.get(
+            f"{self._api.publication_url}/posts/by-id/{post_id}", timeout=30
+        )
+        _check(resp)
+        body = resp.json()
+        return body.get("post", body) if isinstance(body, dict) else {}
+
+    # ---- create / edit / publish ---------------------------------------
+
+    def create_draft(
+        self,
+        title: str,
+        subtitle: str,
+        paragraphs: list[str],
+        *,
+        heading: Optional[str] = None,
+        image_path: Optional[str] = None,
+        audience: str = "everyone",
+    ) -> dict:
+        """Create a newsletter edition as a DRAFT (private — not sent to anyone).
+
+        ``paragraphs`` support inline markdown (``**bold**``, ``[text](url)`` …).
+        Returns the created draft dict (carries ``id``).
+        """
+        post = Post(title, subtitle, self.user_id, audience=audience)
+        if heading:
+            post.heading(heading, level=2)
+        for para in paragraphs:
+            post.add({"type": "paragraph", "content": parse_inline(para)})
+        if image_path:
+            uploaded = self._api.get_image(image_path)
+            url = uploaded.get("url")
+            if url:
+                post.add({"type": "captionedImage", "src": url})
+        return self._api.post_draft(post.get_draft())
+
+    def update_draft(self, draft_id: int, **fields) -> dict:
+        """Edit an existing draft (e.g. ``draft_subtitle=...``)."""
+        return self._api.put_draft(draft_id, **fields)
+
+    def prepublish(self, draft_id: int) -> dict:
+        """Run Substack's own pre-publish validation. Does NOT publish."""
+        return self._api.prepublish_draft(draft_id)
+
+    def publish(self, draft_id: int, *, send: bool = True) -> dict:
+        """Publish a draft. IRREVERSIBLE: ``send=True`` emails subscribers.
+
+        Callers must gate this behind an explicit human confirmation — it is
+        never invoked by the daily pipeline.
+        """
+        return self._api.publish_draft(draft_id, send=send)
+
+    def delete_draft(self, draft_id: int) -> dict:
+        """Delete a draft (used to clean up throwaway validation drafts)."""
+        return self._api.delete_draft(draft_id)

--- a/planning/substack/api_create.py
+++ b/planning/substack/api_create.py
@@ -1,0 +1,96 @@
+r"""Manual CLI — create a newsletter edition as a DRAFT, optionally publish (P1).
+
+Uses the native HTTP API (cookie auth). NOT part of the daily cron.
+
+By default this creates a **private draft** and runs Substack's pre-publish
+validation — it does NOT send anything to subscribers. Publishing (which emails
+the whole list and is irreversible) happens only with the explicit ``--confirm``
+flag.
+
+Usage (from the repo root):
+    & .\.venv\Scripts\python.exe -m planning.substack.api_create \
+        --title "..." --subtitle "..." \
+        (--body "para 1" --body "para 2" | --markdown-file post.md) \
+        [--heading "..."] [--image path.png] [--confirm] [--delete-after]
+
+    --body TEXT        a paragraph (repeatable; inline markdown supported)
+    --markdown-file F  read the body from a markdown file instead of --body
+    --heading TEXT     optional H2 heading at the top
+    --image PATH       optional image (uploaded, appended)
+    --confirm          DANGER: actually publish + email subscribers
+    --delete-after     delete the draft after creating it (smoke-test only)
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from planning.substack.api_client import SubstackAPI
+from planning.substack.substack_session import configure_logger, load_substack_config
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create (and optionally publish) a Substack edition.")
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--subtitle", default="")
+    parser.add_argument("--body", action="append", default=[], help="A paragraph (repeatable).")
+    parser.add_argument("--markdown-file", type=str, default=None, help="Read body paragraphs from a file.")
+    parser.add_argument("--heading", type=str, default=None)
+    parser.add_argument("--image", type=str, default=None)
+    parser.add_argument("--confirm", action="store_true", help="DANGER: publish + email subscribers.")
+    parser.add_argument("--delete-after", action="store_true", help="Delete the draft after creating (smoke test).")
+    parser.add_argument("--debug", action="store_true")
+    return parser.parse_args()
+
+
+def _resolve_paragraphs(args: argparse.Namespace) -> list[str]:
+    if args.markdown_file:
+        text = Path(args.markdown_file).read_text(encoding="utf-8")
+        return [block.strip() for block in text.split("\n\n") if block.strip()]
+    return list(args.body)
+
+
+def main() -> int:
+    args = parse_args()
+    logger = configure_logger("substack_api_create", debug=args.debug)
+    cfg = load_substack_config()
+
+    paragraphs = _resolve_paragraphs(args)
+    if not paragraphs:
+        logger.error("❌ No body content — pass --body (repeatable) or --markdown-file.")
+        return 2
+
+    api = SubstackAPI(publication_url=cfg.get("publish_url"))
+    draft = api.create_draft(
+        title=args.title,
+        subtitle=args.subtitle,
+        paragraphs=paragraphs,
+        heading=args.heading,
+        image_path=args.image,
+    )
+    draft_id = draft.get("id")
+    logger.info("✅ Draft created — id=%s", draft_id)
+
+    verdict = api.prepublish(draft_id)
+    errors = verdict.get("errors") if isinstance(verdict, dict) else None
+    logger.info("🔎 Prepublish — errors=%s", errors or "none")
+
+    if args.delete_after:
+        api.delete_draft(draft_id)
+        logger.info("🗑️ Draft %s deleted (smoke test).", draft_id)
+        return 0
+
+    if args.confirm:
+        logger.warning("🚨 --confirm passed — publishing and emailing subscribers!")
+        result = api.publish(draft_id, send=True)
+        logger.info("📣 Published — id=%s", result.get("id"))
+    else:
+        edit_url = f"{cfg.get('publish_url', '').rsplit('/publish/', 1)[0]}/publish/post/{draft_id}"
+        logger.info("🛑 Not publishing (no --confirm). Review/edit the draft, then publish from Substack:")
+        logger.info("   %s", edit_url)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planning/substack/api_pull.py
+++ b/planning/substack/api_pull.py
@@ -1,0 +1,61 @@
+r"""Manual CLI — pull the publication's published posts into a local archive (P1).
+
+Uses the native HTTP API (cookie auth). NOT part of the daily cron — run it by
+hand when you want an archive snapshot.
+
+Usage (from the repo root):
+    & .\.venv\Scripts\python.exe -m planning.substack.api_pull [--limit N] [--with-body] [--out PATH]
+
+    --limit N      how many recent posts to pull (default 50)
+    --with-body    also fetch each post's full body_html (one extra GET per post)
+    --out PATH     output JSON path (default results/substack/archive_<date>.json)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from planning.substack.api_client import SubstackAPI
+from planning.substack.substack_session import configure_logger, load_substack_config
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Pull Substack posts into a local archive.")
+    parser.add_argument("--limit", type=int, default=50, help="How many recent posts to pull.")
+    parser.add_argument("--with-body", action="store_true", help="Also fetch full body_html per post.")
+    parser.add_argument("--out", type=str, default=None, help="Output JSON path.")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logger = configure_logger("substack_api_pull", debug=args.debug)
+    cfg = load_substack_config()
+
+    out_path = (
+        Path(args.out)
+        if args.out
+        else REPO_ROOT / "results" / "substack" / f"archive_{datetime.now():%Y%m%d}.json"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logger.info("🚀 Substack archive pull — limit=%d with_body=%s", args.limit, args.with_body)
+    api = SubstackAPI(publication_url=cfg.get("publish_url"))
+    archive = api.build_archive(limit=args.limit, with_body=args.with_body)
+
+    out_path.write_text(json.dumps(archive, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
+    logger.info("✅ Wrote %d posts → %s", len(archive), out_path)
+    if archive:
+        newest = archive[0]
+        logger.info("   newest: %s (%s)", newest.get("title"), newest.get("post_date"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/planning/substack/extract_session.py
+++ b/planning/substack/extract_session.py
@@ -1,0 +1,91 @@
+r"""Harvest the Substack session cookie(s) from the dedicated Chrome profile.
+
+This is the once-per-cookie-lifetime chore for the **native HTTP API** path (the
+analogue of ``bootstrap_session`` for the Playwright path). It launches the same
+dedicated real-Chrome profile via :class:`SubstackSession`, confirms the saved
+login is still valid, then reads ``context.cookies()`` and writes the
+Substack-domain cookies + the browser User-Agent to ``api_session.json``
+(gitignored). The native client (:mod:`planning.substack.api_client`) loads that
+file for every subsequent HTTP call — no browser launch needed until the cookie
+expires (~89 days).
+
+The User-Agent is captured because ``cf_clearance`` (Cloudflare) is bound to the
+UA that solved its challenge; the HTTP session must present the same UA.
+
+Usage (from the repo root):
+    & .\.venv\Scripts\python.exe -m planning.substack.extract_session [--debug]
+
+NO cookie *values* are printed — only names + expiry — so nothing secret leaks
+into logs. The written ``api_session.json`` is gitignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+from planning.substack.api_client import SESSION_FILE
+from planning.substack.substack_session import (
+    SubstackSession,
+    configure_logger,
+    load_substack_config,
+)
+
+HARVEST_URL = "https://substack.com/home"
+KEY_COOKIES = {"substack.sid", "substack.lli", "cf_clearance"}
+
+
+def _fmt_expiry(expires: float) -> str:
+    if not expires or expires < 0:
+        return "session (no expiry)"
+    dt = datetime.fromtimestamp(expires, tz=timezone.utc)
+    days = (dt - datetime.now(tz=timezone.utc)).days
+    return f"{dt.date().isoformat()} (~{days}d)"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Harvest Substack cookies for the native API path.")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logger = configure_logger("substack_extract_session", debug=args.debug)
+    cfg = load_substack_config()
+
+    with SubstackSession(cfg) as session:
+        # Raises LoginRequiredError (→ "re-run bootstrap_session") if expired.
+        session.goto_with_login_check(HARVEST_URL)
+        all_cookies = session.context.cookies()
+        user_agent = session.page.evaluate("() => navigator.userAgent")
+
+    substack_cookies = {
+        c["name"]: c["value"]
+        for c in all_cookies
+        if "substack" in (c.get("domain") or "").lower()
+    }
+
+    logger.info("🍪 Harvested %d Substack-domain cookies:", len(substack_cookies))
+    for c in sorted(all_cookies, key=lambda x: x.get("name", "")):
+        if "substack" not in (c.get("domain") or "").lower():
+            continue
+        star = " ⭐" if c.get("name") in KEY_COOKIES else ""
+        logger.info("   %-22s %s%s", c.get("name"), _fmt_expiry(c.get("expires", -1)), star)
+
+    if "substack.sid" not in substack_cookies:
+        logger.error("❌ substack.sid not found — login may have expired. Re-run bootstrap_session.")
+        return 1
+
+    SESSION_FILE.write_text(
+        json.dumps({"cookies": substack_cookies, "user_agent": user_agent}),
+        encoding="utf-8",
+    )
+    logger.info("✅ Wrote native API session → %s", SESSION_FILE)
+    logger.info("   (gitignored — holds live auth cookies, never commit)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reporting/scrape_client/substack_native.py
+++ b/reporting/scrape_client/substack_native.py
@@ -1,0 +1,48 @@
+"""Substack native-API fetchers for the reporting pipeline.
+
+Selected when ``substack_profile.source == "native"`` in ``config.json`` (routed
+by ``reporting/social_client/social_api_client.py``). This is the lighter,
+browser-free alternative to the Playwright scraper in
+``reporting/scrape_client/substack.py`` — which is kept as the ``"playwright"``
+source and is not removed.
+
+Only ``fetch_profile`` (follower count) is implemented natively today; note
+engagement still goes through the Playwright path until the Notes endpoints are
+reverse-engineered. The return envelope is identical to the Playwright scraper's,
+so everything downstream (``save_results`` → ``data_processor`` →
+``profile_aggregator`` → ``notion_update``) is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+from planning.substack.api_client import (  # noqa: E402
+    SessionExpiredError,
+    fetch_follower_count,
+)
+from reporting.scrape_client.base import ScrapeError, normalize_target_date  # noqa: E402
+
+logger = logging.getLogger("substack_native")
+
+
+def fetch_profile(target_date: Optional[str] = None) -> Optional[dict]:
+    """Return ``{"num_followers": N}`` via the native HTTP API (no browser).
+
+    Mirrors ``reporting.scrape_client.substack.fetch_profile`` exactly so the two
+    sources are drop-in interchangeable via the ``source`` config flag.
+    """
+    target_date = normalize_target_date(target_date)
+    logger.info("🚀 Substack native fetch_profile — date=%s", target_date)
+    try:
+        count = fetch_follower_count()
+    except SessionExpiredError as err:
+        raise ScrapeError(f"Substack native session expired: {err}") from err
+    except Exception as err:  # noqa: BLE001
+        raise ScrapeError(f"Substack native follower fetch failed: {err}") from err
+    logger.info("✅ Substack followers (native): %d", count)
+    return {"num_followers": count}

--- a/reporting/social_client/social_api_client.py
+++ b/reporting/social_client/social_api_client.py
@@ -103,6 +103,38 @@ def _fetch_via_playwright(platform_key, reference_date):
         return None
 
 
+def _fetch_via_native(platform_key, reference_date):
+    """Delegate to the per-platform native-API fetcher in ``reporting.scrape_client``.
+
+    ``platform_key`` is e.g. ``"substack_profile"`` → calls
+    ``reporting.scrape_client.substack_native.fetch_profile(reference_date)``.
+    The native fetchers hit the platform's own HTTP API directly (cookie auth);
+    they return the same envelope as the Playwright scrapers, so they are drop-in
+    interchangeable via the ``source`` config flag.
+    """
+    parts = platform_key.split('_', 1)
+    if len(parts) != 2:
+        logger.error(f"❌ Cannot dispatch {platform_key!r} — expected '<platform>_<data_type>'")
+        return None
+    platform, data_type = parts
+    fn_name = f"fetch_{data_type}"
+    try:
+        module = importlib.import_module(f"reporting.scrape_client.{platform}_native")
+    except ImportError as err:
+        logger.error(f"❌ No native-API fetcher module for {platform!r}: {err}")
+        return None
+    fn = getattr(module, fn_name, None)
+    if fn is None:
+        logger.error(f"❌ Native fetcher {platform!r} has no {fn_name}()")
+        return None
+    logger.info(f"🔌 Fetching {platform_key} via native API")
+    try:
+        return fn(reference_date)
+    except Exception as err:
+        logger.error(f"❌ Native API fetch of {platform_key} failed: {err}", exc_info=True)
+        return None
+
+
 def get_api_data(platform_key, config, reference_date=None):
     """Fetch data for the specified platform with retries and exponential backoff.
 
@@ -112,6 +144,9 @@ def get_api_data(platform_key, config, reference_date=None):
       which drives the platform's persistent Chrome profile via the existing
       ``planning/<platform>/<platform>_session.py`` session class (stealth
       launch comes from ``config/chrome_launch.py``).
+    * ``"native"`` → delegates to ``reporting.scrape_client.<platform>_native.fetch_<data_type>``
+      which calls the platform's own HTTP API directly with cookie auth (no
+      browser). Used by Substack's follower count.
     * anything else (including the default when the key is absent) → RapidAPI
       HTTP call as before.
     """
@@ -124,8 +159,10 @@ def get_api_data(platform_key, config, reference_date=None):
     source = api_config.get('source', 'rapidapi')
     if source == 'playwright':
         return _fetch_via_playwright(platform_key, reference_date)
+    if source == 'native':
+        return _fetch_via_native(platform_key, reference_date)
     if source != 'rapidapi':
-        logger.error(f"❌ Unknown source '{source}' for {platform_key} — expected 'rapidapi' or 'playwright'")
+        logger.error(f"❌ Unknown source '{source}' for {platform_key} — expected 'rapidapi', 'playwright', or 'native'")
         return None
 
     logger.info(f"🔍 Fetching {platform_key} data")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,10 @@ python-dotenv
 psycopg2-binary
 # Browser automation for the Substack pipeline (note posting + follower scraping)
 playwright
+# Native Substack HTTP API (cookie-auth) — follower count + draft create/publish,
+# the lighter alternative to the Playwright path. Unofficial/reverse-engineered:
+# pinned so an upstream release can't silently break the private endpoints we use.
+python-substack==0.1.22
 # Article body extraction (readability) for newsletter
 readability-lxml
 # Required HTML cleaner backend for newer readability-lxml versions


### PR DESCRIPTION
## Summary

GO on **P1** of #91: ship the native Substack HTTP API path (cookie-auth) as a real, validated integration. The Playwright path is **kept** as an alternative `source` — this does not remove it.

This PR delivers the daily-relevant, safe win plus the manual P1 tooling. It intentionally does **not** auto-publish anything: publishing is gated behind an explicit `--confirm` and is never wired into the cron.

> Note: `Refs #91` (not `Closes`) — the issue stays open to track the deferred follow-ups (Notes migration, Notion-driven editions, "like").

## What's in it

**Daily run switches to native for the follower count** (the only daily-safe, spike-proven capability):
- `reporting/scrape_client/substack_native.py::fetch_profile` → `{"num_followers": N}`, byte-identical envelope to the Playwright scraper.
- New `"native"` source dispatch in `social_api_client.get_api_data` (alongside `rapidapi` / `playwright`).
- Local `config.json` `substack_profile.source` flipped to `native` so **tomorrow's run uses it**; flip back to `playwright` for instant rollback.

**Auth — cookie harvest, no password:**
- `extract_session.py` harvests `substack.sid` / `cf_clearance` + the browser UA from the existing dedicated Chrome profile into gitignored `api_session.json`. `substack.sid` lives **~89 days**, so this is a ~quarterly chore (same cadence as `bootstrap_session`). On 401/403 the client raises `SessionExpiredError` → re-run `extract_session`.

**Manual P1 tooling (not cron-wired):**
- `api_pull.py` — archive published posts to JSON (`--with-body` adds `body_html` + `canonical_url`).
- `api_create.py` — create a private **draft** edition + Substack pre-publish validation; publishes only with `--confirm`.
- `api_client.py` — single source for the session + `fetch_follower_count()` + `SubstackAPI`.

**Deps/docs:** pin `python-substack==0.1.22`; gitignore `api_session.json`; `docs/substack-native-api.md` (design + endpoint map + fragility) + `planning/substack/README.md` + root README source note.

## Validation (run live today)

| Check | Result |
|---|---|
| `extract_session` harvest | ✅ `substack.sid` ~89d, UA captured |
| `fetch_follower_count()` | ✅ returns the live integer |
| native adapter `fetch_profile` | ✅ `{"num_followers": N}` |
| full dispatcher `source=native` | ✅ same envelope, no browser |
| `api_pull --limit/--with-body` | ✅ archive incl. `body_html` + `canonical_url` |
| `api_create` round-trip | ✅ create → edit → prepublish(errors=none) → delete |
| `py_compile` (6 files) | ✅ |

No test suite or CI exists in this repo (gate = `py_compile` + the live checks above).

## Out of scope (deferred on #91)
Notes migration (daily Note posting + note-engagement scrape stay on Playwright — endpoints not reverse-engineered), Notion-editorial-driven edition creation, and "like" support.
