### PR TITLE
fix: add planning. prefix to bootstrap_session module path in recovery messages

### DIFF
--- a/planning/_session_base.py
+++ b/planning/_session_base.py
@@ -183,7 +183,7 @@ class PlatformSession:
         if not _user_data_dir_initialized(self.user_data_dir):
             raise FileNotFoundError(
                 f"Chrome profile at {self.user_data_dir} is empty or missing. "
-                f"Run `python -m {self.platform_name}.bootstrap_session` first."
+                f"Run `python -m planning.{self.platform_name}.bootstrap_session` first."
             )
         self._playwright = sync_playwright().start()
         self._context = launch_persistent_context_with_lock_wait(
@@ -216,7 +216,7 @@ class PlatformSession:
         if any(marker in current for marker in self.login_markers):
             raise LoginRequiredError(
                 f"{self._display} redirected to login — the saved Chrome profile session "
-                f"expired. Re-run `python -m {self.platform_name}.bootstrap_session` to log in again."
+                f"expired. Re-run `python -m planning.{self.platform_name}.bootstrap_session` to log in again."
             )
 
     def screenshot_failure(self, label: str) -> Path:


### PR DESCRIPTION
## Summary

- `FileNotFoundError` at `planning/_session_base.py:186` and `LoginRequiredError` at `:219` both told users to run `python -m {platform}.bootstrap_session`, which fails with `ModuleNotFoundError` because no top-level `<platform>` package exists.
- The correct invocation is `python -m planning.<platform>.bootstrap_session`, which is the documented command in README.md (setup section, session table).
- Two one-token f-string edits — no logic change.

## Validation

- `py_compile planning/_session_base.py` exit 0
- `git diff HEAD` confirmed exactly two lines changed, both expected — no collateral edits
- Both corrected strings verified present in file at lines 186 and 219
- No CI workflows in this repo

Closes #127