### PR TITLE
fix: schedule weekly video on X (in-dialog Schedule button) + transcode clips to X-safe specs

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -238,7 +238,14 @@
         "post_minute_local": 0,
         "schedule_timezone": "Europe/Madrid",
         "headless": false,
-        "dry_run_default": true
+        "dry_run_default": true,
+        "transcode": {
+            "enabled": true,
+            "max_size_mb": 256,
+            "max_bitrate_mbps": 20,
+            "target_bitrate_mbps": 10,
+            "cache_dir": null
+        }
     },
     "newsletter_archive": {
         "articles_db_id": "67fbcee66711465c852ebf97303787a3",

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -212,12 +212,44 @@ attach helper. See:
   **OneDrive not running** — the read fails with *"The cloud file provider is not
   running"*; start OneDrive and retry. Hydrated files are left pinned ("always
   keep on this device"); free up space again later if needed.
+- **X video scheduling watches the in-dialog Schedule button (issue #107, correcting #106).**
+  The real reason X "never scheduled the weekly clip": the video driver waited on
+  `.last` of a selector matching **both** `tweetButton` (the composer modal's real
+  Schedule button) **and** `tweetButtonInline` (the home timeline's empty,
+  permanently-disabled inline composer). `.last` picked the inline one, so the
+  wait timed out forever even though the real button was enabled within ~8 s of
+  the upload finishing. A network trace proved X ingests + processes the clip
+  every time (INIT/APPEND/FINALIZE → STATUS `succeeded`), so it was never file
+  weight, subtitles, or bandwidth. Fix: `_primary_button_enabled` scopes the
+  lookup to the composer `[role="dialog"]`. Also: readiness is gated on the
+  button enabling, **not** `[role="progressbar"]` — the composer's video *player*
+  mounts scrubber progressbars that never clear (a false "still uploading"
+  signal). `_wait_for_video_upload_ready` now lets the upload settle before the
+  schedule modal opens, so confirming never races a mid-upload state.
+- **Clips are transcoded to platform-safe specs before upload (issue #107).**
+  Independently of the scheduling fix, weekly masters are sometimes exported very
+  heavy (~30 Mbps / 200+ MB — **over X's ~25 Mbps ceiling**) and carry a
+  `mov_text` subtitle track X dislikes. After hydration, `load_clip_payload`
+  calls `ensure_platform_safe_clip`, which `ffprobe`s the master and, if it trips
+  a threshold (`max_size_mb`, `max_bitrate_mbps`) **or** carries a non-audio/video
+  stream, `ffmpeg`-transcodes a derivative (H.264 high, bitrate-capped to
+  `target_bitrate_mbps`, AAC, subtitle/data tracks dropped, `+faststart`) and
+  feeds *that* to all five platforms — normalizing to safe specs and lighter
+  uploads. The OneDrive **master is never modified**. The derivative is cached
+  under `<system temp>/cm-video-transcode/` keyed by the master's mtime+size, so
+  re-runs reuse it; a re-exported master invalidates the cache automatically.
+  Tuned via the `videos.transcode` config block (`enabled` / `max_size_mb` /
+  `max_bitrate_mbps` / `target_bitrate_mbps` / `cache_dir`). If `ffmpeg`/`ffprobe`
+  aren't on `PATH`, or the transcode fails, it logs a clear warning and falls back
+  to uploading the master as-is.
 
 ## Files
 
 - `__init__.py` — empty package marker.
 - `videos_session.py` — config loader, Notion token loader, `ClipPayload`
-  dataclass, `load_clip_payload(notion, editorial_row, video_cols, clip_cols)`.
+  dataclass, `load_clip_payload(notion, editorial_row, video_cols, clip_cols)`,
+  OneDrive hydration (`ensure_local_file`), and platform-safe transcode
+  (`ensure_platform_safe_clip`).
 - `schedule_videos_posts.py` — orchestrator entry point. Implements the
   `main() -> tuple[int, list[dict]]` contract consumed by
   `planning_pipeline.py`.

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -25,8 +25,10 @@ import ctypes
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -50,10 +52,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 # ``post_url_li``.
 PLATFORMS = ("li", "ig", "tw", "th", "sb")
 
-# A large clip keeps uploading/finalizing server-side after the final Schedule /
-# Post click. The per-platform image flows finalize within ~25 s, but a
-# multi-hundred-MB video needs a much longer window before the composer
-# clears / the Post button enables. Mirrors LinkedIn's transcoding budget.
+# A clip keeps uploading/finalizing server-side before the composer's
+# Post/Schedule button enables. The per-platform image flows finalize within
+# ~25 s; a video needs longer for X's chunked upload + server-side processing
+# (INIT/APPEND/FINALIZE then STATUS polling to ``succeeded``) — empirically ~8 s
+# for a platform-safe clip, but allow generous headroom. It is a cap, so healthy
+# uploads return as soon as the button enables (issue #107).
 VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS = 180000
 
 
@@ -285,6 +289,186 @@ def ensure_local_file(path: Path, *, timeout_s: float = 600.0, poll_s: float = 1
     )
 
 
+# ---------------------------------------------------------------------------
+# Platform-safe transcode (issue #107)
+#
+# Some weekly masters are exported very heavy (~30 Mbps / 200+ MB) and carry a
+# mov_text subtitle track. X (Twitter) silently refuses such clips — its
+# Schedule button stays aria-disabled indefinitely — while LI/IG/TH/Substack
+# tolerate them. The durable fix is to transcode a platform-safe derivative
+# (H.264 high, bitrate-capped, AAC, no subtitle/data tracks, faststart) and
+# upload THAT everywhere, leaving the OneDrive master untouched. Degrades
+# gracefully to the master when ffmpeg/ffprobe are missing or transcode fails.
+# ---------------------------------------------------------------------------
+
+# Defaults applied when the ``videos.transcode`` block (or a key) is absent.
+_TRANSCODE_DEFAULTS = {
+    "enabled": True,
+    "max_size_mb": 256,
+    "max_bitrate_mbps": 20,
+    "target_bitrate_mbps": 10,
+    "cache_dir": None,
+}
+
+
+def _resolve_transcode_cfg() -> dict:
+    """Merge the ``videos.transcode`` config over the baked-in defaults."""
+    try:
+        block = load_videos_config().get("transcode") or {}
+    except RuntimeError:
+        block = {}
+    return {**_TRANSCODE_DEFAULTS, **block}
+
+
+def _probe_video(path: Path) -> Optional[dict]:
+    """Return ``{size, bit_rate, has_non_av_stream}`` via ffprobe, or None on failure.
+
+    ``size`` (bytes) and ``bit_rate`` (bits/s) come from ffprobe's format block.
+    ``has_non_av_stream`` is True when any stream's ``codec_type`` is not
+    video/audio (e.g. a ``mov_text`` subtitle or a data track) — X dislikes those.
+    None means we could not probe (ffprobe missing or errored); callers then skip
+    transcoding and log a warning rather than guess.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        proc = subprocess.run(
+            [ffprobe, "-v", "error", "-show_format", "-show_streams",
+             "-of", "json", str(path)],
+            check=True, capture_output=True, timeout=120,
+        )
+        data = json.loads(proc.stdout or b"{}")
+    except (OSError, subprocess.SubprocessError, ValueError) as err:
+        logger.warning("⚠️ ffprobe failed on %s: %s", path.name, err)
+        return None
+
+    def _to_int(v) -> int:
+        try:
+            return int(float(v))
+        except (TypeError, ValueError):
+            return 0
+
+    fmt = data.get("format", {}) or {}
+    streams = data.get("streams", []) or []
+    return {
+        "size": _to_int(fmt.get("size")),
+        "bit_rate": _to_int(fmt.get("bit_rate")),
+        "has_non_av_stream": any(
+            s.get("codec_type") not in ("video", "audio") for s in streams
+        ),
+    }
+
+
+def _needs_transcode(probe: dict, tcfg: dict) -> tuple[bool, str]:
+    """Decide whether a probed master trips a platform-safety threshold."""
+    size_mb = probe["size"] / 1_048_576
+    bitrate_mbps = probe["bit_rate"] / 1_000_000
+    reasons: list[str] = []
+    if probe["has_non_av_stream"]:
+        reasons.append("non-AV stream (subtitle/data) present")
+    if tcfg["max_size_mb"] and size_mb > tcfg["max_size_mb"]:
+        reasons.append(f"size {size_mb:.0f} MB > {tcfg['max_size_mb']} MB")
+    if tcfg["max_bitrate_mbps"] and bitrate_mbps > tcfg["max_bitrate_mbps"]:
+        reasons.append(
+            f"bitrate {bitrate_mbps:.1f} Mbps > {tcfg['max_bitrate_mbps']} Mbps"
+        )
+    return bool(reasons), "; ".join(reasons)
+
+
+def _transcode_cache_path(src: Path, tcfg: dict) -> Path:
+    """Cache path keyed by source mtime+size so a re-exported master invalidates it."""
+    root = tcfg.get("cache_dir")
+    cache_dir = Path(root) if root else Path(tempfile.gettempdir()) / "cm-video-transcode"
+    st = src.stat()
+    return cache_dir / f"clip_{src.stem}_{st.st_mtime_ns}_{st.st_size}.mp4"
+
+
+def _run_ffmpeg_transcode(src: Path, dst: Path, tcfg: dict) -> bool:
+    """Transcode ``src`` → ``dst`` to platform-safe specs. Returns True on success.
+
+    Drops subtitle (``-sn``) / data (``-dn``) tracks and maps a single video +
+    optional audio stream, re-encodes H.264 high with a hard bitrate cap and AAC
+    audio, and writes ``+faststart`` for streaming. On any failure the partial
+    output is removed and False is returned so the caller falls back to the master.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return False
+    target = tcfg["target_bitrate_mbps"]
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ffmpeg, "-y", "-i", str(src),
+        "-map", "0:v:0", "-map", "0:a:0?",
+        "-c:v", "libx264", "-profile:v", "high", "-pix_fmt", "yuv420p",
+        "-b:v", f"{target}M", "-maxrate", f"{target}M", "-bufsize", f"{target * 2}M",
+        "-c:a", "aac", "-b:a", "128k",
+        "-movflags", "+faststart", "-sn", "-dn",
+        str(dst),
+    ]
+    logger.info("🎞️ Transcoding %s → platform-safe (%d Mbps cap)…", src.name, target)
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=1800)
+    except (OSError, subprocess.SubprocessError) as err:
+        stderr = getattr(err, "stderr", b"") or b""
+        logger.error(
+            "❌ ffmpeg transcode failed for %s: %s — falling back to master.",
+            src.name, stderr.decode("utf-8", "replace")[-500:] or err,
+        )
+        try:
+            dst.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def ensure_platform_safe_clip(video_path: Path, tcfg: Optional[dict] = None) -> Path:
+    """Return a platform-safe derivative of ``video_path``, or the master unchanged.
+
+    Transcode triggers on a size/bitrate threshold or a non-audio/video stream
+    (issue #107 — X rejects heavy/subtitled clips). The derivative is cached in
+    the system temp dir keyed by source mtime+size and reused across re-runs.
+    Degrades to the master (logged) when transcode is disabled, ffmpeg/ffprobe
+    are unavailable, the clip is already safe, or ffmpeg fails — never raises,
+    since 4/5 platforms tolerate the heavy master.
+    """
+    tcfg = tcfg or _resolve_transcode_cfg()
+    if not tcfg.get("enabled", True):
+        return video_path
+    if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+        logger.warning(
+            "⚠️ ffmpeg/ffprobe not found on PATH — skipping platform-safe transcode; "
+            "uploading the master %s as-is (X may reject a heavy/subtitled clip).",
+            video_path.name,
+        )
+        return video_path
+
+    probe = _probe_video(video_path)
+    if probe is None:
+        return video_path  # already warned
+    needed, reason = _needs_transcode(probe, tcfg)
+    if not needed:
+        logger.info("✅ %s already platform-safe — no transcode.", video_path.name)
+        return video_path
+
+    cache = _transcode_cache_path(video_path, tcfg)
+    if cache.exists() and cache.stat().st_size > 0:
+        logger.info("♻️ Reusing cached platform-safe clip: %s", cache)
+        return cache
+
+    logger.info("🎬 %s needs transcode: %s", video_path.name, reason)
+    if _run_ffmpeg_transcode(video_path, cache, tcfg):
+        before_mb = probe["size"] / 1_048_576
+        after_mb = cache.stat().st_size / 1_048_576
+        logger.info(
+            "✅ Transcoded %s: %.0f MB → %.0f MB (%s).",
+            video_path.name, before_mb, after_mb, cache.name,
+        )
+        return cache
+    return video_path
+
+
 def load_clip_payload(notion, editorial_row: dict, video_cols: dict, clip_cols: dict) -> ClipPayload:
     """Resolve the shared clip relation off the editorial row and build a payload.
 
@@ -329,6 +513,11 @@ def load_clip_payload(notion, editorial_row: dict, video_cols: dict, clip_cols: 
     # an online-only OneDrive placeholder passes .exists() but uploads as no/partial
     # media (issue #104). Raises loudly if it can't hydrate within the budget.
     ensure_local_file(video_path)
+    # Transcode a platform-safe derivative if the master is too heavy / carries
+    # subtitle or data tracks — X rejects such clips (issue #107). All five
+    # consumers feed off this one ``video_path``, so doing it here covers every
+    # platform uniformly; the OneDrive master is never modified.
+    video_path = ensure_platform_safe_clip(video_path)
     if not thumb_path.exists():
         # Thumb is optional — some platforms auto-generate one. Log but don't fail.
         logger.warning("⚠️ Thumb not found (continuing without): %s", thumb_path)
@@ -389,6 +578,7 @@ __all__ = [
     "ClipPayload",
     "configure_logger",
     "ensure_local_file",
+    "ensure_platform_safe_clip",
     "first_clip_relation_id",
     "is_online_only",
     "load_clip_payload",

--- a/planning/videos/videos_twitter.py
+++ b/planning/videos/videos_twitter.py
@@ -57,32 +57,111 @@ class VideoRow:
         return self.day.strftime("%Y%m%d")
 
 
+def _primary_button_enabled(page) -> Optional[bool]:
+    """Tri-state for X's composer primary action button.
+
+    Returns True if enabled, False if present-but-disabled, None if not found.
+    X keeps this button (``tweetButton``) disabled while an attached video is
+    still uploading / processing and re-enables it once the clip is ready (we
+    always type a caption first, so a disabled button after attaching media
+    means the upload is still in flight, not an empty composer).
+
+    Scoped to the composer ``[role="dialog"]`` on purpose: the home timeline's
+    inline composer (``tweetButtonInline``, outside any dialog) is always present
+    and permanently disabled because it's empty. An unscoped ``.last`` selector
+    picks *that* button and so never sees the real, enabled Schedule button —
+    the actual root cause of the "X never schedules the video" hang (issue #107,
+    correcting #106). Confirmed live: the in-dialog ``tweetButton`` enables ~8 s
+    after the upload's STATUS=succeeded while the inline one stays disabled.
+    """
+    loc = page.locator(
+        '[role="dialog"] [data-testid="tweetButton"], '
+        '[role="dialog"] [data-testid="tweetButtonInline"]'
+    ).last
+    try:
+        if not loc.count():
+            return None
+        aria = loc.get_attribute("aria-disabled")
+        dis = loc.get_attribute("disabled")
+        return aria in (None, "false") and dis is None
+    except Exception:
+        return None
+
+
+def _video_upload_in_progress(page) -> bool:
+    """True while X is still uploading / processing the attached clip.
+
+    Signal: the composer's primary action button is present-but-disabled. We
+    always type a caption before attaching media, so a disabled button means the
+    clip is still uploading/processing, not an empty composer. (We deliberately
+    do NOT key off ``[role="progressbar"]`` — the composer's video *player* mounts
+    its own scrubber/volume progressbars once the preview renders, so that signal
+    is a false positive that never clears; confirmed live in issue #107.)
+    """
+    return _primary_button_enabled(page) is False
+
+
+def _wait_for_video_upload_ready(page, timeout_ms: int) -> None:
+    """Block until X finishes uploading / processing the clip, BEFORE scheduling.
+
+    ``_upload_image`` only waits for the preview thumbnail to render — X keeps
+    uploading the full clip in the background. Opening the schedule modal and
+    confirming *during* that window stalls finalization: the final Schedule
+    button then never enables, even for a small, platform-safe clip (issue #107,
+    on top of #106). So we wait for the upload to settle here, before touching
+    the schedule flow — mirroring LinkedIn's ``_wait_for_video_ready`` and the
+    IG upload settle. Raises ``RuntimeError`` if it never settles.
+    """
+    # Give the upload a moment to register an in-progress signal — a tiny clip
+    # may already be done, in which case we proceed straight away.
+    appear_deadline = page.evaluate("() => Date.now()") + 10000
+    saw_progress = False
+    while page.evaluate("() => Date.now()") < appear_deadline:
+        if _video_upload_in_progress(page):
+            saw_progress = True
+            break
+        page.wait_for_timeout(250)
+    if not saw_progress:
+        logger.info("ℹ️ TW: no upload-in-progress signal seen — clip appears ready.")
+        return
+
+    logger.info("⏳ TW clip still uploading/processing — waiting before schedule…")
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    last = None
+    while page.evaluate("() => Date.now()") < deadline:
+        if not _video_upload_in_progress(page):
+            logger.info("✅ TW clip upload/processing complete — proceeding to schedule.")
+            page.wait_for_timeout(800)
+            return
+        state = f"progress/button-disabled (btn_enabled={_primary_button_enabled(page)})"
+        if state != last:
+            logger.debug("⏳ TW upload not ready (%s) — polling…", state)
+            last = state
+        page.wait_for_timeout(500)
+    raise RuntimeError(
+        "TW clip upload/processing never settled — X did not finish accepting the "
+        "clip within the wait window. The .mp4 may still exceed X's limits "
+        "(≈512 MB / 2:20 / ~25 Mbps) or X is degraded; retry later."
+    )
+
+
 def _wait_tweet_button_enabled(page, timeout_ms: int) -> None:
     """Wait until X's final Schedule (tweetButton) is no longer disabled.
 
-    X keeps the composer's primary button ``aria-disabled`` while an uploaded
-    video is still processing server-side. ``_click_final_schedule_action`` uses
-    a JS-click fallback that *bypasses* the disabled state, so clicking during
-    that window is a silent no-op — the schedule never submits and the composer
-    never clears (issue #106). Poll until it enables (mirrors the Instagram /
-    LinkedIn ready-waits). Raises ``RuntimeError`` if it never enables.
+    Safety net after Confirm in the schedule modal — by this point the upload
+    has already settled (see ``_wait_for_video_upload_ready``), so this normally
+    returns immediately. ``_click_final_schedule_action`` uses a JS-click
+    fallback that *bypasses* the disabled state, so clicking while still disabled
+    is a silent no-op — the schedule never submits and the composer never clears
+    (issue #106). Raises ``RuntimeError`` if it never enables.
     """
     deadline = page.evaluate("() => Date.now()") + timeout_ms
     last = None
     while page.evaluate("() => Date.now()") < deadline:
-        loc = page.locator(
-            '[data-testid="tweetButton"], button[data-testid="tweetButtonInline"]'
-        ).last
-        state = "not found"
-        try:
-            if loc.count():
-                aria = loc.get_attribute("aria-disabled")
-                dis = loc.get_attribute("disabled")
-                if aria in (None, "false") and dis is None:
-                    return
-                state = f"aria-disabled={aria} disabled={dis}"
-        except Exception:
-            state = "error reading state"
+        enabled = _primary_button_enabled(page)
+        if enabled is True:
+            return
+        state = "not found" if enabled is None else "disabled"
         if state != last:
             logger.debug("⏳ TW final Schedule not ready (%s) — polling…", state)
             last = state
@@ -112,6 +191,10 @@ def schedule_one_video(
     # X's fileInput accepts .mp4 directly — same helper as image upload.
     _upload_image(page, row.payload.video_path)
     page.wait_for_timeout(2500)
+    # Wait for X to finish uploading/processing the clip BEFORE opening the
+    # schedule modal — confirming a schedule mid-upload stalls finalization and
+    # the final Schedule button then never enables (issue #107).
+    _wait_for_video_upload_ready(page, VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS)
     _click_schedule_toolbar(page)
     _set_schedule_modal(
         page, row.day,


### PR DESCRIPTION
## Summary

Fixes the weekly clip never scheduling on X (Twitter), and transcodes clips to platform-safe specs before upload.

While validating #107 live, the issue's premise turned out to be a misdiagnosis. A network trace of the composer showed X ingests and processes the clip every time (`INIT` → `APPEND` → `FINALIZE` → `STATUS` = `succeeded`, ~8 s) — it was never file weight, the subtitle track, or bandwidth. The real bug: the video driver's button-wait used `.last` of a selector matching **both** `tweetButton` (the composer modal's real Schedule button) **and** `tweetButtonInline` (the home timeline's empty, permanently-disabled inline composer). `.last` picked the inline one, so the wait timed out forever even though the real button was enabled. This also explains why #106's video fix never actually worked.

### Changes

- **Root-cause fix** — `_primary_button_enabled` scopes the button lookup to the composer `[role="dialog"]`, excluding the always-disabled home inline button.
- **Readiness signal** — gate on the button enabling, not `[role="progressbar"]` (the composer's video *player* mounts scrubber progressbars that never clear). New `_wait_for_video_upload_ready` lets the upload settle before the schedule modal opens.
- **Transcode** — `ensure_platform_safe_clip` normalizes a heavy/subtitled master (~30 Mbps / 200+ MB / `mov_text`, over X's ~25 Mbps ceiling) to H.264 high, bitrate-capped, AAC, subtitle/data tracks dropped, `+faststart`. Cached in system temp by mtime+size; OneDrive master untouched; graceful fallback when `ffmpeg`/`ffprobe` are missing. Uniform across all five platforms. New `videos.transcode` config block.

## Validation

`py_compile` clean on all touched modules (no linter/test suite configured in this repo). End-to-end **live**: the `20260609` clip now schedules on X for 19:00 — driver returned `TW:LIVE`, composer cleared. Transcode verified on the real master: 202 MB / 30.1 Mbps / subtitle → 64.4 MB / 9.6 Mbps / clean, cache reuse confirmed, master byte-identical.

Closes #107
