### PR TITLE
chore: rename claude-config → fleet-config in tracked text files

### DIFF
--- a/.agents/skills/schedule-autoheal/SKILL.md
+++ b/.agents/skills/schedule-autoheal/SKILL.md
@@ -96,7 +96,7 @@ Leave the working tree clean (or the branch un-pushed) and hand off to a human.
 ## Step 5 — escalate via Slack, then stop
 
 Read the Slack target from `config/config.json` → `slack.autoheal_channel`. Send the
-ping through the **fleet-wide Slack bot helper** (provided by `claude-config`, available
+ping through the **fleet-wide Slack bot helper** (provided by `fleet-config`, available
 with zero install at `~/.claude/hooks/slack_notify.py`):
 
 ```
@@ -111,7 +111,7 @@ Why the bot and not the Slack MCP connector: the MCP connector posts **as the us
 Slack never fires a notification for it and the escalation lands silently — defeating the
 point of an unattended scheduler. The bot posts as a separate identity, which actually
 notifies. The bot token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never
-in this repo; see `claude-config/docs/slack-workflow.md`.
+in this repo; see `fleet-config/docs/slack-workflow.md`.
 
 If `autoheal_channel` is blank **or** the helper reports a failure (missing token, API
 error), surface that plainly in the run output and still **stop**. Either way: do not

--- a/.claude/skills/schedule-autoheal/SKILL.md
+++ b/.claude/skills/schedule-autoheal/SKILL.md
@@ -96,7 +96,7 @@ Leave the working tree clean (or the branch un-pushed) and hand off to a human.
 ## Step 5 — escalate via Slack, then stop
 
 Read the Slack target from `config/config.json` → `slack.autoheal_channel`. Send the
-ping through the **fleet-wide Slack bot helper** (provided by `claude-config`, available
+ping through the **fleet-wide Slack bot helper** (provided by `fleet-config`, available
 with zero install at `~/.claude/hooks/slack_notify.py`):
 
 ```
@@ -111,7 +111,7 @@ Why the bot and not the Slack MCP connector: the MCP connector posts **as the us
 Slack never fires a notification for it and the escalation lands silently — defeating the
 point of an unattended scheduler. The bot posts as a separate identity, which actually
 notifies. The bot token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never
-in this repo; see `claude-config/docs/slack-workflow.md`.
+in this repo; see `fleet-config/docs/slack-workflow.md`.
 
 If `autoheal_channel` is blank **or** the helper reports a failure (missing token, API
 error), surface that plainly in the run output and still **stop**. Either way: do not

--- a/docs/self-healing-scheduler.md
+++ b/docs/self-healing-scheduler.md
@@ -73,12 +73,12 @@ follow-up work).
 A fix lands end-to-end only when **all** hold: exactly one strong role/text
 candidate, the validating dry-run passes, and the diff is a pure selector-string
 change. Otherwise the skill escalates via the **fleet-wide Slack bot helper**
-(`~/.claude/hooks/slack_notify.py`, provided by `claude-config`) to the channel
+(`~/.claude/hooks/slack_notify.py`, provided by `fleet-config`) to the channel
 in `config/config.json` → `slack.autoheal_channel`, and stops. A bot identity is
 used deliberately: the claude.ai Slack MCP connector posts *as the user*, so Slack
 never fires a notification and the escalation would land silently. The bot token
 lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never in this repo;
-see `claude-config/docs/slack-workflow.md`.
+see `fleet-config/docs/slack-workflow.md`.
 
 ## The visible-console + tee mechanism
 

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -155,7 +155,7 @@ def _load_slack_notify():
     """Import the fleet-wide Slack helper from ``~/.claude/hooks/slack_notify.py``.
 
     Returns the module, or ``None`` if it can't be located/imported (logged).
-    The helper is provided by the ``claude-config`` project and reused fleet-wide
+    The helper is provided by the ``fleet-config`` project and reused fleet-wide
     (the same transport ``/schedule-autoheal`` uses) — do not reimplement it.
     """
     helper = Path.home() / ".claude" / "hooks" / "slack_notify.py"


### PR DESCRIPTION
## Summary

- Replace repo name token `claude-config` → `fleet-config` in all tracked text files: `.claude/skills/schedule-autoheal/SKILL.md`, `.agents/skills/schedule-autoheal/SKILL.md` (real copy, not a junction), `docs/self-healing-scheduler.md`, and `reporting_pipeline.py` docstring.
- `~/.claude/...` install-target paths are unchanged — only the repo name token was updated.

Follows decision record ferraroroberto/claude-config#100.

## Test plan

- [x] `grep -r "claude-config" .` on tracked files returns zero matches
- [x] `py_compile reporting_pipeline.py` passes
- No tests dir; no ruff installed — only gate applicable was syntax check

Closes #120