### PR TITLE
refactor: consolidate audit duplication findings (#133)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -73,6 +73,18 @@ force_utf8_stdio()   # called once at each entry-point module's top level
 
 All entry points (`*_pipeline.py`, `app/*.py`, `newsletter/*.py`, etc.) call this instead of the inline `for _stream in (sys.stdout, sys.stderr): _stream.reconfigure(...)` loop that was previously hand-copied across ~13 modules.
 
+### 6. `loader.py`
+Single-source loader for `config.json`. Every module that needs the config reads it through here instead of re-implementing its own open/parse helper. Exposes two functions:
+
+```python
+from config.loader import load_full_config, load_block
+
+cfg = load_full_config()        # full config.json, cached for the process
+notion = load_block("notion")   # one top-level block, raises if missing
+```
+
+Both raise on a missing or corrupt `config.json` (config is mandatory — a clear exception beats a silent skip), matching the contracts already used by `reporting/scrape_client/base.py` and `planning/_session_base.py`. This replaced seven hand-copied `load_config()` variants scattered across `reporting/`, `engagement/`, and `newsletter/`.
+
 ## Usage
 
 1. Copy `config_example.json` to `config.json`

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,36 @@
+"""Single-source config.json loader.
+
+Every module that needs the project config reads it through here instead of
+re-implementing its own open/parse helper. ``load_full_config`` is cached so
+the file is read once per process; ``load_block`` resolves a named top-level
+block and fails loud when it's missing.
+
+Both raise on a missing or corrupt ``config.json`` rather than returning
+``None`` — config is mandatory, so a clear exception beats a silent skip.
+This matches the contracts already used by ``reporting/scrape_client/base.py``
+and ``planning/_session_base.py``.
+"""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).parent / "config.json"
+
+
+@lru_cache(maxsize=1)
+def load_full_config() -> dict:
+    """Load and return the full ``config.json`` as a dict (cached per process)."""
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def load_block(name: str) -> dict:
+    """Return a named top-level block from ``config.json``.
+
+    Raises ``RuntimeError`` if the block is missing or empty.
+    """
+    block = load_full_config().get(name)
+    if not block:
+        raise RuntimeError(f"Missing '{name}' block in config.json")
+    return block

--- a/engagement/db/client.py
+++ b/engagement/db/client.py
@@ -12,24 +12,20 @@ in exactly one place.
 
 from __future__ import annotations
 
-import json
 import logging
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
-logger = logging.getLogger("engagement.db")
+# Add the repo root to sys.path to allow importing the shared config loader.
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+from config.loader import load_full_config as load_config  # noqa: E402
 
-REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-CONFIG_PATH = REPO_ROOT / "config" / "config.json"
+logger = logging.getLogger("engagement.db")
 
 
 # ---------- Config ----------
-
-@lru_cache(maxsize=1)
-def load_config() -> dict:
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        return json.load(fp)
 
 
 def load_engagement_config() -> dict:

--- a/newsletter/pipeline.py
+++ b/newsletter/pipeline.py
@@ -9,7 +9,6 @@ Two entrypoints:
 
 from __future__ import annotations
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -24,17 +23,12 @@ from config.console import force_utf8_stdio  # noqa: E402
 force_utf8_stdio()
 
 from config.logger_config import setup_logger  # noqa: E402
+from config.loader import load_full_config as load_config  # noqa: E402
 from newsletter import (  # noqa: E402
     author_resolver, chrome_tabs, classifier, extractor, llm, notion_io,
     summarizer,
 )
 from newsletter.cache import CacheState  # noqa: E402
-
-
-def load_config() -> Dict[str, Any]:
-    cfg_path = REPO_ROOT / "config" / "config.json"
-    with cfg_path.open("r", encoding="utf-8") as f:
-        return json.load(f)
 
 
 def process_url(

--- a/reporting/notion/_client.py
+++ b/reporting/notion/_client.py
@@ -1,0 +1,47 @@
+"""Shared Notion client helpers.
+
+Single-source for the two helpers that were previously copy-pasted across
+``notion_update.py`` and ``notion_database_structure.py`` (and imported by
+``editorial.py``): initializing the Notion ``Client`` and formatting a
+32-char database id into hyphenated UUID form.
+
+The logger is configured at import (mirroring ``supabase_uploader.py``) so
+``init_notion_client`` never hits an uninitialized module-level logger,
+regardless of which caller imports it.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from notion_client import Client
+
+# Add the repo root to sys.path to allow importing from sibling packages
+sys.path.append(str(Path(__file__).parent.parent.parent))
+from config.logger_config import setup_logger
+
+# Set up logger - will use existing logger if available
+logger = logging.getLogger("notion_client_helpers")
+if not logger.handlers:
+    # Only set up if no handlers exist (i.e., not already configured)
+    logger = setup_logger("notion_client_helpers", file_logging=False)
+
+
+def init_notion_client(api_token):
+    """Initialize Notion Client using the provided API token."""
+    logger.debug("🔑 Initializing Notion client")
+    try:
+        client = Client(auth=api_token)
+        logger.info("✅ Notion client initialized successfully")
+        return client
+    except Exception as e:
+        logger.error(f"❌ Error initializing Notion client: {e}")
+        return None
+
+
+def format_database_id(database_id):
+    """Format database ID with hyphens if needed."""
+    if len(database_id) == 32:
+        # Insert hyphens to convert into UUID format
+        return f"{database_id[:8]}-{database_id[8:12]}-{database_id[12:16]}-{database_id[16:20]}-{database_id[20:]}"
+    return database_id

--- a/reporting/notion/editorial.py
+++ b/reporting/notion/editorial.py
@@ -20,10 +20,12 @@ from notion_client import Client
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from reporting.notion import notion_update as _nu  # noqa: E402
-from reporting.notion.notion_update import (  # noqa: E402
-    extract_property_value,
+from reporting.notion._client import (  # noqa: E402
     format_database_id,
     init_notion_client,
+)
+from reporting.notion.notion_update import (  # noqa: E402
+    extract_property_value,
     prepare_notion_update,
 )
 

--- a/reporting/notion/notion_database_structure.py
+++ b/reporting/notion/notion_database_structure.py
@@ -4,13 +4,13 @@ import sys
 import argparse
 from pathlib import Path
 import os
-from notion_client import Client
 import pandas as pd
 from datetime import datetime
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from reporting.notion._client import init_notion_client, format_database_id
 
 # Set up logger
 logger = None
@@ -21,24 +21,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("notion_database_structure", file_logging=False, level=log_level)
     return logger
-
-def init_notion_client(api_token):
-    """Initialize Notion Client using the provided API token."""
-    logger.debug("🔑 Initializing Notion client")
-    try:
-        client = Client(auth=api_token)
-        logger.info("✅ Notion client initialized successfully")
-        return client
-    except Exception as e:
-        logger.error(f"❌ Error initializing Notion client: {e}")
-        return None
-
-def format_database_id(database_id):
-    """Format database ID with hyphens if needed."""
-    if len(database_id) == 32:
-        # Insert hyphens to convert into UUID format
-        return f"{database_id[:8]}-{database_id[8:12]}-{database_id[12:16]}-{database_id[16:20]}-{database_id[20:]}"
-    return database_id
 
 def get_database_structure(notion, database_id):
     """Retrieve the structure of a Notion database."""

--- a/reporting/notion/notion_unify_data.py
+++ b/reporting/notion/notion_unify_data.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from config.loader import load_full_config as load_config
 from reporting.process.supabase_uploader import get_db_connection
 
 # Set up logger
@@ -21,23 +22,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("notion_unify_data", file_logging=False, level=log_level)
     return logger
-
-def load_config():
-    """Load main configuration from config.json file."""
-    logger.debug("📂 Loading main configuration file")
-    config_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config')
-    config_path = os.path.join(config_dir, 'config.json')
-    
-    try:
-        with open(config_path, 'r') as file:
-            logger.info("✅ Main configuration loaded successfully")
-            return json.load(file)
-    except FileNotFoundError:
-        logger.error(f"❌ Error: Main configuration file not found at {config_path}")
-        return None
-    except json.JSONDecodeError:
-        logger.error(f"❌ Error: Invalid JSON in main configuration file at {config_path}")
-        return None
 
 def read_sql_from_file():
     """Read the SQL content from the existing SQL file."""
@@ -89,10 +73,7 @@ def main(args=None):
     
     # Load configuration
     config = load_config()
-    if not config:
-        logger.error("❌ Failed to load configuration")
-        return
-    
+
     # Read SQL from file
     logger.info("📝 Reading SQL from file")
     sql_content = read_sql_from_file()

--- a/reporting/notion/notion_update.py
+++ b/reporting/notion/notion_update.py
@@ -4,7 +4,6 @@ import sys
 import argparse
 from pathlib import Path
 import os
-from notion_client import Client
 from datetime import datetime, timedelta
 import psycopg2
 from dotenv import load_dotenv
@@ -13,6 +12,9 @@ from dotenv import load_dotenv
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from reporting.process.supabase_uploader import get_db_connection
+# init_notion_client / format_database_id live in the shared _client module;
+# re-exported here so existing importers (e.g. editorial.py) keep working.
+from reporting.notion._client import init_notion_client, format_database_id
 
 # Set up logger
 logger = None
@@ -23,24 +25,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("notion_update", file_logging=False, level=log_level)
     return logger
-
-def init_notion_client(api_token):
-    """Initialize Notion Client using the provided API token."""
-    logger.debug("🔑 Initializing Notion client")
-    try:
-        client = Client(auth=api_token)
-        logger.info("✅ Notion client initialized successfully")
-        return client
-    except Exception as e:
-        logger.error(f"❌ Error initializing Notion client: {e}")
-        return None
-
-def format_database_id(database_id):
-    """Format database ID with hyphens if needed."""
-    if len(database_id) == 32:
-        # Insert hyphens to convert into UUID format
-        return f"{database_id[:8]}-{database_id[8:12]}-{database_id[12:16]}-{database_id[16:20]}-{database_id[20:]}"
-    return database_id
 
 def extract_property_value(property_item):
     """Extract the value from a property item based on its type."""

--- a/reporting/notion/setup_notion_relations_system.py
+++ b/reporting/notion/setup_notion_relations_system.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from config.loader import load_full_config as load_config
 from reporting.process.supabase_uploader import get_db_connection
 
 # Set up logger
@@ -21,23 +22,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("setup_notion_relations_system", file_logging=False, level=log_level)
     return logger
-
-def load_config():
-    """Load main configuration from config.json file."""
-    logger.debug("📂 Loading main configuration file")
-    config_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config')
-    config_path = os.path.join(config_dir, 'config.json')
-    
-    try:
-        with open(config_path, 'r') as file:
-            logger.info("✅ Main configuration loaded successfully")
-            return json.load(file)
-    except FileNotFoundError:
-        logger.error(f"❌ Error: Main configuration file not found at {config_path}")
-        return None
-    except json.JSONDecodeError:
-        logger.error(f"❌ Error: Invalid JSON in main configuration file at {config_path}")
-        return None
 
 def read_sql_from_file():
     """Read the SQL content from the existing SQL file."""
@@ -99,10 +83,7 @@ def main(args=None):
     
     # Load configuration
     config = load_config()
-    if not config:
-        logger.error("❌ Failed to load configuration")
-        return
-    
+
     # Read SQL from file
     logger.info("📝 Reading SQL from file")
     sql_content = read_sql_from_file()

--- a/reporting/process/data_processor.py
+++ b/reporting/process/data_processor.py
@@ -11,6 +11,7 @@ import glob
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from config.loader import load_full_config as load_config
 from reporting.process.supabase_uploader import upload_all_dataframes
 
 # Set up logger
@@ -38,23 +39,6 @@ def load_mapping_config():
         return None
     except json.JSONDecodeError:
         logger.error(f"❌ Error: Invalid JSON in mapping configuration file at {config_path}")
-        return None
-
-def load_config():
-    """Load main configuration from config.json file."""
-    logger.debug("📂 Loading main configuration file")
-    config_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config')
-    config_path = os.path.join(config_dir, 'config.json')
-    
-    try:
-        with open(config_path, 'r') as file:
-            logger.info("✅ Main configuration loaded successfully")
-            return json.load(file)
-    except FileNotFoundError:
-        logger.error(f"❌ Error: Main configuration file not found at {config_path}")
-        return None
-    except json.JSONDecodeError:
-        logger.error(f"❌ Error: Invalid JSON in main configuration file at {config_path}")
         return None
 
 def get_nested_value(data, path):
@@ -604,9 +588,7 @@ def main(args=None):
         return
     
     main_config = load_config()
-    if not main_config:
-        logger.warning("⚠️  Failed to load main configuration, using defaults")
-    
+
     # Process all JSON files and get DataFrames by data type
     dataframes = process_all_files(mapping_config, main_config, debug_mode=debug_mode, target_date=args.date)
     

--- a/reporting/process/posts_consolidator.py
+++ b/reporting/process/posts_consolidator.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from config.loader import load_full_config as load_config
 from reporting.process.supabase_uploader import get_db_connection
 
 # Set up logger
@@ -21,23 +22,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("posts_consolidator", file_logging=False, level=log_level)
     return logger
-
-def load_config():
-    """Load main configuration from config.json file."""
-    logger.debug("📂 Loading main configuration file")
-    config_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config')
-    config_path = os.path.join(config_dir, 'config.json')
-    
-    try:
-        with open(config_path, 'r') as file:
-            logger.info("✅ Main configuration loaded successfully")
-            return json.load(file)
-    except FileNotFoundError:
-        logger.error(f"❌ Error: Main configuration file not found at {config_path}")
-        return None
-    except json.JSONDecodeError:
-        logger.error(f"❌ Error: Invalid JSON in main configuration file at {config_path}")
-        return None
 
 def read_sql_from_file():
     """Read the SQL content from the existing SQL file."""
@@ -90,10 +74,7 @@ def main(args=None):
     
     # Load configuration
     config = load_config()
-    if not config:
-        logger.error("❌ Failed to load configuration")
-        return
-    
+
     # Read SQL from file
     logger.info("📝 Reading SQL from file")
     sql_content = read_sql_from_file()

--- a/reporting/process/supabase_policy_script.py
+++ b/reporting/process/supabase_policy_script.py
@@ -7,7 +7,6 @@ Follows project automation standards with logging and configuration management.
 """
 
 import json
-import os
 import logging
 from pathlib import Path
 import sys
@@ -15,78 +14,19 @@ import psycopg2
 import psycopg2.extras
 from psycopg2 import sql
 import argparse
-from dotenv import load_dotenv
 from typing import Dict, List, Any, Optional, Tuple, Set
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+# Single-source DB helpers — canonical defs live in supabase_uploader.
+from reporting.process.supabase_uploader import load_db_config, get_db_connection
 
 # Set up logger - will use existing logger if available
 logger = logging.getLogger("supabase_policy_script")
 if not logger.handlers:
     # Only set up if no handlers exist (i.e., not already configured)
     logger = setup_logger("supabase_policy_script", file_logging=False)
-
-def load_db_config(environment="cloud"):
-    """
-    Load database configuration from environment variables.
-    
-    Args:
-        environment (str): The environment to use, either 'local' or 'cloud'
-    """
-    logger.debug(f"📂 Loading database configuration for {environment} environment")
-    
-    # Load environment variables from .env file
-    load_dotenv()
-    
-    env_suffix = f"_{environment}"
-    
-    db_config = {
-        "user": os.getenv(f"db_user{env_suffix}"),
-        "password": os.getenv(f"db_password{env_suffix}"),
-        "host": os.getenv(f"db_host{env_suffix}"),
-        "port": os.getenv(f"db_port{env_suffix}"),
-        "dbname": os.getenv(f"db_name{env_suffix}")
-    }
-    
-    # Check if all required configuration exists
-    missing_keys = [k for k, v in db_config.items() if not v]
-    if missing_keys:
-        logger.error(f"❌ Database configuration missing: {', '.join(missing_keys)}")
-        return None
-            
-    logger.info(f"✅ Database configuration loaded successfully for {environment} environment")
-    return db_config
-
-def get_db_connection(db_config=None, environment="cloud"):
-    """
-    Get a PostgreSQL database connection.
-    
-    Args:
-        db_config (dict, optional): Database configuration parameters
-        environment (str, optional): The environment to use if db_config is None
-    """
-    if db_config is None:
-        db_config = load_db_config(environment)
-        
-    if not db_config:
-        return None
-        
-    try:
-        connection = psycopg2.connect(
-            user=db_config.get("user"),
-            password=db_config.get("password"),
-            host=db_config.get("host"),
-            port=db_config.get("port"),
-            dbname=db_config.get("dbname")
-        )
-        connection.autocommit = True
-        logger.info("✅ Connected to database successfully")
-        return connection
-    except Exception as e:
-        logger.error(f"❌ Error connecting to database: {e}")
-        return None
 
 def get_all_tables(connection):
     """

--- a/reporting/process/supabase_relations_creator.py
+++ b/reporting/process/supabase_relations_creator.py
@@ -7,7 +7,6 @@ Follows project automation standards with logging and configuration management.
 """
 
 import json
-import os
 import pandas as pd
 import logging
 from pathlib import Path
@@ -15,12 +14,13 @@ import sys
 import psycopg2
 import psycopg2.extras
 import argparse
-from dotenv import load_dotenv
 from typing import Dict, List, Any, Optional, Tuple, Set
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+# Single-source DB helpers — canonical defs live in supabase_uploader.
+from reporting.process.supabase_uploader import load_db_config, get_db_connection
 
 # Set up logger - will use existing logger if available
 logger = logging.getLogger("supabase_relations_creator")
@@ -69,66 +69,6 @@ def apply_table_policies(connection, table_name):
     except Exception as e:
         logger.error(f"❌ Error applying policies to table {table_name}: {e}")
         return False
-
-def load_db_config(environment="cloud"):
-    """
-    Load database configuration from environment variables.
-    
-    Args:
-        environment (str): The environment to use, either 'local' or 'cloud'
-    """
-    logger.debug(f"📂 Loading database configuration for {environment} environment")
-    
-    # Load environment variables from .env file
-    load_dotenv()
-    
-    env_suffix = f"_{environment}"
-    
-    db_config = {
-        "user": os.getenv(f"db_user{env_suffix}"),
-        "password": os.getenv(f"db_password{env_suffix}"),
-        "host": os.getenv(f"db_host{env_suffix}"),
-        "port": os.getenv(f"db_port{env_suffix}"),
-        "dbname": os.getenv(f"db_name{env_suffix}")
-    }
-    
-    # Check if all required configuration exists
-    missing_keys = [k for k, v in db_config.items() if not v]
-    if missing_keys:
-        logger.error(f"❌ Database configuration missing: {', '.join(missing_keys)}")
-        return None
-            
-    logger.info(f"✅ Database configuration loaded successfully for {environment} environment")
-    return db_config
-
-def get_db_connection(db_config=None, environment="cloud"):
-    """
-    Get a PostgreSQL database connection.
-    
-    Args:
-        db_config (dict, optional): Database configuration parameters
-        environment (str, optional): The environment to use if db_config is None
-    """
-    if db_config is None:
-        db_config = load_db_config(environment)
-        
-    if not db_config:
-        return None
-        
-    try:
-        connection = psycopg2.connect(
-            user=db_config.get("user"),
-            password=db_config.get("password"),
-            host=db_config.get("host"),
-            port=db_config.get("port"),
-            dbname=db_config.get("dbname")
-        )
-        connection.autocommit = True
-        logger.info("✅ Connected to database successfully")
-        return connection
-    except Exception as e:
-        logger.error(f"❌ Error connecting to database: {e}")
-        return None
 
 def load_notion_data():
     """

--- a/reporting/social_client/social_api_client.py
+++ b/reporting/social_client/social_api_client.py
@@ -13,6 +13,7 @@ from pathlib import Path
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
+from config.loader import load_full_config as load_config
 
 # Set up logger
 logger = None
@@ -32,23 +33,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("social_api_client", file_logging=False, level=log_level)
     return logger
-
-def load_config():
-    """Load configuration from config.json file."""
-    logger.debug("📂 Loading configuration file")
-    config_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'config')
-    config_path = os.path.join(config_dir, 'config.json')
-    
-    try:
-        with open(config_path, 'r') as file:
-            logger.info("✅ Configuration loaded successfully")
-            return json.load(file)
-    except FileNotFoundError:
-        logger.error(f"❌ Error: Configuration file not found at {config_path}")
-        return None
-    except json.JSONDecodeError:
-        logger.error(f"❌ Error: Invalid JSON in configuration file at {config_path}")
-        return None
 
 def check_file_exists_for_date(platform_key, config, date_str):
     """Check if a file already exists for the specified date for this platform."""
@@ -355,10 +339,7 @@ def main(args=None):
     
     # Load configuration
     config = load_config()
-    if not config:
-        logger.error("❌ Failed to load configuration")
-        return
-    
+
     # Use arguments instead of prompts
     skip_existing = args.skip_existing
     logger.info(f"⏩ Skip existing: {'Enabled' if skip_existing else 'Disabled'}")


### PR DESCRIPTION
## Summary

Consolidates the three duplication clusters surfaced by `/codebase-audit` in #133. Net **−173 LOC** of copy-paste removed; the config/secrets path and the two DB/Notion helper sets are now single-source.

| SHA | What | Why |
|---|---|---|
| `297b508` | New `reporting/notion/_client.py` owns `init_notion_client` + `format_database_id`; `notion_update` / `notion_database_structure` import & re-export from it; `editorial` imports from `_client` | Finding 1 — the two helpers were verbatim across both notion modules |
| `254a336` | `load_db_config` + `get_db_connection` kept only in `supabase_uploader`; `supabase_policy_script` / `supabase_relations_creator` import them; dead `os`/`load_dotenv` imports dropped | Finding 2 — both helpers were verbatim across all three supabase modules |
| `92458a2` | New `config/loader.py` (`load_full_config()` cached + `load_block()`); the 7 per-module `load_config()` reinventions migrated to it; dead `None`-guards and `json`/`REPO_ROOT`/`CONFIG_PATH` imports removed | Finding 3 — seven hand-copied config loaders |
| `aa3d46b` | Document `config/loader.py` as section 6 of `config/README.md` | Point future code at the single source so the reinvention doesn't recur |

## Behavioral change worth flagging

The 5 reporting `load_config()` variants previously logged + returned `None` on a missing/corrupt `config.json`; callers did `if not config: return`. The canonical loader **fails loud** (raises) instead — matching `engagement`, `newsletter`, `reporting/scrape_client/base.py`, and `planning/_session_base.py`, which already raise. Config is mandatory, so a clear exception beats a silent skip. The now-dead `None`-guards were removed.

## Scope note

`reporting/scrape_client/base.py` and `planning/_session_base.py` were left untouched. The issue cites them as the **good exemplars**, and `_session_base` exports/uses `CONFIG_PATH`/`REPO_ROOT` across several functions — folding only its `load_config_block` would leave a sibling reading inline (an inconsistent half-migration on a hot path). They stay as self-contained shared bases. `add_editorial_dates.py::load_config(override)→tuple` is genuinely different and also left as-is.

## Validation

- `python -m py_compile` on all 14 touched modules → clean.
- Import-smoke all 14 modules + `engagement.linkedin.scrape_comments` → clean, no circular imports.
- Identity checks: every moved helper and all 7 `load_config` aliases resolve to a single canonical object; loader is process-cached; `format_database_id` behaves. All green.
- No external importer references the moved symbols from the stripped modules.
- No test suite / CI / pytest config exists in this repo — the gate is byte-compile + import-smoke.

Closes #133
