### PR TITLE
fix: st.tabs() resets to first tab on any widget rerun — replace with st.segmented_control

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,9 +1,11 @@
 r"""Unified control-panel Streamlit app.
 
-Tabs: 📊 Reporting · 📅 Planning · 📰 Newsletter · 🛡️ Engagement.
-Each tab owns its own module (`app.tab_*`) per the project's per-tab
-convention (see pdf-to-markdown sibling project + CLAUDE.md). Subprocess
-lifecycle + live log streaming lives in `app/process_runner.py`.
+Sections: 📊 Reporting · 📅 Editorial · 📅 Planning · 📰 Newsletter · 🛡️ Engagement.
+Routed via st.segmented_control rather than st.tabs() (issue #157 — st.tabs()
+loses the active tab on any widget rerun). Each section owns its own module
+(`app.tab_*`) per the project's per-tab convention (see pdf-to-markdown
+sibling project + CLAUDE.md). Subprocess lifecycle + live log streaming lives
+in `app/process_runner.py`.
 
 Launch via the wrapper (recommended — applies logging filters before server start):
     .\launch_app.bat
@@ -80,31 +82,42 @@ with st.sidebar:
     st.code(str(REPO_ROOT), language=None)
 
 
-# ── Tabs ─────────────────────────────────────────────────────────────
-tab_rep, tab_ed, tab_plan, tab_news, tab_eng = st.tabs([
-    "📊 reporting",
-    "📅 editorial",
-    "📅 planning",
-    "📰 newsletter",
-    "🛡️ engagement",
-])
+# ── Section routing ────────────────────────────────────────────────
+# st.segmented_control rather than st.tabs() — st.tabs() does not preserve
+# the active tab across a script rerun triggered by a widget on a
+# non-default tab (it silently snaps back to the first tab and the
+# triggering widget's new value never reaches the script). Confirmed
+# against upstream Streamlit 1.59.1 too, so it isn't fixable by upgrading
+# (issue #157; streamlit/streamlit#11160, #12554). segmented_control is a
+# real widget — its selection is ordinary widget state, so it survives any
+# rerun the way st.tabs()'s internal state does not.
+SECTIONS = ["📊 reporting", "📅 editorial", "📅 planning", "📰 newsletter", "🛡️ engagement"]
 
-with tab_rep:
+section = st.segmented_control(
+    "section",
+    options=SECTIONS,
+    default=SECTIONS[0],
+    key="app-section",
+    label_visibility="collapsed",
+)
+# On the very first script run of a fresh session, segmented_control can
+# return None for one rerun before its frontend component echoes back the
+# default (the page briefly renders with nothing selected below the nav).
+# Falling back to the default here avoids a blank-body flash / e2e race.
+section = section or SECTIONS[0]
+
+if section == "📊 reporting":
     from app import tab_reporting  # noqa: PLC0415
     tab_reporting.run()
-
-with tab_ed:
+elif section == "📅 editorial":
     from app import tab_editorial  # noqa: PLC0415
     tab_editorial.run()
-
-with tab_plan:
+elif section == "📅 planning":
     from app import tab_planning  # noqa: PLC0415
     tab_planning.run()
-
-with tab_news:
+elif section == "📰 newsletter":
     from app import tab_newsletter  # noqa: PLC0415
     tab_newsletter.run()
-
-with tab_eng:
+elif section == "🛡️ engagement":
     from app import tab_engagement  # noqa: PLC0415
     tab_engagement.run()

--- a/app/check_control_panel.py
+++ b/app/check_control_panel.py
@@ -46,7 +46,7 @@ def _shot(page, out_dir: Path, label: str) -> None:
 def _assert_no_traceback(page, label: str) -> bool:
     """Scan ONLY Streamlit's exception widgets for Python errors. Body-text
     scanning gives false positives — log panels of past runs contain
-    'Traceback:' as data, and st.tabs keeps all sub-tab content in the DOM."""
+    'Traceback:' as data."""
     try:
         excs = page.locator("[data-testid='stException']")
         count = excs.count()
@@ -204,6 +204,11 @@ def run() -> int:
             fails += 1
 
         print("\n📱 step 6 — custom .streamlit/config.toml theme is applied")
+        # Since app.py routes sections via st.segmented_control (issue #157), only
+        # the active section's buttons exist in the DOM — go back to reporting so
+        # a type=primary button is guaranteed present for the probe below.
+        _click_tab(page, "reporting")
+        page.wait_for_timeout(800)
         # Theme values from .streamlit/config.toml (repo root — the config
         # Streamlit actually reads via launch_app.bat / run_app.py):
         #   backgroundColor          = "#0E1117"  → rgb(14, 17, 23)
@@ -216,12 +221,12 @@ def run() -> int:
             () => {
                 const body = document.body;
                 const sidebar = document.querySelector("section[data-testid='stSidebar']");
-                // The 'run reporting pipeline' button is type=primary so it should use primaryColor.
-                let primaryBtn = null;
-                const btns = Array.from(document.querySelectorAll("button"));
-                for (const b of btns) {
-                    if ((b.innerText || '').toLowerCase().includes('run reporting pipeline')) { primaryBtn = b; break; }
-                }
+                // Any type=primary button should use primaryColor. Selected by Streamlit's
+                // own data-testid rather than a button label — since app.py routes sections
+                // via st.segmented_control (issue #157), only the currently active section's
+                // buttons exist in the DOM, so a label from a specific section (e.g. "run
+                // reporting pipeline") may not be present at this point in the script.
+                const primaryBtn = document.querySelector("button[data-testid='stBaseButton-primary']");
                 const cs = (el) => el ? getComputedStyle(el) : null;
                 return {
                     bodyBg:    cs(body)?.backgroundColor    || null,

--- a/app/tab_engagement.py
+++ b/app/tab_engagement.py
@@ -164,17 +164,26 @@ def run() -> None:
         with col_filters:
             platform, search = render_sidebar_filters(key_suffix="-engagement-tab")
 
-    sub_run, sub_real, sub_ai, sub_people = st.tabs([
-        "🚀 scrape + classify",
-        "🧑 real comments",
-        "🤖 AI triage",
-        "📊 commenters",
-    ])
-    with sub_run:
+    # st.segmented_control rather than st.tabs() — same fix as app.py's
+    # top-level routing (issue #157): st.tabs() loses the active sub-tab on
+    # any widget rerun triggered inside a non-default sub-tab.
+    SUB_SECTIONS = ["🚀 scrape + classify", "🧑 real comments", "🤖 AI triage", "📊 commenters"]
+    sub_section = st.segmented_control(
+        "engagement sub-section",
+        options=SUB_SECTIONS,
+        default=SUB_SECTIONS[0],
+        key="engagement-sub-section",
+        label_visibility="collapsed",
+    )
+    # See app.py's app-section for why this fallback is needed — segmented_control
+    # can return None for one rerun before its default is echoed back.
+    sub_section = sub_section or SUB_SECTIONS[0]
+
+    if sub_section == "🚀 scrape + classify":
         _render_run_subtab()
-    with sub_real:
+    elif sub_section == "🧑 real comments":
         render_real_tab(platform, search)
-    with sub_ai:
+    elif sub_section == "🤖 AI triage":
         render_ai_tab(platform, search)
-    with sub_people:
+    elif sub_section == "📊 commenters":
         render_commenters_tab(platform, search)


### PR DESCRIPTION
## Summary
- `st.tabs()` does not preserve the active tab across a script rerun triggered by a widget on a non-default tab — it silently snaps back to the first tab and the triggering widget's value never reaches the script. Confirmed still present in upstream Streamlit 1.59.1, so it isn't fixable by upgrading (streamlit/streamlit#11160, #12554, both closed by maintainers for lack of a repro rather than fixed).
- #155's fix (moving buttons out of `st.columns()`) treated a symptom, not this cause — it stopped buttons from silently no-op'ing, but any widget on any non-default tab still resets the whole view.
- Replaces `st.tabs()` with `st.segmented_control` (a real widget whose selection is ordinary session state, so it survives any rerun) for `app.py`'s top-level section routing and `tab_engagement.py`'s nested scrape/real-comments/AI-triage/commenters sub-tabs, which have the identical defect.
- Guards against a one-rerun `None` return from `segmented_control` on a truly fresh session (before its frontend echoes back the `default`), which otherwise renders a blank page for that first script run.
- Updates `check_control_panel.py`'s e2e probes for the new DOM shape: only the active section's content is mounted now, not every tab simultaneously.

## Validation
- Reproduced the original bug live (fresh page load → newsletter tab → type a number → Enter → app snapped to "reporting", the number never registered) before the fix.
- After the fix, re-tested the same sequence plus planning's mode/skip toggles and engagement's nested sub-tabs (switched to "AI triage", interacted with a filter widget) — all now stay on the interacted-with section/sub-section, values commit correctly.
- `py_compile` on all touched files — clean.
- `python -m app.check_control_panel` (full Playwright e2e suite) — all checks pass.
- `git diff main...HEAD` reviewed — only the 3 files described above.

## Test plan
- [x] Newsletter tab: type a newsletter number, press Enter, confirm view stays on newsletter and Build/Run enable.
- [x] Planning tab: switch mode to live, confirm view stays on planning and the warning banner + last-run panel render.
- [x] Engagement tab: switch to "AI triage" sub-section, toggle the pending/all filter, confirm it stays on AI triage.
- [x] `python -m app.check_control_panel` passes end to end.

Closes #157