### PR TITLE
chore: demote supabase key-fallback failure log to DEBUG (#102)

### DIFF
--- a/engagement/db/client.py
+++ b/engagement/db/client.py
@@ -72,8 +72,13 @@ def supabase_client():
             logger.info("🔑 using supabase key: %s", label)
             return client
         except Exception as err:
+            # Trying candidates in priority order and moving on is by design, so a
+            # failed candidate is not warning-worthy — it's the expected fallback
+            # path. Keep the detail at DEBUG for when someone is actually debugging;
+            # the terminal RuntimeError below is the single loud signal when *no*
+            # key works (it carries last_err).
             last_err = err
-            logger.warning("🔑 supabase key %s failed: %s", label, err)
+            logger.debug("🔑 supabase key %s not usable, trying next: %s", label, err)
             continue
     raise RuntimeError(f"No working supabase key found in config.supabase (last err: {last_err})")
 


### PR DESCRIPTION
## Summary

Silences the misleading `WARNING` that `engagement/db/client.py` printed on every run in anon-only / partial-key setups:

```
🔑 supabase key service_role_key failed: {'message': 'Invalid API key', ...}
```

`supabase_client()` deliberately tries keys in priority order (`service_role_key` → `key` → `anon_key`) and uses the first that works. A failed candidate is the *expected* fallback path, not an error — logging it at `WARNING` made a healthy run look broken and trained the eye to ignore real warnings. This demotes the per-candidate failure to `DEBUG`; the terminal `RuntimeError` (raised only when *no* key works) remains the single loud signal and still carries `last_err`. No change to key selection, fallback order, or all-fail behaviour.

## Validation

- **Behavioural proof — fallback path:** a probe injected a fake `supabase` module and ran the candidate loop with the first two keys invalid and `anon_key` valid. Output: two `[DEBUG] 🔑 supabase key ... not usable, trying next` lines, **zero** `WARNING`/`ERROR`, and `[INFO] 🔑 using supabase key: anon_key`. PASS.
- **Behavioural proof — all keys fail:** same probe with no working key → `RuntimeError: No working supabase key found in config.supabase (last err: ...)`. Behaviour unchanged. PASS.
- **Syntax:** `py_compile engagement/db/client.py` → OK.
- **Lint/tests:** no ruff config and no test suite exist in this repo; none to run.
- **Diff sweep:** single file, 6 insertions / 1 deletion — only the log line + an explanatory comment. Broad `except` not broadened; all-fail path untouched.

Closes #102
