### PR TITLE
fix: detect IG reel 'Reel scheduled' dialog so a scheduled reel isn't FAILed

### DIFF
--- a/planning/instagram/schedule_instagram_posts.py
+++ b/planning/instagram/schedule_instagram_posts.py
@@ -1458,11 +1458,47 @@ def _set_reel_schedule_datetime(page: Page, target: date, hour: int, minute: int
     logger.info("🕒 Reel scheduled for %s %d:%02d %s", target.isoformat(), h12, minute, mer)
 
 
+# Anchored so it matches only the post-Schedule confirmation heading, never the
+# earlier "Schedule" radio option or the "Scheduling options" step label.
+REEL_SCHEDULED_DIALOG_RE = re.compile(r"^Reel scheduled$", re.I)
+
+
+def _reel_scheduled_dialog_visible(page: Page) -> bool:
+    """True when Meta's post-Schedule 'Reel scheduled' confirmation dialog is up."""
+    try:
+        loc = page.get_by_text(REEL_SCHEDULED_DIALOG_RE)
+        return loc.count() > 0 and loc.first.is_visible()
+    except Exception:
+        return False
+
+
+def _dismiss_reel_success_dialog(page: Page) -> None:
+    """Best-effort click 'Done' on the 'Reel scheduled' confirmation dialog so
+    the next day starts from a clean planner state."""
+    try:
+        done = page.get_by_role("button", name=re.compile(r"^Done$", re.I))
+        if done.count():
+            done.first.click(timeout=3000)
+            page.wait_for_timeout(800)
+    except Exception:
+        pass
+
+
 def _wait_reel_composer_closes(page: Page, *, timeout_ms: int = 30000) -> bool:
-    """Wait until the URL leaves /reels_composer/ (the reel was scheduled)."""
+    """Wait for either success signal that means the reel was scheduled.
+
+    Two outcomes count as success, either of which ends the wait:
+    (1) the URL leaves /reels_composer/ (Meta navigates back to the planner), or
+    (2) the in-place "Reel scheduled" confirmation dialog appears over the
+        composer while the URL stays on /latest/reels_composer/ (issue #125).
+        A URL-only check times out here and falsely reports failure even though
+        the reel IS scheduled; the caller dismisses the dialog via "Done".
+    """
     deadline = page.evaluate("() => Date.now()") + timeout_ms
     while page.evaluate("() => Date.now()") < deadline:
         if REELS_COMPOSER_URL_FRAGMENT not in (page.url or "").lower():
+            return True
+        if _reel_scheduled_dialog_visible(page):
             return True
         page.wait_for_timeout(500)
     return False

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -97,7 +97,13 @@ attach helper. See:
   date/time → footer `Schedule`. The date field is a segmented editor pre-set to
   today — *typing* corrupts it and unmounts the form, so the date is set by
   clicking the target day in its calendar popup (`_set_reel_schedule_datetime`);
-  the hours/minutes/meridiem triplet is typed as usual.
+  the hours/minutes/meridiem triplet is typed as usual. **Success signal:** after
+  the final `Schedule` click Meta does *not* always navigate back to the planner —
+  it often stays on `/latest/reels_composer/` behind an in-place `Reel scheduled`
+  confirmation dialog, so `_wait_reel_composer_closes` treats *either* the URL
+  leaving the composer *or* that dialog appearing as success, then clicks its
+  `Done` button (issue #125). A URL-only check false-FAILs an already-scheduled
+  reel.
 - Twitter (X): `planning/twitter/schedule_twitter_posts.py` — same
   `SideNav_NewTweet_Button`, same `fileInput` (accepts .mp4 directly),
   same `scheduleOption` + 6 native selects.

--- a/planning/videos/videos_instagram.py
+++ b/planning/videos/videos_instagram.py
@@ -32,6 +32,7 @@ from planning.instagram.instagram_session import (  # noqa: E402
 from planning.instagram.schedule_instagram_posts import (  # noqa: E402
     _cancel_composer,
     _click_reel_footer,
+    _dismiss_reel_success_dialog,
     _fill_post_text,
     _open_day_schedule_menu,
     _reel_add_video,
@@ -120,6 +121,10 @@ def schedule_one_video(
         shot = out_dir / f"{label}-ig-FAIL.png"
         page.screenshot(path=str(shot), full_page=False)
         raise RuntimeError(f"IG reel composer did not close — see {shot}")
+    # On success Meta may stay on /reels_composer/ behind a "Reel scheduled"
+    # confirmation dialog rather than navigating back — dismiss it so the next
+    # day starts from a clean planner state (issue #125).
+    _dismiss_reel_success_dialog(page)
     page.wait_for_timeout(1500)
     logger.info("✅ LIVE %s IG video scheduled as reel", label)
     return "IG:LIVE"


### PR DESCRIPTION
## Summary

A weekly-video IG reel that schedules correctly was being reported as a hard failure. After the final footer **Schedule** click, Meta's Reels composer often stays on `/latest/reels_composer/` and shows an in-place **"Reel scheduled"** confirmation dialog (Done button) instead of navigating back to the planner. `_wait_reel_composer_closes` detected success solely by the URL leaving `/reels_composer/`, so it timed out after 30s and raised `IG reel composer did not close` — a false FAIL on an already-scheduled reel.

The failure screenshot (`results/videos/20260623-ig-FAIL.png`) shows the "Reel scheduled" dialog up, confirming the post succeeded.

**Fix:**
- `_wait_reel_composer_closes` now treats the **"Reel scheduled"** dialog as a success signal in addition to the existing URL-leaves-composer signal.
- The dialog is dismissed via its **Done** button after success so the next day starts from a clean planner state.
- The dialog matcher is anchored (`^Reel scheduled$`) so it cannot fire on the earlier "Schedule" radio option or the "Scheduling options" step.

Feed-post / story / Threads / LinkedIn composers are untouched (those genuinely navigate away, so their URL-based checks are correct).

## Validation

- **py_compile** (both changed `.py`): `PY_COMPILE_OK`.
- **Behavioural repro/proof** — a probe exercising the *real* `_wait_reel_composer_closes` / `_reel_scheduled_dialog_visible` against a fake page reproducing the live state (dialog up, URL stuck on `/reels_composer/`). All checks pass:
  - `Reel scheduled` heading detected ✅
  - matcher not fooled by `Schedule` / `Scheduling options` ✅
  - **success dialog over composer URL → True** (the #125 fix; pre-fix returned False) ✅
  - URL-left-composer → True (existing signal preserved) ✅
  - stuck on composer, no dialog → False (real failure preserved) ✅
- **No test suite / ruff / verify-gate exists in this repo** — stated plainly rather than claimed green.
- **Diff sanity sweep:** only the two intended source files + the videos README; no dependency bumps, removed tests, or weakened assertions.

Closes #125
