### PR TITLE
fix: schedule IG video via the Reels composer (issue #118)

### DIFF
--- a/planning/instagram/schedule_instagram_posts.py
+++ b/planning/instagram/schedule_instagram_posts.py
@@ -762,129 +762,6 @@ def _count_composer_media(page: Page) -> int:
         return 0
 
 
-def _delete_extra_media_tiles(page: Page, target: int) -> int:
-    """Dismiss attached-media tiles until the composer shows ``target`` tiles.
-
-    LIFO — the duplicate from a re-upload race is always the newer tile.
-    Verified live (probe_meta_composer.py): clicking the trash button on
-    a tile removes it immediately; Meta does NOT open a confirmation
-    popover. Stops as soon as ``count <= target`` is reached, or aborts
-    if a click makes no progress.
-
-    Issue #37 — designed to recover from a duplicate-attach so the live
-    run does not deadlock waiting for the user to intervene in the
-    browser.
-    """
-    js_delete_last = r"""
-    () => {
-        const labelRe = /^(remove|delete|eliminar|quitar)\s+(video|photo|media|attachment|file|image|v[ií]deo|foto)\b/i;
-        const buttons = Array.from(document.querySelectorAll('[role="button"], button'))
-            .filter(b => labelRe.test(((b.innerText || '') + '').trim()));
-        if (!buttons.length) return false;
-        const last = buttons[buttons.length - 1];
-        last.scrollIntoView({block: 'center'});
-        last.click();
-        return true;
-    }
-    """
-    count = _count_composer_media(page)
-    if count <= target:
-        return count
-    logger.warning(
-        "⚠️ composer shows %d attached media (target %d) — attempting "
-        "LIFO delete recovery (issue #37 duplicate-attach).",
-        count, target,
-    )
-    safety = 0
-    while count > target and safety < (count - target) + 3:
-        safety += 1
-        try:
-            clicked = bool(page.evaluate(js_delete_last))
-        except Exception as err:
-            logger.warning("⚠️ Delete-last click failed: %s — aborting recovery.", err)
-            break
-        if not clicked:
-            logger.warning("⚠️ No delete button found in composer — aborting recovery.")
-            break
-        page.wait_for_timeout(700)
-        new_count = _count_composer_media(page)
-        if new_count >= count:
-            logger.warning("⚠️ Delete made no progress (%d→%d) — aborting recovery.", count, new_count)
-            break
-        logger.info("🧹 Dedupe: %d → %d tile(s).", count, new_count)
-        count = new_count
-    return count
-
-
-def _assert_composer_media_count(page: Page, expected: int) -> None:
-    """Verify Meta's composer shows exactly ``expected`` attached media tiles.
-
-    Raises ``RuntimeError`` on a confirmed mismatch (>0 but != expected).
-    A 0 result is logged but does not raise — the probe is best-effort
-    and 0 may mean "selector drift" rather than "really empty". Callers
-    that need to GUARANTEE attached media should pair this with
-    ``_count_composer_media`` themselves.
-    """
-    count = _count_composer_media(page)
-    logger.info("🔢 composer media-count probe: %d (expected %d).", count, expected)
-    if count == 0:
-        logger.warning(
-            "⚠️ media-count probe returned 0 — selector may be stale. "
-            "Not blocking; if Schedule fails to enable, this probe is "
-            "the first thing to fix (issue #37 reference)."
-        )
-        return
-    if count != expected:
-        raise RuntimeError(
-            f"IG composer reports {count} attached media after upload "
-            f"(expected {expected}) — likely duplicated attach (issue #37). "
-            f"Aborting before Schedule deadlock."
-        )
-
-
-def _check_meta_video_error_toast(page: Page) -> Optional[str]:
-    """Scan the composer for Meta's video-rejection error toasts.
-
-    Returns the matched toast text (truncated) if one is visible, else
-    None. Callers raise so the existing FAIL handler screenshots and
-    records the row. Known strings (Meta A/Bs these — substring scan over
-    role=alert / role=status nodes):
-
-    - "more than 1 minute"
-    - "only post one video"
-    - "video is too long"
-    """
-    patterns = [
-        "more than 1 minute",
-        "only post one video",
-        "can only post one video",
-        "can only upload one video",
-        "video is too long",
-    ]
-    try:
-        toast_text = page.evaluate(
-            """
-            (patterns) => {
-                const nodes = Array.from(document.querySelectorAll(
-                    '[role="alert"],[role="status"]'
-                ));
-                for (const n of nodes) {
-                    const t = (n.innerText || '').toLowerCase();
-                    for (const p of patterns) {
-                        if (t.includes(p)) return t.trim().slice(0, 240);
-                    }
-                }
-                return null;
-            }
-            """,
-            patterns,
-        )
-    except Exception as err:
-        logger.debug("Meta-error-toast probe failed: %s", err)
-        return None
-    return toast_text
-
-
 # Meta renders date and time controls as ``div[role="button"]`` with the
 # formatted text inside, NOT as <input> elements. Click opens a calendar /
 # typeahead — same pattern LinkedIn uses. Regexes are intentionally NOT
@@ -1367,6 +1244,228 @@ def _set_all_visible_date_time(
         "🕒 Updated %d date input(s) and %d time triplet(s) → %s %d:%02d %s",
         n_dates, n_hours, date_str, h12, minute, mer,
     )
+
+
+# ---------- Reels composer (issue #118) ----------
+#
+# Instagram now requires vertical 9:16 video to go through the dedicated Reels
+# composer ("Create reel" in the day's Schedule ▾ menu). The feed-post composer
+# rejects anything outside Instagram's 4:5–16:9 range ("doesn't fit within
+# Instagram's accepted aspect ratio range…") and keeps Schedule disabled — and
+# it also duplicates a single video set_files into two tiles. The Reels composer
+# avoids both: it accepts 9:16 and attaches one tile per file.
+#
+# It is a full-page wizard at /latest/reels_composer/ (NOT a modal):
+#   Add Video → fill caption → footer "Next" (enables once the upload hits 100%)
+#   → "Scheduling options" → pick "Schedule" (reveals the mm/dd/yyyy + hours/
+#   minutes/meridiem inputs that _set_all_visible_date_time already drives) →
+#   footer "Schedule".
+# Selectors verified live, 2026-06.
+
+REELS_COMPOSER_URL_FRAGMENT = "reels_composer"
+
+# The footer action ("Next" / "Schedule") is the bottom-most button whose
+# trimmed innerText equals the label — the thumbnail widget mounts its own
+# "Next", so we always key off the LAST match.
+_REEL_FOOTER_STATE_JS = r"""
+(label) => {
+    const bs = Array.from(document.querySelectorAll('[role="button"],button'))
+        .filter(b => ((b.innerText || '') + '').trim() === label);
+    if (!bs.length) return {found: false, disabled: null};
+    return {found: true, disabled: bs[bs.length - 1].getAttribute('aria-disabled')};
+}
+"""
+
+_REEL_FOOTER_CLICK_JS = r"""
+(label) => {
+    const bs = Array.from(document.querySelectorAll('[role="button"],button'))
+        .filter(b => ((b.innerText || '') + '').trim() === label);
+    if (!bs.length) return false;
+    bs[bs.length - 1].click();
+    return true;
+}
+"""
+
+# The "Schedule" radio option on the Scheduling-options step is the FIRST node
+# whose trimmed text equals "Schedule" (the footer action is later in the DOM).
+_REEL_SCHEDULE_OPTION_JS = r"""
+() => {
+    const els = Array.from(document.querySelectorAll('[role="radio"],[role="button"],label,div'));
+    const opt = els.find(e => ((e.innerText || '') + '').trim() === 'Schedule');
+    if (!opt) return false;
+    opt.click();
+    return true;
+}
+"""
+
+
+def _wait_reels_composer_ready(page: Page, *, timeout_ms: int = 30000) -> None:
+    """Wait for the Reels composer page to load and its 'Add Video' button.
+
+    "Create reel" is a full-page navigation to /latest/reels_composer/, so we
+    wait on both the URL and the visible upload affordance before driving it.
+    """
+    add = page.get_by_role("button", name=re.compile(r"^Add Video$", re.I))
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    while page.evaluate("() => Date.now()") < deadline:
+        if REELS_COMPOSER_URL_FRAGMENT in (page.url or "").lower() and add.count():
+            try:
+                add.first.wait_for(state="visible", timeout=2000)
+                return
+            except Exception:
+                pass
+        page.wait_for_timeout(500)
+    raise RuntimeError(
+        "Reels composer did not load (no visible 'Add Video' button) — "
+        f"url={page.url!r}."
+    )
+
+
+def _reel_add_video(page: Page, video_path: Path) -> None:
+    """Click 'Add Video' and push the clip via the file chooser.
+
+    Mirrors ``_upload_files`` Leg 1 (Playwright click → JS-native retry) because
+    the Reels composer's button hits the same React handler-binding race the
+    post composer does. One file in → one tile here (the post composer's
+    duplicate-attach does not occur in the Reels composer).
+    """
+    add = page.get_by_role("button", name=re.compile(r"^Add Video$", re.I)).first
+    add.wait_for(state="visible", timeout=12000)
+
+    def _try(click_fn) -> Optional[object]:
+        try:
+            with page.expect_file_chooser(timeout=6000) as fc_info:
+                click_fn()
+            return fc_info.value
+        except Exception as err:
+            logger.debug("Reels 'Add Video' click → no FileChooser: %s", err)
+            return None
+
+    chooser = _try(lambda: add.click(timeout=5000))
+    if chooser is None:
+        page.wait_for_timeout(600)
+        chooser = _try(lambda: add.evaluate("el => el.click()"))
+    if chooser is None:
+        raise RuntimeError("Reels 'Add Video' did not open a file chooser.")
+    chooser.set_files([str(video_path)])
+    logger.info("📤 Reels: video sent via 'Add Video' file chooser.")
+    page.wait_for_timeout(2500)
+
+
+def _wait_reel_footer_enabled(
+    page: Page, label: str, *, timeout_ms: int = 120000, poll_ms: int = 1000,
+) -> None:
+    """Poll until the reels footer ``label`` button is present and enabled.
+
+    Meta keeps footer "Next" ``aria-disabled`` until the upload finishes
+    processing (the left rail shows the percentage climbing to 100%); a
+    multi-MB clip can take a while, hence the generous default.
+    """
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    last = None
+    while page.evaluate("() => Date.now()") < deadline:
+        st = page.evaluate(_REEL_FOOTER_STATE_JS, label)
+        if st["found"] and st["disabled"] not in ("true",):
+            return
+        if st != last:
+            logger.debug("⏳ reels footer '%s' state=%s, polling…", label, st)
+            last = st
+        page.wait_for_timeout(poll_ms)
+    raise RuntimeError(
+        f"Reels footer '{label}' stayed disabled/absent after {timeout_ms} ms — "
+        f"upload likely did not finish."
+    )
+
+
+def _click_reel_footer(page: Page, label: str) -> None:
+    """JS-native click the bottom-most reels footer button named ``label``."""
+    if not page.evaluate(_REEL_FOOTER_CLICK_JS, label):
+        raise RuntimeError(f"Reels footer '{label}' button not found.")
+    page.wait_for_timeout(1500)
+
+
+def _select_reel_schedule_option(page: Page) -> None:
+    """On the Scheduling-options step, pick 'Schedule' (vs 'Share now').
+
+    Selecting it reveals the date/time inputs and flips the footer action from
+    'Share now' to 'Schedule'. The time triplet (``aria-label="hours"`` etc.)
+    mounts a beat after the date input, so we wait for it before returning —
+    otherwise ``_set_all_visible_date_time`` finds the date input but 0 time
+    triplets and Schedule never enables.
+    """
+    if not page.evaluate(_REEL_SCHEDULE_OPTION_JS):
+        raise RuntimeError("Could not find the 'Schedule' option on the reels scheduling step.")
+    try:
+        page.locator('input[aria-label="hours"]').first.wait_for(state="attached", timeout=15000)
+    except Exception:
+        logger.warning("⚠️ reels time inputs did not mount after selecting 'Schedule' — proceeding anyway.")
+    page.wait_for_timeout(800)
+
+
+def _click_reel_calendar_day(page: Page, target: date) -> None:
+    """In the open reels date-calendar popup, navigate to the target month and
+    click the day cell.
+
+    The reels calendar labels day cells "Tuesday, 16 June 2026" (day-before-
+    month, no comma after the day) — distinct from the post/story composer's
+    "Tuesday, June 16, 2026", so it needs its own matcher. Forward-only month
+    navigation is enough: the calendar opens on the current month and video is
+    always scheduled for a future day.
+    """
+    day_aria = f"{target.strftime('%A')}, {target.day} {target.strftime('%B %Y')}"
+    for _ in range(18):  # ~1.5 years forward bound
+        if page.locator(f'[aria-label="{day_aria}"]').count():
+            break
+        nxt = page.get_by_role("button", name=NEXT_MONTH_BTN_RE)
+        if not nxt.count():
+            break
+        try:
+            nxt.first.click(timeout=3000)
+            page.wait_for_timeout(400)
+        except Exception:
+            break
+    cell = page.locator(f'[aria-label="{day_aria}"]')
+    if not cell.count():
+        raise RuntimeError(f"Reels calendar: could not find day cell {day_aria!r}.")
+    cell.first.click(timeout=5000)
+    page.wait_for_timeout(600)
+
+
+def _set_reel_schedule_datetime(page: Page, target: date, hour: int, minute: int) -> None:
+    """Set the reel's scheduled date + time on the Scheduling-options step.
+
+    The reels date field is a segmented editor pre-set to today; *typing* into
+    it (even valid digits) corrupts it and unmounts the whole scheduling form,
+    so the date is set by opening its calendar popup and clicking the target day
+    (see ``_click_reel_calendar_day``). The hours/minutes/meridiem triplet is a
+    plain input set and is typed exactly like the post/story composer.
+    """
+    date_inp = page.locator('input[placeholder="mm/dd/yyyy"]').first
+    date_inp.click(timeout=4000)
+    page.wait_for_timeout(800)
+    _click_reel_calendar_day(page, target)
+
+    h12 = hour % 12 or 12
+    mer = "AM" if hour < 12 else "PM"
+    try:
+        _fill_input(page, page.locator('input[aria-label="hours"]').first, str(h12))
+        _fill_input(page, page.locator('input[aria-label="minutes"]').first, f"{minute:02d}")
+        _fill_input(page, page.locator('input[aria-label="meridiem"]').first, mer)
+        page.keyboard.press("Tab")
+        page.wait_for_timeout(300)
+    except Exception as err:
+        raise RuntimeError(f"Could not set reel schedule time: {err}")
+    logger.info("🕒 Reel scheduled for %s %d:%02d %s", target.isoformat(), h12, minute, mer)
+
+
+def _wait_reel_composer_closes(page: Page, *, timeout_ms: int = 30000) -> bool:
+    """Wait until the URL leaves /reels_composer/ (the reel was scheduled)."""
+    deadline = page.evaluate("() => Date.now()") + timeout_ms
+    while page.evaluate("() => Date.now()") < deadline:
+        if REELS_COMPOSER_URL_FRAGMENT not in (page.url or "").lower():
+            return True
+        page.wait_for_timeout(500)
+    return False
 
 
 def schedule_story(

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -84,15 +84,20 @@ attach helper. See:
   typeahead dropdown (see Gotchas). After the final Schedule click,
   `wait_for_upload_complete` (same shared module) keeps the browser open
   until LinkedIn's background video upload settles (also see Gotchas).
-- Instagram (Meta planner): `planning/instagram/schedule_instagram_posts.py`
-  — same `Schedule post` menu, same FileChooser-intercept upload (accepts
-  .mp4), same `Set date and time` toggle + split hours/minutes/meridiem.
-  After upload the driver waits a short 2-second head-start, fills the
-  caption + date/time, then **polls the Schedule button's
-  `aria-disabled` attribute** (via `wait_action_button_enabled`, shared
-  helper in the IG planner module) for up to 90 s before clicking.
-  Meta keeps the Schedule control disabled until the .mp4 finishes
-  server-side transcoding; a fixed sleep is not reliable.
+- Instagram (Meta planner): `planning/videos/videos_instagram.py` via the
+  **Reels composer** (`Create reel` in the day's `Schedule ▾` menu), not the
+  feed-post composer (issue #118). Instagram rejects vertical 9:16 clips in the
+  post composer ("doesn't fit within Instagram's accepted aspect ratio range of
+  4:5 to 16:9", Schedule never enables) and also duplicates a single video
+  upload into two tiles there; the Reels composer accepts 9:16 and attaches one
+  tile per file. `Create reel` opens a full-page wizard at
+  `/latest/reels_composer/`: `Add Video` → fill caption → footer `Next` (which
+  stays `aria-disabled` until the upload hits 100%, polled via
+  `_wait_reel_footer_enabled`) → `Scheduling options` → pick `Schedule` → set
+  date/time → footer `Schedule`. The date field is a segmented editor pre-set to
+  today — *typing* corrupts it and unmounts the form, so the date is set by
+  clicking the target day in its calendar popup (`_set_reel_schedule_datetime`);
+  the hours/minutes/meridiem triplet is typed as usual.
 - Twitter (X): `planning/twitter/schedule_twitter_posts.py` — same
   `SideNav_NewTweet_Button`, same `fileInput` (accepts .mp4 directly),
   same `scheduleOption` + 6 native selects.

--- a/planning/videos/videos_instagram.py
+++ b/planning/videos/videos_instagram.py
@@ -1,10 +1,15 @@
 """Instagram (Meta planner) video composer driver for the weekly-video orchestrator.
 
-Walks the Meta Business planner for one clip: planner → hover day column →
-Schedule menu → Schedule post → close sub-modal → upload .mp4 → caption
-(short) → Set date and time → fill date+time → Schedule. Reuses every
-helper from ``planning.instagram.schedule_instagram_posts`` — Meta's
-composer accepts .mp4 through the same FileChooser path as images.
+Schedules one clip through Meta's **Reels** composer (issue #118): planner →
+hover day column → Schedule menu → "Create reel" → Add Video → caption →
+Next → Scheduling options → pick "Schedule" → fill date+time → Schedule.
+
+The feed-post composer is deliberately not used for video: Instagram rejects
+vertical 9:16 clips there ("doesn't fit within Instagram's accepted aspect
+ratio range of 4:5 to 16:9", Schedule never enables) and duplicates a single
+upload into two tiles. The Reels composer accepts 9:16 and attaches one tile
+per file. The reel-specific composer helpers (and the shared date/time +
+caption helpers) all live in ``planning.instagram.schedule_instagram_posts``.
 """
 
 from __future__ import annotations
@@ -25,22 +30,18 @@ from planning.instagram.instagram_session import (  # noqa: E402
     load_instagram_config,
 )
 from planning.instagram.schedule_instagram_posts import (  # noqa: E402
-    _assert_composer_media_count,
     _cancel_composer,
-    _check_meta_video_error_toast,
-    _click_action_button,
-    _count_composer_media,
-    _delete_extra_media_tiles,
-    _dismiss_initial_schedule_submodal,
-    _ensure_set_date_toggle_on,
+    _click_reel_footer,
     _fill_post_text,
     _open_day_schedule_menu,
-    _set_all_visible_date_time,
-    _upload_files,
-    _wait_composer_closes,
+    _reel_add_video,
+    _select_reel_schedule_option,
+    _set_reel_schedule_datetime,
+    _wait_reel_composer_closes,
+    _wait_reel_footer_enabled,
+    _wait_reels_composer_ready,
     dismiss_meta_verified_modal,
     return_to_planner,
-    wait_action_button_enabled,
 )
 from planning.videos.videos_session import ClipPayload  # noqa: E402
 
@@ -70,55 +71,33 @@ def schedule_one_video(
     page = session.page
     label = row.day_title
 
-    _open_day_schedule_menu(page, row.day, "Schedule post")
-    _dismiss_initial_schedule_submodal(page)
-    # Meta's "Add photo/video" accepts .mp4 — give the same helper a list of one.
-    # is_video=True narrows Leg 0 to the video-accept input (issue #37).
-    _upload_files(page, [row.payload.video_path], is_video=True)
-    # Video transcoding in Meta's composer takes noticeably longer than images.
-    # Give it a head-start before we poll, so we don't spin on a button that's
-    # been re-rendered by the upload mid-attach.
-    page.wait_for_timeout(2000)
+    # Issue #118 — schedule via the Reels composer, not the feed-post composer.
+    # Instagram rejects vertical 9:16 clips in the post composer ("doesn't fit
+    # within Instagram's accepted aspect ratio range of 4:5 to 16:9", Schedule
+    # never enables) and IG now routes video to reels anyway. "Create reel" is a
+    # full-page wizard that accepts 9:16 and attaches one tile per file (no
+    # duplicate-attach). See the Reels-composer section in
+    # ``schedule_instagram_posts`` for the verified-live selectors.
+    _open_day_schedule_menu(page, row.day, "Create reel")
+    _wait_reels_composer_ready(page)
 
-    # Issue #37 — duplicate-attach recovery + assertion.
-    # When Leg 0's set_input_files times out (Playwright's 4 s default was
-    # too tight for a multi-MB video, raised after the file was actually
-    # accepted), the legacy fallthrough opened the file chooser and
-    # attached the same clip TWICE. Leg 0 now race-guards, but we also
-    # defend in depth here: if the composer ends up with extra tiles for
-    # any reason, dedupe LIFO before driving the Schedule button.
-    pre_dedupe_count = _count_composer_media(page)
-    if pre_dedupe_count > 1:
-        logger.warning(
-            "⚠️ %s IG: composer shows %d media tiles after upload — "
-            "auto-deduping to 1 (issue #37).",
-            label, pre_dedupe_count,
-        )
-        final_count = _delete_extra_media_tiles(page, target=1)
-        # Give Meta a beat to re-evaluate the error toast / Schedule state.
-        page.wait_for_timeout(1500)
-        if final_count != 1:
-            # Dedupe over-deleted (e.g. 0 left) or could not make progress.
-            # Either way scheduling now would create an empty/duplicated
-            # post — abort hard so the FAIL handler screenshots the
-            # composer instead of driving Schedule.
-            raise RuntimeError(
-                f"Dedupe ended with {final_count} attached media tile(s) "
-                f"(expected 1) — aborting before Schedule click."
-            )
-
-    # Hard assertion: any remaining mismatch raises and the existing FAIL
-    # handler screenshots the composer for triage.
-    _assert_composer_media_count(page, expected=1)
-    # Check for Meta's "video too long" / "only one video" toast, which
-    # also keeps Schedule disabled. Surface it as an explicit FAIL.
-    toast = _check_meta_video_error_toast(page)
-    if toast:
-        raise RuntimeError(f"Meta rejected the video: {toast!r}")
-
+    _reel_add_video(page, row.payload.video_path)
+    # Caption lives on the reel-details step (fillable before the upload
+    # finishes processing).
     _fill_post_text(page, row.payload.caption_short)
-    _ensure_set_date_toggle_on(page)
-    _set_all_visible_date_time(
+
+    # Footer "Next" stays aria-disabled until Meta finishes processing the
+    # upload (the left rail counts up to 100%). A multi-MB clip can take a
+    # while, so wait generously before advancing.
+    _wait_reel_footer_enabled(page, "Next", timeout_ms=120000)
+    _click_reel_footer(page, "Next")
+
+    # Scheduling-options step: choose "Schedule" (vs "Share now") to reveal the
+    # date/time inputs, then set them. The reels date field is a segmented
+    # editor that must be set via its calendar popup (typing corrupts it) — see
+    # _set_reel_schedule_datetime.
+    _select_reel_schedule_option(page)
+    _set_reel_schedule_datetime(
         page, row.day,
         video_cfg["post_hour_local"], video_cfg["post_minute_local"],
     )
@@ -129,29 +108,20 @@ def schedule_one_video(
     if dry_run:
         shot = out_dir / f"{label}-ig-dryrun.png"
         page.screenshot(path=str(shot), full_page=False)
-        logger.info("✅ DRY-RUN %s IG: composer ready, screenshot → %s", label, shot)
+        logger.info("✅ DRY-RUN %s IG: reel composer ready, screenshot → %s", label, shot)
         _cancel_composer(page)
         return "IG:DRY"
 
-    # Wait for Meta's transcode to finish — the Schedule button is
-    # ``aria-disabled="true"`` while the upload is still being processed.
-    # 90 s is comfortably above the typical short-clip transcode time. If
-    # it never enables, check the error toast before erroring out so the
-    # FAIL detail names the actual Meta cause when present.
-    try:
-        wait_action_button_enabled(page, "Schedule", timeout_ms=90000)
-    except (RuntimeError, PWTimeoutError) as err:
-        late_toast = _check_meta_video_error_toast(page)
-        if late_toast:
-            raise RuntimeError(f"Meta rejected the video: {late_toast!r}") from err
-        raise
-    _click_action_button(page, "Schedule")
-    if not _wait_composer_closes(page, ig_cfg["feed_url"], timeout_ms=30000):
+    # Footer flips to "Schedule" once the Schedule option is selected; it stays
+    # aria-disabled until the date/time are valid and the upload is done.
+    _wait_reel_footer_enabled(page, "Schedule", timeout_ms=120000)
+    _click_reel_footer(page, "Schedule")
+    if not _wait_reel_composer_closes(page, timeout_ms=30000):
         shot = out_dir / f"{label}-ig-FAIL.png"
         page.screenshot(path=str(shot), full_page=False)
-        raise RuntimeError(f"IG composer did not close — see {shot}")
+        raise RuntimeError(f"IG reel composer did not close — see {shot}")
     page.wait_for_timeout(1500)
-    logger.info("✅ LIVE %s IG video scheduled", label)
+    logger.info("✅ LIVE %s IG video scheduled as reel", label)
     return "IG:LIVE"
 
 


### PR DESCRIPTION
## Summary

Fixes the IG video planning crash (#118). Reproduced live: a single video `set_files` makes Meta's **feed-post** composer materialize two identical tiles, the tiles render ~8 s after the chooser closes (the old ~6.5 s probe got 0, so the #37 dedup never fired), and — even after deduping to one tile — the post composer **rejects the 9:16 vertical clip** ("doesn't fit within Instagram's accepted aspect ratio range of 4:5 to 16:9"), so Schedule never enables.

Instagram now routes video to reels. So `videos_instagram.schedule_one_video` is pivoted to the **Reels composer** (`Create reel`), which accepts 9:16 and attaches one tile per file (the duplicate-attach simply doesn't occur there).

## Changes

- `planning/videos/videos_instagram.py` — drive the full-page reels wizard: `Add Video` → fill caption → footer `Next` (waits for the upload to hit 100% via `_wait_reel_footer_enabled`) → `Scheduling options` → select `Schedule` → set date/time → footer `Schedule`. Removed the post-composer upload + dedup path.
- `planning/instagram/schedule_instagram_posts.py` — new reels-composer helpers (`_wait_reels_composer_ready`, `_reel_add_video`, `_wait_reel_footer_enabled`, `_click_reel_footer`, `_select_reel_schedule_option`, `_set_reel_schedule_datetime`, `_click_reel_calendar_day`, `_wait_reel_composer_closes`). The reels date field is a segmented editor that **corrupts on typing** (unmounts the whole scheduling form), so the date is set by clicking the target day in its calendar popup; the hours/minutes/meridiem triplet is typed as before. Dropped three now-dead post-composer video helpers (`_delete_extra_media_tiles`, `_assert_composer_media_count`, `_check_meta_video_error_toast`).
- `planning/videos/README.md` — document the Reels-composer flow.

## Validation

- `py_compile` clean on all touched modules + `schedule_videos_posts.py`. No ruff configured; repo has no test suite.
- **Live behavioral verification** against the real planner with the failing clip (1080×1920, 1:01), replaying the shipped LIVE sequence verbatim and stopping short of the final click (no real post created):
  - `📤 Reels: video sent via 'Add Video' file chooser.` → exactly **one** tile, no aspect-ratio rejection.
  - `🕒 Reel scheduled for 2026-06-16 7:00 PM` (date via calendar click, time typed).
  - `FOOTER 'Schedule' ENABLED ✅` — screenshot confirms one clean reel, "Jun 16, 2026 | 07:00 PM (Europe/Madrid)", footer Schedule enabled.
- Not exercised live (would create a real scheduled reel): the final footer `Schedule` click + `_wait_reel_composer_closes`. Mechanics mirror the proven post/story composer pattern (JS-native click + URL-leaves-composer wait).

Closes #118
