### PR TITLE
fix: wait for large video to finalize before TW/TH/Substack schedule

### DIFF
--- a/planning/substack/post_substack_video_note.py
+++ b/planning/substack/post_substack_video_note.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -48,6 +47,7 @@ from planning.substack.substack_session import (  # noqa: E402
     normalize_day,
 )
 from planning.videos.videos_session import (  # noqa: E402
+    VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
     load_clip_payload,
     load_videos_config,
 )
@@ -237,9 +237,28 @@ def _post_video_note_for_row(
         logger.info("✅ DRY-RUN: video composer screenshot → %s (no post was published)", shot)
         return 0
 
+    # The Post button stays `disabled` until the clip finishes uploading
+    # server-side; for a large video that runs well past the click's own retry
+    # window, so wait for it to enable before clicking (issue #106).
     try:
-        session.page.get_by_role("dialog").first.get_by_role(
-            "button", name=re.compile(r"^post$", re.I)
+        session.page.wait_for_function(
+            """() => {
+                const b = document.querySelector('[role="dialog"] button[data-testid="composer-post"]')
+                          || document.querySelector('button[data-testid="composer-post"]');
+                return !!b && !b.disabled;
+            }""",
+            timeout=VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
+        )
+    except PWTimeoutError:
+        session.screenshot_failure(f"{payload.title or 'video'}-post-disabled")
+        logger.error("❌ Substack Post button never enabled — the video upload "
+                     "likely did not finish in time.")
+        return 9
+
+    try:
+        session.page.locator(
+            '[role="dialog"] button[data-testid="composer-post"], '
+            'button[data-testid="composer-post"]'
         ).first.click()
         session.page.get_by_role("dialog").first.wait_for(state="hidden", timeout=120000)
         logger.info("✅ Note dialog closed — video post submitted.")

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -50,6 +50,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # ``post_url_li``.
 PLATFORMS = ("li", "ig", "tw", "th", "sb")
 
+# A large clip keeps uploading/finalizing server-side after the final Schedule /
+# Post click. The per-platform image flows finalize within ~25 s, but a
+# multi-hundred-MB video needs a much longer window before the composer
+# clears / the Post button enables. Mirrors LinkedIn's transcoding budget.
+VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS = 180000
+
 
 @dataclass
 class ClipPayload:
@@ -379,6 +385,7 @@ def load_clip_payload(notion, editorial_row: dict, video_cols: dict, clip_cols: 
 
 __all__ = [
     "PLATFORMS",
+    "VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS",
     "ClipPayload",
     "configure_logger",
     "ensure_local_file",

--- a/planning/videos/videos_threads.py
+++ b/planning/videos/videos_threads.py
@@ -40,7 +40,10 @@ from planning.threads.schedule_threads_posts import (  # noqa: E402
     _wait_composer_closes,
     return_to_profile,
 )
-from planning.videos.videos_session import ClipPayload  # noqa: E402
+from planning.videos.videos_session import (  # noqa: E402
+    VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
+    ClipPayload,
+)
 
 logger = logging.getLogger("videos_threads")
 
@@ -102,7 +105,10 @@ def schedule_one_video(
 
     _click_calendar_done(page)
     _click_final_schedule_action(page)
-    if not _wait_composer_closes(page, timeout_ms=25000):
+    # A large clip keeps uploading after Schedule; the New-thread dialog only
+    # closes once it finalizes. Use the video budget, not the image-sized
+    # default (issue #106).
+    if not _wait_composer_closes(page, timeout_ms=VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS):
         shot = out_dir / f"{label}-th-FAIL.png"
         page.screenshot(path=str(shot), full_page=False)
         raise RuntimeError(f"TH composer did not close — see {shot}")

--- a/planning/videos/videos_twitter.py
+++ b/planning/videos/videos_twitter.py
@@ -37,7 +37,10 @@ from planning.twitter.schedule_twitter_posts import (  # noqa: E402
     _wait_composer_clears,
     return_to_home,
 )
-from planning.videos.videos_session import ClipPayload  # noqa: E402
+from planning.videos.videos_session import (  # noqa: E402
+    VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
+    ClipPayload,
+)
 
 logger = logging.getLogger("videos_twitter")
 
@@ -52,6 +55,44 @@ class VideoRow:
     @property
     def day_title(self) -> str:
         return self.day.strftime("%Y%m%d")
+
+
+def _wait_tweet_button_enabled(page, timeout_ms: int) -> None:
+    """Wait until X's final Schedule (tweetButton) is no longer disabled.
+
+    X keeps the composer's primary button ``aria-disabled`` while an uploaded
+    video is still processing server-side. ``_click_final_schedule_action`` uses
+    a JS-click fallback that *bypasses* the disabled state, so clicking during
+    that window is a silent no-op — the schedule never submits and the composer
+    never clears (issue #106). Poll until it enables (mirrors the Instagram /
+    LinkedIn ready-waits). Raises ``RuntimeError`` if it never enables.
+    """
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    last = None
+    while page.evaluate("() => Date.now()") < deadline:
+        loc = page.locator(
+            '[data-testid="tweetButton"], button[data-testid="tweetButtonInline"]'
+        ).last
+        state = "not found"
+        try:
+            if loc.count():
+                aria = loc.get_attribute("aria-disabled")
+                dis = loc.get_attribute("disabled")
+                if aria in (None, "false") and dis is None:
+                    return
+                state = f"aria-disabled={aria} disabled={dis}"
+        except Exception:
+            state = "error reading state"
+        if state != last:
+            logger.debug("⏳ TW final Schedule not ready (%s) — polling…", state)
+            last = state
+        page.wait_for_timeout(500)
+    raise RuntimeError(
+        "TW final Schedule button never enabled — X has not accepted the clip. "
+        "Most often the .mp4 exceeds X's limits (≈512 MB / 2:20 / ~25 Mbps) or "
+        "carries an embedded subtitle track; re-encode the clip lower / strip "
+        "extra tracks for X."
+    )
 
 
 def schedule_one_video(
@@ -98,8 +139,14 @@ def schedule_one_video(
         return "TW:DRY"
 
     _click_confirm_in_modal(page)
+    # X keeps the final Schedule button disabled until the video finishes
+    # processing; clicking before then is a silent no-op (issue #106).
+    _wait_tweet_button_enabled(page, VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS)
     _click_final_schedule_action(page)
-    if not _wait_composer_clears(page, timeout_ms=25000):
+    # A large clip is still committing server-side after Schedule; the inline
+    # composer only reverts once that finishes. Use the video budget, not the
+    # image-sized default (issue #106).
+    if not _wait_composer_clears(page, timeout_ms=VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS):
         shot = out_dir / f"{label}-tw-FAIL.png"
         page.screenshot(path=str(shot), full_page=False)
         raise RuntimeError(f"TW composer did not clear — see {shot}")


### PR DESCRIPTION
## Summary

In a LIVE weekly-video run, Twitter/X and Threads failed to schedule the clip and the Substack video note failed to post — even though the clip uploaded fine (the #104 OneDrive fix is confirmed: the video loads full-bytes on every platform). Each of these three drivers finalized the submit on an image-sized timetable, too short for a large clip to commit server-side. This makes the finalize step video-aware:

- **Substack video note** — poll the Post button (`data-testid="composer-post"`) until it is no longer `disabled` before clicking, instead of racing a 30s click window. A large clip uploads past that window, which previously left the note unposted.
- **Threads** — extend the post-Schedule composer-close wait to the video budget so a big clip finalizes before we give up.
- **Twitter/X** — wait for the final Schedule button (`tweetButton`) to leave `aria-disabled` before clicking. `_click_final_schedule_action` uses a JS-click fallback that *bypasses* the disabled check, so clicking while X is still busy was a silent no-op and the schedule never submitted. When X never enables the button, fail loudly with an actionable message.
- Add a shared `VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS` (180s) in `videos_session`. Image flows are untouched.

## Validation (live, real platforms)

- **Substack:** before the fix the Post button stayed `disabled` and the click timed out (no note). After: it waited ≈34s for Post to enable, posted the note (`…/note/c-272023299`), and wrote `link SB(v)`. ✅
- **Threads:** before, the composer was mid-submit (spinner) when the 25s wait elapsed → FAIL. After: `✅ LIVE … TH video scheduled`, composer closed in ≈64s. ✅
- **Twitter/X:** the new enable-wait + debug poll proved X holds the Schedule button `aria-disabled` for the **entire 10-minute** window — X is refusing this specific clip (`ffprobe`: ~30 Mbps, 202 MB, plus an embedded `mov_text` subtitle track; LI/IG/Substack accept it, X does not). TW now **fails loudly with a precise message** instead of silently no-op-clicking a disabled button. The clip-encoding root cause is tracked separately in #107 (transcode clips to platform-safe specs before upload).
- **Syntax:** `py_compile` clean on all four files. No ruff/test suite in this repo.
- **Diff sweep:** four files, image flows unchanged, no dependency/test/gitignore edits; the unused `re` import in the Substack module was removed.

Closes #106
