### PR TITLE
fix: suppress Windows asyncio/tornado console noise in control panel

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,19 +5,26 @@ Each tab owns its own module (`app.tab_*`) per the project's per-tab
 convention (see pdf-to-markdown sibling project + CLAUDE.md). Subprocess
 lifecycle + live log streaming lives in `app/process_runner.py`.
 
-Launch:
+Launch via the wrapper (recommended — applies logging filters before server start):
     .\launch_app.bat
-    # or directly:
-    & .\.venv\Scripts\python.exe -m streamlit run app\app.py
+    # or: & .\.venv\Scripts\python.exe run_app.py
 """
 
 from __future__ import annotations
 
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path
 
 import streamlit as st
+
+# Belt-and-suspenders filter for direct launches (run_app.py applies these earlier).
+logging.getLogger("tornado.general").addFilter(
+    type("_NoInvalidHTTP", (logging.Filter,), {
+        "filter": staticmethod(lambda r: "Invalid HTTP request" not in r.getMessage())
+    })()
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -1,4 +1,4 @@
 @echo off
 cd /d "%~dp0"
-".venv\Scripts\python.exe" -m streamlit run "app\app.py" --browser.gatherUsageStats=false
+".venv\Scripts\python.exe" run_app.py
 pause

--- a/run_app.py
+++ b/run_app.py
@@ -1,0 +1,44 @@
+r"""Launch wrapper for the control-panel Streamlit app.
+
+Applies logging filters that suppress Windows networking noise before
+Streamlit's server starts, then delegates to Streamlit's CLI.
+
+Use via launch_app.bat or directly:
+    .venv\Scripts\python.exe run_app.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+class _SuppressConnReset(logging.Filter):
+    """Drop ConnectionResetError tracebacks from asyncio's ProactorEventLoop.
+
+    On Windows, the ProactorEventLoop logs a full traceback for every browser
+    disconnect ([WinError 10054]). These are harmless; suppress them.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        ei = record.exc_info
+        if ei and ei[0] and issubclass(ei[0], (ConnectionResetError, BrokenPipeError)):
+            return False
+        return True
+
+
+# Suppress "Invalid HTTP request received" — Tornado/Uvicorn warning triggered by
+# browser preconnects and non-HTTP traffic; not an app error.
+logging.getLogger("tornado.general").addFilter(
+    type("_NoInvalidHTTP", (logging.Filter,), {
+        "filter": staticmethod(lambda r: "Invalid HTTP request" not in r.getMessage())
+    })()
+)
+# Suppress ConnectionResetError / BrokenPipeError tracebacks from asyncio callbacks.
+logging.getLogger("asyncio").addFilter(_SuppressConnReset())
+
+sys.argv = ["streamlit", "run", "app/app.py", "--browser.gatherUsageStats=false"]
+
+from streamlit.web import cli as stcli  # noqa: E402
+
+stcli.main(standalone_mode=False)


### PR DESCRIPTION
## Summary

- Add `run_app.py` launch wrapper that installs logging filters **before** Streamlit's Uvicorn-based server starts, so `Invalid HTTP request received` and `ConnectionResetError [WinError 10054]` messages are suppressed at the source rather than after they reach the terminal.
- Update `launch_app.bat` to invoke `run_app.py` instead of `-m streamlit run` directly.
- Add a belt-and-suspenders `tornado.general` filter in `app/app.py` for direct launches that bypass the wrapper.

The event-loop-policy approach (`asyncio.WindowsSelectorEventLoopPolicy`) was considered and rejected: both `set_event_loop_policy` and `WindowsSelectorEventLoopPolicy` are deprecated in the Python version in use (3.14) and slated for removal in 3.16 — using them would trade one console-noise problem for another (DeprecationWarnings). The logging-filter approach has no API lifecycle risk.

## Validation

- **Syntax:** `py_compile` on `run_app.py` and `app/app.py` → clean.
- **Lint:** no ruff in this project; no linter errors from the hook.
- **Behavioural (3e):** launched app via `run_app.py`, navigated browser to `localhost:8501`, performed multiple connect/disconnect cycles. Console output captured to file — only startup line present, zero `Invalid HTTP request` or `ConnectionResetError` noise.

Closes #139
