### PR TITLE
fix: replace st.columns() with st.container(horizontal=True) for newsletter/planning run buttons

### DIFF
--- a/app/tab_newsletter.py
+++ b/app/tab_newsletter.py
@@ -68,8 +68,11 @@ def run() -> None:
     st.caption("→ after bootstrap, open your article tabs in that Chrome window, then run ② (or ▶).")
 
     # ── ②③④ step buttons ─────────────────────────────────────────────
-    c2, c3, c4 = st.columns(3)
-    with c2:
+    # st.container(horizontal=True) rather than st.columns() — buttons with
+    # on_click nested inside st.columns() under st.tabs() silently fail to
+    # fire and reset the active tab on Streamlit's uvicorn/Starlette server
+    # (issue #155). container(horizontal=True) doesn't have this problem.
+    with st.container(horizontal=True, gap="small"):
         st.button(
             "② Archive → Notion",
             key="newsletter-archive",
@@ -78,7 +81,6 @@ def run() -> None:
             args=(PIPELINE_NAME, base + ["archive"] + dbg),
             width="stretch",
         )
-    with c3:
         st.button(
             "③ Normalize titles+URLs",
             key="newsletter-normalize",
@@ -87,7 +89,6 @@ def run() -> None:
             args=(PIPELINE_NAME, base + ["normalize", "--days", str(int(days))] + dbg),
             width="stretch",
         )
-    with c4:
         st.button(
             "④ Build HTML",
             key="newsletter-build",

--- a/app/tab_planning.py
+++ b/app/tab_planning.py
@@ -122,8 +122,11 @@ def run() -> None:
     if mode == "live":
         st.warning("⚠️ LIVE mode will write real schedules into LI/IG/TW/TH. Make sure your WIP-* checkboxes are correct.")
 
-    run_cols = st.columns([3, 4])
-    with run_cols[0]:
+    # st.container(horizontal=True) rather than st.columns() — buttons with
+    # on_click nested inside st.columns() under st.tabs() silently fail to
+    # fire and reset the active tab on Streamlit's uvicorn/Starlette server
+    # (issue #155). container(horizontal=True) doesn't have this problem.
+    with st.container(horizontal=True, gap="small"):
         st.button(
             "▶ run planning pipeline",
             key="planning-run",
@@ -132,7 +135,6 @@ def run() -> None:
             on_click=_launch_plain,
             args=(cmd,),
         )
-    with run_cols[1]:
         st.button(
             "🔧 run + autoheal (console)",
             key="planning-autoheal-run",


### PR DESCRIPTION
## Summary
- The newsletter tab's Archive/Normalize/Build buttons and planning's run buttons are `st.button(..., on_click=...)` nested inside `st.columns()`, itself nested inside `st.tabs()`. This reproducibly failed to fire the callback and reset the active tab to the first one, blocking the newsletter archive/normalize/build steps.
- Replaces `st.columns()` with `st.container(horizontal=True, gap="small")` for both button rows, matching the pattern already used (and already working) for `process_runner.py`'s stop/clear buttons in the same app.

## Validation
- `py_compile` clean on both files.
- Live-verified the newsletter fix against the real running app: clicked the fixed "Archive -> Notion" button and confirmed via OS process inspection that the `newsletter_pipeline.py archive` subprocess spawned and ran to completion, correctly archiving real articles into Notion (11 created, 1 duplicate URL correctly skipped) and closing the corresponding Chrome tabs — the actual end-to-end behavior the button is supposed to trigger.
- `tab_planning.py`'s fix follows the identical, already-proven pattern but wasn't independently re-run live in this session (no planning run was triggered) — flagging that explicitly rather than overclaiming.
- Note on diagnosis: while investigating, browser-automation clicks (via a CDP-driven click tool) were themselves unreliable against this button independent of the columns/container distinction, which complicated isolating the exact root cause. What's confirmed is the *outcome*: the old `st.columns()` layout consistently failed across many attempts with the live app, and the new `st.container(horizontal=True)` layout worked correctly on a real click, matching the working sibling pattern already in this codebase.
- `git diff main...HEAD` — scoped to the two button-layout blocks, no unintended changes.

Closes #155