### PR TITLE
docs: fix stale invocations and inaccurate claims in README Advanced Config sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,23 +654,23 @@ ORDER BY date DESC;
 
 ### Debug Mode
 
-Most scripts support debug mode for detailed logging:
-```bash
-python script_name.py --debug
+Most scripts support debug mode for detailed logging. Use the venv-explicit module form (see Debug Commands below for ready-to-run examples):
+```powershell
+& .\.venv\Scripts\python.exe -m reporting.process.data_processor --debug
 ```
 
 ### Environment-Specific Settings
 
 Switch between local and cloud databases:
-```bash
-python supabase_uploader.py --environment local
+```powershell
+& .\.venv\Scripts\python.exe -m reporting.process.supabase_uploader --environment local
 ```
 
 ### Custom Configurations
 
 Override default configuration files:
-```bash
-python notion_supabase_sync.py --config custom_config.json
+```powershell
+& .\.venv\Scripts\python.exe -m reporting.notion.notion_supabase_sync --config custom_config.json
 ```
 
 ## 🐛 Troubleshooting
@@ -715,9 +715,7 @@ python notion_supabase_sync.py --config custom_config.json
 ## 📈 Performance Optimization
 
 - **Batch Processing**: Data is processed in batches to handle large datasets
-- **Incremental Sync**: Only new/modified data is synced to avoid redundant operations
-- **Connection Pooling**: Database connections are pooled for efficiency
-- **Smart Caching**: API responses are cached daily to minimize API calls
+- **Incremental Sync**: Only new/modified data is synced — `reporting_pipeline.py` skips re-fetch when today's JSON file already exists (`check_file_exists_for_date`), acting as an idempotent re-run guard
 
 ## 🔐 Security Best Practices
 
@@ -726,11 +724,9 @@ python notion_supabase_sync.py --config custom_config.json
    - Use `.env` files for database credentials
    - Rotate API keys regularly
 
-2. **Use environment variables in production**
-   ```bash
-   export SUPABASE_URL="your-url"
-   export SUPABASE_KEY="your-key"
-   ```
+2. **Store credentials in the right place**
+   - Supabase URL and key go in `config/config.json` (`supabase.url`, `supabase.key` / `supabase.service_role_key`) — keep that file out of version control
+   - PostgreSQL connection credentials go in `.env` (read by `python-dotenv` at startup)
 
 3. **Implement access controls**
    - Use read-only database users where possible
@@ -746,13 +742,13 @@ python notion_supabase_sync.py --config custom_config.json
    - Define field mappings in `mapping.json`
 
 2. **Test data collection**
-   ```bash
-   python social_api_client.py --platform new_platform --debug
+   ```powershell
+   & .\.venv\Scripts\python.exe -m reporting.social_client.social_api_client --platform new_platform --debug
    ```
 
 3. **Verify processing**
-   ```bash
-   python data_processor.py --debug
+   ```powershell
+   & .\.venv\Scripts\python.exe -m reporting.process.data_processor --debug
    ```
 
 ### Extending Functionality


### PR DESCRIPTION
## Summary

- **Debug Mode / Env-Specific / Custom Configs (lines 654–674):** replaced all naked `python script.py` calls with the venv-explicit module form (`& .\.venv\Scripts\python.exe -m reporting.*`) mandated by CLAUDE.md, and fixed wrong top-level script paths to correct `reporting.process.*` / `reporting.notion.*` module paths.
- **Performance Optimization (lines 715–720):** dropped the false "Connection Pooling" and "Smart Caching" bullets (no pool in `supabase_uploader.py`, no cache layer — just an idempotent daily-file guard); rewrote Incremental Sync to accurately describe `check_file_exists_for_date`.
- **Security Best Practices (lines 729–733):** replaced the non-existent `export SUPABASE_URL` / `export SUPABASE_KEY` snippet (no code in the repo reads those vars) with a description of the actual credential mechanism: `config/config.json` for Supabase, `.env` via `python-dotenv` for PostgreSQL.
- **Adding New Platforms (lines 744–756):** fixed both example commands to use the venv-explicit module form with correct paths.

## Validation

- No Python files changed — no py_compile / pytest applicable.
- `git diff main...HEAD` reviewed: only README.md, exactly the five finding areas from the issue, nothing outside scope.
- All corrected invocations cross-checked against actual module paths (`reporting/process/`, `reporting/notion/`, `reporting/social_client/`) and confirmed flags (`--environment`, `--config`, `--debug`) exist in the respective `argparse` setups.
- No CI workflows in this repo — docs-only change, no CI wait needed.

Closes #111
