### PR TITLE
feat: add editorial-calendar seeding tab to the control panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ content-management/                   # repo root
 │   ├── classify/                     # layered classifier + phrase config
 │   ├── reputation/                   # per-commenter reputation feedback loop
 │   └── db/                           # Supabase schema (commenters + comments tables)
-├── app/                              # Streamlit control panel (four tabs: reporting/planning/newsletter/engagement)
+├── app/                              # Streamlit control panel (tabs: reporting/editorial/planning/newsletter/engagement)
 ├── config/                           # config.json, mapping.json, logger_config, chrome_launch, console
 ├── results/                          # outputs — planning summaries + raw API JSON
 ├── logs/                             # per-module .log files

--- a/app/app.py
+++ b/app/app.py
@@ -44,6 +44,7 @@ from app.process_runner import exit_code, is_running  # noqa: E402
 
 PIPELINES = [
     ("reporting",          "📊 reporting"),
+    ("editorial",          "📅 editorial"),
     ("planning",           "📅 planning"),
     ("newsletter",         "📰 newsletter"),
     ("engagement-scrape",  "🛡️ engagement (scrape)"),
@@ -73,8 +74,9 @@ with st.sidebar:
 
 
 # ── Tabs ─────────────────────────────────────────────────────────────
-tab_rep, tab_plan, tab_news, tab_eng = st.tabs([
+tab_rep, tab_ed, tab_plan, tab_news, tab_eng = st.tabs([
     "📊 reporting",
+    "📅 editorial",
     "📅 planning",
     "📰 newsletter",
     "🛡️ engagement",
@@ -83,6 +85,10 @@ tab_rep, tab_plan, tab_news, tab_eng = st.tabs([
 with tab_rep:
     from app import tab_reporting  # noqa: PLC0415
     tab_reporting.run()
+
+with tab_ed:
+    from app import tab_editorial  # noqa: PLC0415
+    tab_editorial.run()
 
 with tab_plan:
     from app import tab_planning  # noqa: PLC0415

--- a/app/check_control_panel.py
+++ b/app/check_control_panel.py
@@ -105,8 +105,8 @@ def run() -> int:
             return 1
 
         body = page.inner_text("body")
-        if all(label in body.lower() for label in ("reporting", "planning", "newsletter", "engagement")):
-            _pass("all 4 pipeline tabs present")
+        if all(label in body.lower() for label in ("reporting", "editorial", "planning", "newsletter", "engagement")):
+            _pass("all 5 pipeline tabs present")
         else:
             _fail("missing pipeline tabs", "")
             fails += 1
@@ -125,6 +125,19 @@ def run() -> int:
             _pass("reporting controls render")
         else:
             _fail("reporting controls", "expected 'run reporting pipeline' button + 'skip substack' toggle")
+            fails += 1
+
+        print("\n📱 step 2b — Editorial tab renders seed button (before planning)")
+        _click_tab(page, "editorial")
+        page.wait_for_timeout(800)
+        _shot(page, out_dir, "02b-editorial")
+        body = page.inner_text("body")
+        if "seed editorial rows" in body.lower() and "seed calendar rows" in body.lower():
+            _pass("editorial controls render")
+        else:
+            _fail("editorial controls", "expected 'seed editorial rows' button + 'seed calendar rows' header")
+            fails += 1
+        if not _assert_no_traceback(page, "editorial tab"):
             fails += 1
 
         print("\n📱 step 3 — Planning tab renders dry-run/live radio")

--- a/app/tab_editorial.py
+++ b/app/tab_editorial.py
@@ -1,0 +1,47 @@
+"""Editorial tab — seed the Notion editorial-calendar day-rows.
+
+Runs ``reporting.notion.add_editorial_dates``, which creates any missing
+editorial rows for the current + next calendar month (idempotent). One run
+button + the shared streamed-log panel, same as the reporting/planning tabs.
+No date selector — the default current+next-month range is what runs.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from app.process_runner import (
+    VENV_PY,
+    is_running,
+    render_log_panel,
+    render_status_badge,
+    start_pipeline,
+)
+
+PIPELINE_NAME = "editorial"
+
+
+def run() -> None:
+    st.subheader("📅 editorial — seed calendar rows")
+    st.caption(
+        "Adds any missing day-rows to the Notion editorial DB for the current + next "
+        "calendar month (day · date · DoW). Idempotent — re-running only fills gaps."
+    )
+
+    debug = st.toggle("debug", value=False, key="editorial-debug")
+
+    cmd = [str(VENV_PY), "-m", "reporting.notion.add_editorial_dates"]
+    if debug:
+        cmd.append("--debug")
+
+    st.button(
+        "▶ seed editorial rows",
+        key="editorial-run",
+        type="primary",
+        disabled=is_running(PIPELINE_NAME),
+        on_click=start_pipeline,
+        args=(PIPELINE_NAME, cmd),
+    )
+
+    render_status_badge(PIPELINE_NAME)
+    render_log_panel(PIPELINE_NAME)

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -122,6 +122,11 @@
                 "name": "database_name"
             }
         ],
+        "editorial_date_columns": {
+            "title_day": "day",
+            "date": "date",
+            "day_of_week": "DoW"
+        },
         "update_fields_followers": [
             "follow LI",
             "follow TW",

--- a/reporting/notion/README.md
+++ b/reporting/notion/README.md
@@ -265,6 +265,22 @@ relations system from Python. One-time / ad hoc — not a pipeline step.
 python -m reporting.notion.notion_relations_python_setup [setup|test|verify|demo]
 ```
 
+### add_editorial_dates.py — seed editorial-calendar rows
+
+Creates any missing day-rows in the editorial DB for the **current + next
+calendar month** (writing `day` / `date` / `DoW`). Idempotent — only missing
+dates are added, so re-running is a no-op. Resolves the editorial DB and token
+from `config.json` (`notion.api_token` + `notion.databases[0]`; column names
+overridable via `notion.editorial_date_columns`). Run on demand from a console
+or from the control-panel app's **📅 editorial** tab — both share this one code
+path.
+
+```bash
+python -m reporting.notion.add_editorial_dates            # current + next month
+python -m reporting.notion.add_editorial_dates --debug
+python -m reporting.notion.add_editorial_dates --database-id <id>
+```
+
 ### next_relation_check.py — read-only diagnostic preview
 
 Read-only preview for the editorial DB's `next`-relation auto-fill: looks up the

--- a/reporting/notion/add_editorial_dates.py
+++ b/reporting/notion/add_editorial_dates.py
@@ -1,0 +1,205 @@
+r"""Seed missing editorial-calendar day-rows in the Notion editorial database.
+
+For every day in a date range, create the editorial row if it does not already
+exist — writing the ``day`` title (``YYYYMMDD``), the ``date`` property
+(``YYYY-MM-DD``) and the ``DoW`` lowercase-weekday rich-text. The run is
+idempotent: only missing dates are created, so re-running is a no-op.
+
+Default range is the **current calendar month start → next calendar month end**,
+i.e. the rows the upcoming planning/reporting runs will need. This is the spine
+the rest of the pipelines read from (see ``reporting/notion/editorial.py``).
+
+CLI-compatible — runnable standalone and from the control-panel app's
+📅 editorial tab through one code path::
+
+    & .\.venv\Scripts\python.exe -m reporting.notion.add_editorial_dates
+    & .\.venv\Scripts\python.exe -m reporting.notion.add_editorial_dates --debug
+    & .\.venv\Scripts\python.exe -m reporting.notion.add_editorial_dates --database-id <id>
+
+Authenticates and resolves the editorial DB from this repo's ``config.json``
+(``notion.api_token`` + ``notion.databases``), reusing the existing
+``reporting/notion`` helpers rather than re-implementing client setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from calendar import monthrange
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Importing editorial configures notion_update's module-level logger on import,
+# so the reused init_notion_client / query helpers below don't blow up.
+from reporting.notion import notion_update as _nu  # noqa: E402
+from reporting.notion.editorial import query_rows_by_filter  # noqa: E402
+from reporting.notion.notion_update import (  # noqa: E402
+    format_database_id,
+    init_notion_client,
+)
+
+logger = logging.getLogger("add_editorial_dates")
+
+CONFIG_PATH = REPO_ROOT / "config" / "config.json"
+
+# Editorial-DB property names are structural; defaults match the live DB and can
+# be overridden via ``notion.editorial_date_columns`` in config.json (per the
+# repo's no-hardcoded-column-names convention).
+DEFAULT_COLUMNS = {"title_day": "day", "date": "date", "day_of_week": "DoW"}
+
+_DATE_FMT = "%Y-%m-%d"      # ISO 8601 for the Notion date property
+_DAY_TEXT_FMT = "%Y%m%d"    # YYYYMMDD title text
+_DOW_FMT = "%a"             # short weekday name (lowercased)
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Configure stdout logging (UTF-8) for both this module and the reused helpers."""
+    sys.stdout.reconfigure(encoding="utf-8")
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+    # init_notion_client / format_database_id log via notion_update's own logger.
+    _nu.configure_logger(debug_mode=debug)
+
+
+def editorial_date_range(now: Optional[datetime] = None) -> tuple[str, str]:
+    """First day of the current calendar month → last day of the next month (YYYY-MM-DD)."""
+    today = now or datetime.now()
+    start = datetime(today.year, today.month, 1)
+    if today.month == 12:
+        end_year, end_month = today.year + 1, 1
+    else:
+        end_year, end_month = today.year, today.month + 1
+    last_day = monthrange(end_year, end_month)[1]
+    end = datetime(end_year, end_month, last_day)
+    return start.strftime(_DATE_FMT), end.strftime(_DATE_FMT)
+
+
+def load_config(database_id_override: Optional[str] = None) -> tuple[str, str, dict]:
+    """Return ``(api_token, database_id, columns)`` from config.json.
+
+    The editorial DB is the first entry in ``notion.databases`` (matching
+    ``notion_update.py``), unless ``database_id_override`` is given.
+    """
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        config = json.load(fh)
+    notion_cfg = config.get("notion", {})
+
+    api_token = notion_cfg.get("api_token")
+    if not api_token:
+        raise ValueError("notion.api_token missing from config.json")
+
+    if database_id_override:
+        database_id = database_id_override
+    else:
+        databases = notion_cfg.get("databases", [])
+        if not databases:
+            raise ValueError("notion.databases is empty in config.json")
+        database_id = databases[0]["id"]
+
+    columns = {**DEFAULT_COLUMNS, **notion_cfg.get("editorial_date_columns", {})}
+    return api_token, database_id, columns
+
+
+def get_existing_dates(notion, database_id: str, start_date: str, end_date: str, date_col: str) -> set[str]:
+    """Return the set of ``YYYY-MM-DD`` dates already present in the range."""
+    date_filter = {
+        "and": [
+            {"property": date_col, "date": {"on_or_after": start_date}},
+            {"property": date_col, "date": {"on_or_before": end_date}},
+        ]
+    }
+    rows = query_rows_by_filter(notion, database_id, date_filter)
+    existing: set[str] = set()
+    for row in rows:
+        date_prop = row.get("properties", {}).get(date_col, {}).get("date")
+        if date_prop and date_prop.get("start"):
+            value = date_prop["start"]
+            if "T" in value:
+                value = value.split("T")[0]
+            existing.add(value)
+    return existing
+
+
+def add_date_record(notion, database_id: str, day_text: str, date_str: str, day_of_week: str, columns: dict) -> Optional[dict]:
+    """Create one editorial row; returns the created page or ``None`` on error."""
+    try:
+        return notion.pages.create(
+            parent={"database_id": format_database_id(database_id)},
+            properties={
+                columns["title_day"]: {"title": [{"text": {"content": day_text}}]},
+                columns["date"]: {"date": {"start": date_str}},
+                columns["day_of_week"]: {"rich_text": [{"text": {"content": day_of_week}}]},
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — log and continue past a single bad row
+        logger.error("❌ Error adding record for %s: %s", date_str, exc)
+        return None
+
+
+def add_missing_dates(notion, database_id: str, start_date: str, end_date: str, columns: dict) -> int:
+    """Create every missing day-row in ``[start_date, end_date]``. Returns the count added."""
+    start = datetime.strptime(start_date, _DATE_FMT)
+    end = datetime.strptime(end_date, _DATE_FMT)
+    logger.info("📅 Range: %s → %s", start_date, end_date)
+
+    existing = get_existing_dates(notion, database_id, start_date, end_date, columns["date"])
+    logger.info("📊 Found %d existing date(s) in range", len(existing))
+
+    added = 0
+    current = start
+    while current <= end:
+        date_str = current.strftime(_DATE_FMT)
+        if date_str not in existing:
+            day_text = current.strftime(_DAY_TEXT_FMT)
+            day_of_week = current.strftime(_DOW_FMT).lower()
+            entry = add_date_record(notion, database_id, day_text, date_str, day_of_week, columns)
+            if entry:
+                logger.info("📝 Added: day=%s, date=%s, DoW=%s", day_text, date_str, day_of_week)
+                added += 1
+        else:
+            logger.debug("Skipping existing date: %s", date_str)
+        current += timedelta(days=1)
+
+    logger.info("✅ Total new records added: %d", added)
+    return added
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed missing editorial-calendar rows for the current + next calendar month."
+    )
+    parser.add_argument("--database-id", type=str, default=None, help="Override the editorial DB ID from config.json")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    setup_logging(args.debug)
+    logger.info("🚀 Editorial DB sync starting (current month + next month)")
+
+    try:
+        api_token, database_id, columns = load_config(args.database_id)
+        notion = init_notion_client(api_token)
+        if notion is None:
+            logger.error("❌ Failed to initialize Notion client")
+            sys.exit(1)
+        start_date, end_date = editorial_date_range()
+        add_missing_dates(notion, database_id, start_date, end_date, columns)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("❌ Fatal error: %s", exc)
+        if args.debug:
+            logger.exception("Full traceback:")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a **📅 editorial** tab to the Streamlit control panel, placed **before** the planning tab, that seeds the Notion editorial calendar with any missing day-rows for the current + next calendar month. It's the spine every pipeline reads from, and seeding it previously lived in a sibling script outside this repo.

- **`reporting/notion/add_editorial_dates.py`** (new) — idempotently creates missing editorial rows (`day` title `YYYYMMDD`, `date`, `DoW` lowercase weekday) for the default current+next-month range. Resolves the API token + editorial DB from this repo's `config.json` and reuses the existing `notion_update` / `editorial` helpers (this repo's `notion-client` 2.2.x uses `databases.query` + `pages.create` — the sibling's `data_sources.query` path was not copied). CLI-compatible: `-m reporting.notion.add_editorial_dates [--database-id <id>] [--debug]`, so console and app share one code path.
- **`app/tab_editorial.py`** (new) + `app/app.py` wiring — one run button, debug toggle, and the same streamed-log panel the reporting/planning tabs use. Added to the sidebar pipeline-status list and the tab row before planning. No date selector — the default range is what runs.
- **`app/check_control_panel.py`** — extended the e2e check so it asserts the editorial tab renders (before planning), keeping the suite from going blind to the new tab.
- Column names exposed via `notion.editorial_date_columns` in `config_example.json` (defaults match the live DB); module documented in the notion README; main README tab list updated.

## Validation

- `py_compile` of all new/changed files — clean (and import raises no `SyntaxWarning`).
- **CLI end-to-end** — `python -m reporting.notion.add_editorial_dates` ran to exit 0: resolved config, computed range `2026-06-01 → 2026-07-31`, found 61/61 days already present, added 0 (idempotent no-op confirmed).
- **Read-only probe** — exercised config load → client init → live Notion date-range query without writing; reported 0 missing.
- **Playwright control-panel e2e** (`app.check_control_panel`) — 19/19 checks PASS against a live app, including the new step asserting the editorial tab renders with its seed button before the planning tab, no Python tracebacks, and the theme probe. Screenshot inspected locally (not attached).

Closes #137