### PR TITLE
fix: suppress Invalid HTTP request warning on Streamlit's uvicorn server

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -27,13 +27,15 @@ class _SuppressConnReset(logging.Filter):
         return True
 
 
-# Suppress "Invalid HTTP request received" — Tornado/Uvicorn warning triggered by
-# browser preconnects and non-HTTP traffic; not an app error.
-logging.getLogger("tornado.general").addFilter(
-    type("_NoInvalidHTTP", (logging.Filter,), {
-        "filter": staticmethod(lambda r: "Invalid HTTP request" not in r.getMessage())
-    })()
-)
+# Suppress "Invalid HTTP request received" — a warning triggered by browser
+# preconnects and non-HTTP traffic; not an app error. Streamlit >=1.5x serves
+# over Starlette/uvicorn (not Tornado), so the real logger is "uvicorn.error";
+# the "tornado.general" filter is kept for older Streamlit installs.
+_no_invalid_http = type("_NoInvalidHTTP", (logging.Filter,), {
+    "filter": staticmethod(lambda r: "Invalid HTTP request" not in r.getMessage())
+})()
+logging.getLogger("tornado.general").addFilter(_no_invalid_http)
+logging.getLogger("uvicorn.error").addFilter(_no_invalid_http)
 # Suppress ConnectionResetError / BrokenPipeError tracebacks from asyncio callbacks.
 logging.getLogger("asyncio").addFilter(_SuppressConnReset())
 


### PR DESCRIPTION
## Summary
- Streamlit's default `requirements.txt` install pulled 1.57.0, which replaced the Tornado server with Starlette/uvicorn — the existing `tornado.general` log filter went dead, so `Invalid HTTP request received.` warnings flood the terminal unsuppressed and coincide with the app appearing to hang.
- Adds the same suppression filter on `logging.getLogger("uvicorn.error")` (the new source of that warning), keeping the old `tornado.general` filter for compatibility.

## Validation
- Confirmed root cause by reading the installed `streamlit` package: `web/server/starlette/starlette_server.py` (`UvicornServer`) and `uvicorn/protocols/http/h11_impl.py:182-183` (`self.logger = logging.getLogger("uvicorn.error")`, warns `"Invalid HTTP request received."` on `h11.RemoteProtocolError`).
- Reproduced deterministically on a throwaway port (8510, not the live :8501 session): sent raw malformed bytes over a socket.
  - Pre-fix: 1 garbage send -> 1 unsuppressed `Invalid HTTP request received.` line in the server log.
  - Post-fix (same repro): 5 garbage sends -> 0 lines logged.
- `py_compile run_app.py` — clean.
- Loaded the control panel in a real browser against the fixed build — all tabs render, newsletter tab's Bootstrap Chrome / Archive / Normalize buttons render and respond normally.
- `git diff main...HEAD` — single-file, scoped diff, no unintended changes.
- No repo test suite / lint config exists for this project (no `pytest`, `ruff`, or `scripts/verify-before-ship.*`) — the above is the available verification surface.

Closes #152