### PR TITLE
chore: warn when supabase_client falls back to anon_key

### DIFF
--- a/engagement/db/client.py
+++ b/engagement/db/client.py
@@ -65,6 +65,10 @@ def supabase_client():
             client = create_client(url, key)
             # Cheap sanity ping — pick a table that exists, limit 1.
             client.table("commenters").select("platform").limit(1).execute()
+            if label == "anon_key":
+                # service_role_key and key both unavailable/failed — track whether
+                # this fallback is ever actually exercised (see issue #51).
+                logger.warning("🔓 supabase_client() fell back to anon_key — service_role_key and key both unavailable")
             logger.info("🔑 using supabase key: %s", label)
             return client
         except Exception as err:


### PR DESCRIPTION
## Summary
- Part of #51 (step 1 only — the observation window, not the actual privilege revocation).
- `engagement/db/client.py`'s `supabase_client()` now logs a WARNING the one time per process it actually falls back to the `anon_key` candidate (i.e. `service_role_key` and `key` both failed/unavailable), instead of only logging it at INFO like every other candidate.
- Goal: run this in production for ~7 days to confirm the anon-key fallback path is genuinely never exercised, before touching `reporting/process/supabase_policy_script.sql` to revoke anon's privileges on the live Supabase project.

## Not in this PR
- The actual SQL privilege revocation and stale-docstring fix (issue's step 2/3) — deliberately deferred until the 7-day observation window has run with zero hits, per the issue's own acceptance criteria. This PR does not close #51.

## Validation
- `py_compile` on the changed file: clean.
- Behavioral probe (fake `supabase` module + patched config, no real credentials/network): confirmed the warning fires exactly once when only `anon_key` is usable, and does not fire when `service_role_key` works — both the normal path and the fallback path behave as intended.
- `git diff main...HEAD`: 4-line addition only, no unrelated changes.

## Test plan
- [x] Confirmed no warning on the normal `service_role_key` path (probe).
- [x] Confirmed exactly one warning on the `anon_key`-only fallback path (probe).
- [ ] Watch production logs for `engagement.db` warnings over the next 7 days (tracked in #51).