### PR TITLE
fix: configure engagement package-root logger so sibling records reach logs

### DIFF
--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -689,7 +689,11 @@ def main() -> None:  # pragma: no cover
     args = parser.parse_args()
 
     force_utf8_stdio()
-    setup_logger("engagement.linkedin.scrape", level=logging.DEBUG if args.debug else logging.INFO, file_logging=True)
+    # Configure the package-root logger so siblings (engagement.db,
+    # engagement.classify.*, engagement.reputation) propagate into the same log
+    # file. Naming a leaf here leaves them with no configured ancestor, so they
+    # fall through to logging.lastResort — stderr-only, WARNING+ (issue #160).
+    setup_logger("engagement", level=logging.DEBUG if args.debug else logging.INFO, file_logging=True)
     logging.getLogger().setLevel(logging.DEBUG if args.debug else logging.INFO)
 
     cfg = load_config().get("engagement", {})


### PR DESCRIPTION
## Summary

`engagement.db`'s records — including #159's `🔓 fell back to anon_key` WARNING — never reached any log file. `scrape_comments.py`'s `main()` configured the **leaf** logger `"engagement.linkedin.scrape"`, but `config/logger_config.py`'s `setup_logger` attaches handlers to exactly the logger it is named, and nothing else. `engagement.db` is a *sibling* of that leaf, not a child, so it had no configured ancestor: its records propagated to a root logger this repo never gives a handler, and fell through to `logging.lastResort` — stderr only, WARNING+, unformatted, INFO dropped entirely.

The fix configures the package root `"engagement"` instead, matching the pattern `newsletter/pipeline.py:144` already documents for `newsletter_archive`. Every `engagement.*` child now propagates into one file, and `%(name)s` in the format string still identifies each record's source module.

This is one line plus a comment. `config/logger_config.py` is untouched — it behaves as documented, and reporting/planning pass flat, childless logger names, so nothing else in the repo was affected by the bug or is affected by the fix.

## Validation

**Reproduction (before the fix).** A probe replicating `main()`'s setup for both wirings, emitting on the sibling `engagement.db` logger with a run-unique marker so a stale line cannot fake a pass:

```
  leaf  setup_logger('engagement.linkedin.scrape') -> engagement.db record in file: False
  root  setup_logger('engagement')                 -> engagement.db record in file: True

REPRO CONFIRMED: leaf wiring loses the sibling record; package-root wiring keeps it.
```

Under the leaf wiring the record also printed to stderr *unformatted* — no timestamp, no logger name, no level — the visible signature of `lastResort`.

**End-to-end (after the fix).** The real `main()` executed with only the Playwright scrape stubbed out, so the actual changed line ran, then the genuine `engagement.db` path exercised. Both records — including the exact WARNING that was invisible for four days, and the INFO line that was being dropped — landed in `logs/engagement.log`, fully formatted:

```
2026-07-16 22:15:19,506 - engagement.db - WARNING - 🔓 supabase_client() fell back to anon_key — service_role_key and key both unavailable
2026-07-16 22:15:19,506 - engagement.db - INFO - 🔑 using supabase key: anon_key

engagement.db (sibling) records that reached the file: 2
PASS — sibling records now land in logs/
```

**Byte-compile.** `py_compile engagement/linkedin/scrape_comments.py` → OK.

**Test suite / CI.** This repo has neither — no pytest suite, no lint config, and no `.github/workflows/`. Stating that explicitly rather than implying a green run; the reproduction and end-to-end probe above are the evidence.

**Scope sweep.** `git diff main...HEAD` touches one file: the `setup_logger` argument and its comment. No dependency changes, no weakened assertions, no `.gitignore` edits.

## Notes

Nothing in the repo references the old `logs/engagement.linkedin.scrape.log` filename (the `engagement.linkedin.scrape_comments` hits are the *module* path, unchanged), no README documents log filenames, and `logs/` is gitignored — so there is nothing to migrate and no docs to update.

Those two log lines are themselves worth reading: the service-role credential really is invalid and engagement really is authenticating as anon. That is tracked separately in #51's post-mortem and is not addressed here.

Closes #160
