### PR TITLE
chore: hoist load_notion_token and load_config_block into _session_base

### DIFF
--- a/planning/_session_base.py
+++ b/planning/_session_base.py
@@ -26,6 +26,7 @@ single-source here — never re-inline it in a platform module.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +40,7 @@ from config.logger_config import setup_logger
 
 # Repo root is two levels up from this file: planning/_session_base.py -> repo.
 REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "config" / "config.json"
 
 
 class LoginRequiredError(RuntimeError):
@@ -54,6 +56,38 @@ def configure_logger(name: str, debug: bool = False) -> logging.Logger:
     """Set up a logger using the project-wide pattern."""
     level = logging.DEBUG if debug else logging.INFO
     return setup_logger(name, level=level, file_logging=True)
+
+
+def load_notion_token() -> str:
+    """Load Notion API token from config.json.
+
+    Single-source for every platform session — platform modules re-export this
+    name so existing ``from planning.<P>.<P>_session import load_notion_token``
+    imports keep resolving unchanged.
+    """
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
+        cfg = json.load(fp)
+    token = cfg.get("notion", {}).get("api_token")
+    if not token:
+        raise RuntimeError("Missing 'notion.api_token' in config.json")
+    return token
+
+
+def load_config_block(name: str) -> dict:
+    """Load and return a named top-level block from config.json.
+
+    Single-source for the ``load_<platform>_config()`` helpers: each is the
+    same open/parse/raise body differing only by the block name. Platform
+    modules define a thin one-liner — ``return load_config_block("<name>")``
+    — so the logic lives once here. Re-export the per-platform name so
+    call sites are untouched.
+    """
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
+        cfg = json.load(fp)
+    block = cfg.get(name)
+    if not block:
+        raise RuntimeError(f"Missing '{name}' block in config.json")
+    return block
 
 
 def _resolve_user_data_dir(rel_or_abs: str, *, example_subdir: str = "<platform>/chrome_user_data") -> Path:
@@ -200,10 +234,13 @@ class PlatformSession:
 
 
 __all__ = [
+    "CONFIG_PATH",
     "REPO_ROOT",
     "LoginRequiredError",
     "PlatformSession",
     "configure_logger",
+    "load_config_block",
+    "load_notion_token",
     "_resolve_user_data_dir",
     "_user_data_dir_initialized",
 ]

--- a/planning/instagram/instagram_session.py
+++ b/planning/instagram/instagram_session.py
@@ -19,7 +19,6 @@ specific to Meta.
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -30,10 +29,10 @@ from planning._session_base import (  # noqa: E402
     PlatformSession,
     _resolve_user_data_dir,
     _user_data_dir_initialized,
+    load_config_block,
+    load_notion_token,
 )
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
 
 __all__ = [
     "InstagramSession",
@@ -54,32 +53,12 @@ def configure_logger(name: str = "instagram", debug: bool = False) -> logging.Lo
 
 def load_instagram_config() -> dict:
     """Load and return the `instagram` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("instagram")
-    if not block:
-        raise RuntimeError("Missing 'instagram' block in config.json")
-    return block
+    return load_config_block("instagram")
 
 
 def load_clone_config() -> dict:
     """Load and return the `clone_ig_to_others` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("clone_ig_to_others")
-    if not block:
-        raise RuntimeError("Missing 'clone_ig_to_others' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    """Load Notion API token from config.json (reuses existing notion block)."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("clone_ig_to_others")
 
 
 class InstagramSession(PlatformSession):

--- a/planning/linkedin/linkedin_session.py
+++ b/planning/linkedin/linkedin_session.py
@@ -20,7 +20,6 @@ specific to LinkedIn.
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from datetime import datetime
@@ -33,10 +32,10 @@ from planning._session_base import (  # noqa: E402
     PlatformSession,
     _resolve_user_data_dir,
     _user_data_dir_initialized,
+    load_config_block,
+    load_notion_token,
 )
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
 
 __all__ = [
     "LinkedInSession",
@@ -67,22 +66,7 @@ def configure_logger(name: str = "linkedin", debug: bool = False) -> logging.Log
 
 def load_linkedin_config() -> dict:
     """Load and return the `linkedin` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("linkedin")
-    if not block:
-        raise RuntimeError("Missing 'linkedin' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    """Load Notion API token from config.json (reuses existing notion block)."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("linkedin")
 
 
 class LinkedInSession(PlatformSession):

--- a/planning/substack/substack_session.py
+++ b/planning/substack/substack_session.py
@@ -21,7 +21,6 @@ specific to Substack.
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from datetime import datetime
@@ -34,10 +33,10 @@ from planning._session_base import (  # noqa: E402
     PlatformSession,
     _resolve_user_data_dir,
     _user_data_dir_initialized,
+    load_config_block,
+    load_notion_token,
 )
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
 
 __all__ = [
     "SubstackSession",
@@ -72,22 +71,7 @@ def configure_logger(name: str = "substack", debug: bool = False) -> logging.Log
 
 def load_substack_config() -> dict:
     """Load and return the `substack` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("substack")
-    if not block:
-        raise RuntimeError("Missing 'substack' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    """Load Notion API token from config.json (reuses existing notion block)."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("substack")
 
 
 class SubstackSession(PlatformSession):

--- a/planning/threads/threads_session.py
+++ b/planning/threads/threads_session.py
@@ -17,7 +17,6 @@ specific to Threads.
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -28,10 +27,10 @@ from planning._session_base import (  # noqa: E402
     PlatformSession,
     _resolve_user_data_dir,
     _user_data_dir_initialized,
+    load_config_block,
+    load_notion_token,
 )
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
 
 __all__ = [
     "ThreadsSession",
@@ -51,22 +50,7 @@ def configure_logger(name: str = "threads", debug: bool = False) -> logging.Logg
 
 def load_threads_config() -> dict:
     """Load and return the `threads` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("threads")
-    if not block:
-        raise RuntimeError("Missing 'threads' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    """Load Notion API token from config.json (reuses existing notion block)."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("threads")
 
 
 class ThreadsSession(PlatformSession):

--- a/planning/twitter/twitter_session.py
+++ b/planning/twitter/twitter_session.py
@@ -13,7 +13,6 @@ specific to X.
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -24,10 +23,10 @@ from planning._session_base import (  # noqa: E402
     PlatformSession,
     _resolve_user_data_dir,
     _user_data_dir_initialized,
+    load_config_block,
+    load_notion_token,
 )
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
 
 # Re-exported so callers' `except LoginRequiredError` / `_resolve_user_data_dir`
 # / `_user_data_dir_initialized` imports keep resolving against this module.
@@ -49,22 +48,7 @@ def configure_logger(name: str = "twitter", debug: bool = False) -> logging.Logg
 
 def load_twitter_config() -> dict:
     """Load and return the `twitter` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("twitter")
-    if not block:
-        raise RuntimeError("Missing 'twitter' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    """Load Notion API token from config.json (reuses existing notion block)."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("twitter")
 
 
 class TwitterSession(PlatformSession):

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -36,6 +36,7 @@ from typing import Optional
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from planning._session_base import configure_logger as _configure_logger  # noqa: E402
+from planning._session_base import load_config_block, load_notion_token  # noqa: E402
 from reporting.notion.editorial import (  # noqa: E402
     get_field,
     get_page_body_text,
@@ -43,9 +44,6 @@ from reporting.notion.editorial import (  # noqa: E402
 )
 
 logger = logging.getLogger("videos_session")
-
-CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "config.json"
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Per-platform role suffixes on the editorial DB. The roles are wired in
 # config under ``videos.editorial_columns`` as e.g. ``clip_rel_li`` and
@@ -92,21 +90,7 @@ def configure_logger(name: str = "videos", debug: bool = False) -> logging.Logge
 
 def load_videos_config() -> dict:
     """Return the ``videos`` block from config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get("videos")
-    if not block:
-        raise RuntimeError("Missing 'videos' block in config.json")
-    return block
-
-
-def load_notion_token() -> str:
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
-    if not token:
-        raise RuntimeError("Missing 'notion.api_token' in config.json")
-    return token
+    return load_config_block("videos")
 
 
 def first_clip_relation_id(editorial_row: dict, video_cols: dict) -> Optional[str]:


### PR DESCRIPTION
## Summary

- Add `load_notion_token()` and `load_config_block(name: str) -> dict` to `planning/_session_base.py` so the open/parse/raise logic for config loading lives in exactly one place
- All six platform session modules (`instagram`, `threads`, `twitter`, `linkedin`, `substack`, `videos`) now delegate to these helpers: each `load_<P>_config()` becomes a one-liner and `load_notion_token` is a direct re-export from the base
- Remove six duplicate `json.load` bodies and six per-module `CONFIG_PATH` constants; all existing `from planning.<P>.<P>_session import ...` call sites are untouched

## Validation

- `py_compile` on all 7 modified files: OK
- Import identity check: all platform `load_notion_token` re-exports are the same object as `_session_base.load_notion_token` (no copies)
- Delegation check: `load_<P>_config` functions verified to call `load_config_block` via `inspect.getsource`
- `git diff main...HEAD` reviewed: no unintended changes, no removed tests, no dependency bumps

Closes #94