### PR TITLE
fix: bootstrap sys.path in autoheal_console so the config import works

### DIFF
--- a/app/autoheal_console.py
+++ b/app/autoheal_console.py
@@ -33,6 +33,11 @@ from pathlib import Path
 from typing import Any, Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+# Run as a script (python app/autoheal_console.py via the app or launch_autoheal.bat),
+# so sys.path[0] is app/, not the repo root — without this the `from config.console`
+# import below raises ModuleNotFoundError and the wrapper dies before opening its log.
+# Mirrors app/app.py's own sys.path bootstrap.
+sys.path.insert(0, str(REPO_ROOT))
 DEFAULT_MODEL = "claude-opus-4-8"
 
 


### PR DESCRIPTION
## Summary

Fixes the autoheal console failing every run with a **0-byte log and exit 1** (the disease behind #98, which only hardened the in-app tail against the symptom).

`app/autoheal_console.py` imports `from config.console import force_utf8_stdio` inside `main()`. Run as a script — `python app/autoheal_console.py`, exactly how `app/process_runner.py:start_skill_console` and `launch_autoheal.bat` invoke it — `sys.path[0]` is `app/`, not the repo root, so `config` (a repo-root package) isn't importable and the wrapper dies with `ModuleNotFoundError: No module named 'config'` **before** `run()` opens the log. With `CREATE_NEW_CONSOLE`, the window flashes and vanishes, so the error was never visible.

Fix: add `sys.path.insert(0, str(REPO_ROOT))` before the `config` import, mirroring the same bootstrap already in `app/app.py:23`. Fixes every invocation path (Streamlit button + `launch_autoheal.bat`).

## Validation

- **Reproduction proof (before):** `python app/autoheal_console.py --skill-cmd "/help" --log tmp.log --no-remote-control` → `ModuleNotFoundError: No module named 'config'`, exit 1, no log file.
- **Reproduction proof (after):** same command → wrapper passes the import, writes the `$ claude -p ...` / `# started` header to the log, spawns claude, and streams `stream-json` events into the log (non-empty). Confirmed log head contains the command line + session banner.
- **Syntax:** `py_compile app/autoheal_console.py` → OK.
- **Diagnosis evidence:** 2026-05-30 autoheal logs are full (2761 B, clean run); 2026-06-07 logs are 0 bytes — the regression window matches when the `config.console` import was introduced.
- **Tests:** no project test suite exists in this repo; none to run.

Closes #100
