### PR TITLE
fix: prevent autoheal console tail FileNotFoundError on early child exit

### DIFF
--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -161,6 +161,11 @@ def start_skill_console(name: str, skill_cmd: str, *, model: str = "claude-opus-
     ts = datetime.now().strftime("%Y-%m-%d-%H%M%S")
     log_path = REPO_ROOT / "results" / "planning" / f"autoheal-{ts}.log"
     log_path.parent.mkdir(parents=True, exist_ok=True)
+    # Create the file now, before the tail thread starts. The wrapper opens it
+    # with "wb" only after its own (new-console) Python startup, so if that child
+    # dies early the file would never exist and the tail's open() would raise
+    # FileNotFoundError — masking the child's real failure. touch() closes that race.
+    log_path.touch()
 
     wrapper = REPO_ROOT / "app" / "autoheal_console.py"
     cmd = [
@@ -201,6 +206,12 @@ def start_skill_console(name: str, skill_cmd: str, *, model: str = "claude-opus-
         # deque until the process exits and the file is fully drained.
         while not log_path.exists() and proc.poll() is None:
             time.sleep(0.2)
+        if not log_path.exists():
+            # Child exited before producing a log (and the pre-touch is gone).
+            # Surface its exit code instead of crashing on a missing-file open().
+            rc = proc.poll()
+            lines.append(f"[autoheal] console exited (code {rc}) before writing any log output.")
+            return
         try:
             with log_path.open("r", encoding="utf-8", errors="replace") as fh:
                 while True:


### PR DESCRIPTION
## Summary

Fixes the misleading `[tail error] [Errno 2] No such file or directory: '...autoheal-<ts>.log'` failure on the planning tab's **"run + autoheal (console)"** button.

`start_skill_console()` only created the log's *parent* dir and left file creation to the new-console wrapper child (`autoheal_console.py`), which opens it only after its own Python startup. If that child exited early, the file never existed, the `_tail` thread's wait loop broke on `proc.poll()`, and the immediately-following `open("r")` raised `FileNotFoundError` — crashing the tail and masking the child's real exit-1.

Changes (both in `app/process_runner.py`):
1. `log_path.touch()` right after the parent `mkdir`, so the file always exists before the tail thread starts — eliminates the launch race. The wrapper still owns the content via `open("wb")`.
2. Defensive guard in `_tail`: if the file is still missing after the wait loop, append a clear `[autoheal] console exited (code N) before writing any log output.` message instead of opening a non-existent path.

## Validation

- **Reproduction proof:** a standalone repro replicating the exact `_tail` core against a real fast-exiting child that never writes the log. OLD path reproduced the precise `[tail error] [Errno 2] No such file` error; NEW path opened the pre-touched log cleanly with no exception. → `RESULT: PASS — bug reproduced on old, gone on new`.
- **Syntax:** `py_compile app/process_runner.py app/autoheal_console.py` → OK.
- **Streamlit boot:** `streamlit run app/app.py --server.headless true` booted cleanly (server started, no traceback).
- **Tests:** no project test suite or `scripts/verify` gate exists in this repo (only `.venv` matches) — none to run.
- **Diff sweep:** change is +11 lines, fully scoped to the two functions; no unrelated edits, dependency bumps, or weakened assertions.

Closes #98
