### PR TITLE
docs: correct check_control_panel docstring port from :8502 to :8501

### DIFF
--- a/app/check_control_panel.py
+++ b/app/check_control_panel.py
@@ -1,12 +1,12 @@
 r"""End-to-end Playwright check of the control-panel app.
 
-Drives http://localhost:8502 (control panel) — different port from the
-legacy standalone review at :8501 so both can coexist during the
-transition. Verifies each pipeline tab renders + the engagement
-sub-tabs work.
+Drives http://localhost:8501 (Streamlit's default — what ``launch_app.bat``
+uses). Verifies each pipeline tab renders + the engagement sub-tabs work.
+Override the target with the APP_URL environment variable when the app is
+running on a non-default port.
 
 Usage (control panel must already be running):
-    & .\.venv\Scripts\python.exe -m streamlit run app\app.py --server.port 8502
+    launch_app.bat   # or: .venv\Scripts\python.exe -m streamlit run app\app.py
     & .\.venv\Scripts\python.exe -m app.check_control_panel
 """
 


### PR DESCRIPTION
## Summary

- The module docstring in `app/check_control_panel.py` documented a `:8501 vs :8502 port-coexistence transition` that was never implemented in `launch_app.bat`.
- `launch_app.bat` runs `streamlit run app\app.py` with no `--server.port`, i.e. on Streamlit's default `:8501`.
- The code's own `APP_URL` default (line 31) was already `8501`, with a comment reading "what `launch_app.bat` uses" — the docstring was the only thing that disagreed.
- Rewrites the docstring and usage example to match the real `:8501` runtime. No code or behavior changed.

## Validation

- **py_compile** `app/check_control_panel.py` — OK (syntax clean).
- **No test suite** in this project (pytest not installed, no tests dir, no verify-before-ship script) — noted explicitly.
- **Diff scope** — 10 lines in the module docstring only; no runtime code, no imports, no `APP_URL` default touched.
- **Behavioral** — pure comment fix; the `APP_URL = os.environ.get("APP_URL", "http://localhost:8501")` at line 31 was already correct and unchanged.

Closes #128