### PR TITLE
chore: unify notion config loading and streamlit theme source

### DIFF
--- a/app/.streamlit/config.toml
+++ b/app/.streamlit/config.toml
@@ -1,6 +1,0 @@
-[theme]
-primaryColor = "#1E88E5"
-backgroundColor = "#0E1117"
-secondaryBackgroundColor = "#262730"
-textColor = "#FAFAFA"
-font = "sans serif"

--- a/app/check_control_panel.py
+++ b/app/check_control_panel.py
@@ -204,7 +204,8 @@ def run() -> int:
             fails += 1
 
         print("\n📱 step 6 — custom .streamlit/config.toml theme is applied")
-        # Theme values from app/.streamlit/config.toml:
+        # Theme values from .streamlit/config.toml (repo root — the config
+        # Streamlit actually reads via launch_app.bat / run_app.py):
         #   backgroundColor          = "#0E1117"  → rgb(14, 17, 23)
         #   secondaryBackgroundColor = "#262730"  → rgb(38, 39, 48)
         #   primaryColor             = "#1E88E5"  → rgb(30, 136, 229)

--- a/reporting/notion/add_editorial_dates.py
+++ b/reporting/notion/add_editorial_dates.py
@@ -24,7 +24,6 @@ Authenticates and resolves the editorial DB from this repo's ``config.json``
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import sys
 from calendar import monthrange
@@ -38,16 +37,15 @@ if str(REPO_ROOT) not in sys.path:
 
 # Importing editorial configures notion_update's module-level logger on import,
 # so the reused init_notion_client / query helpers below don't blow up.
+from config.loader import load_full_config  # noqa: E402
 from reporting.notion import notion_update as _nu  # noqa: E402
-from reporting.notion.editorial import query_rows_by_filter  # noqa: E402
-from reporting.notion.notion_update import (  # noqa: E402
+from reporting.notion._client import (  # noqa: E402
     format_database_id,
     init_notion_client,
 )
+from reporting.notion.editorial import query_rows_by_filter  # noqa: E402
 
 logger = logging.getLogger("add_editorial_dates")
-
-CONFIG_PATH = REPO_ROOT / "config" / "config.json"
 
 # Editorial-DB property names are structural; defaults match the live DB and can
 # be overridden via ``notion.editorial_date_columns`` in config.json (per the
@@ -91,9 +89,8 @@ def load_config(database_id_override: Optional[str] = None) -> tuple[str, str, d
     The editorial DB is the first entry in ``notion.databases`` (matching
     ``notion_update.py``), unless ``database_id_override`` is given.
     """
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
-        config = json.load(fh)
-    notion_cfg = config.get("notion", {})
+    cfg = load_full_config()
+    notion_cfg = cfg.get("notion", {})
 
     api_token = notion_cfg.get("api_token")
     if not api_token:


### PR DESCRIPTION
## Summary
- `reporting/notion/add_editorial_dates.py` now loads `config.json` through `config.loader.load_full_config()` instead of its own inline `open()`/`json.load()` — matching the convention the rest of `reporting/`, `engagement/`, and `newsletter/` already migrated to (`config/README.md` §6).
- Imports `format_database_id` / `init_notion_client` directly from `reporting.notion._client` instead of the deprecated re-export path through `reporting.notion.notion_update` (matching `reporting/notion/editorial.py`'s existing pattern).
- Deletes the byte-identical `app/.streamlit/config.toml` duplicate — `.streamlit/config.toml` at the repo root is the one Streamlit actually reads, since `launch_app.bat` / `run_app.py` both run from the repo root.
- Fixes the stale comment in `app/check_control_panel.py` step 6 that pointed at the now-deleted `app/.streamlit/config.toml`.

## Validation
- `py_compile` on both changed Python files: clean.
- No test suite or CI configured in this repo (`.github/workflows/` absent, no `tests/` dir) — confirmed by search.
- Read-only behavioral probe run against the real `config.json` + live Notion API (no writes): `load_config()` → `init_notion_client()` → `format_database_id()` → `get_existing_dates()` (a real, read-only query) all succeeded end-to-end, proving the refactored config path resolves the same api_token/database_id/columns and the client + query pipeline still works.
- `git diff main...HEAD` reviewed — scoped to exactly the two findings in #144, no unrelated changes.

Closes #144