### PR TITLE
chore: detect Supabase RLS / policy drift on the daily pipeline

### DIFF
--- a/reporting/process/README.md
+++ b/reporting/process/README.md
@@ -110,8 +110,36 @@ Applies Row Level Security (RLS) policies to all existing tables in Supabase:
 **Command Line Options:**
 - `--environment`: Choose between local/cloud database (default: cloud)
 - `--dry-run`: Preview what would be done without executing
+- `--check`: Detect RLS / policy / view-security drift and exit non-zero on any drift (read-only, no changes)
 - `--force`: Drop existing policies before creating new ones
 - `--debug`: Enable detailed debug logging
+
+**Drift detection (`--check`):**
+
+`--check` is a read-only gate that asserts the current security posture instead
+of changing it. For every public table it verifies RLS is enabled **and** all
+four `anon_*_all` policies exist; for every public view it verifies
+`security_invoker = on`. It exits `0` when everything conforms and non-zero,
+with an emoji-prefixed per-object summary of what drifted, when anything is
+missing. This catches a newly-created table or view that slipped through
+without RLS on the project's own clock, rather than waiting for the weekly
+Supabase security-advisor email.
+
+The daily reporting pipeline (`reporting_pipeline.py`, Step 7) runs this same
+check on every run: drift is folded into the pipeline's consolidated failure
+alert and makes the pipeline exit non-zero, so a red daily run is the signal.
+
+**Remediation runbook** — when `--check` (or the pipeline's Step 7) reports
+drift:
+
+1. Re-apply the policies by running `reporting/process/supabase_policy_script.sql`
+   in Supabase → SQL Editor, or run `python supabase_policy_script.py` (without
+   `--check`) to enable RLS + create the missing policies and set
+   `security_invoker = on` on views.
+2. Re-run `python supabase_policy_script.py --check` and confirm it exits `0`.
+
+Remediation stays a deliberate human action — the check only reports; it never
+auto-remediates, so an unintended schema change can't be silently papered over.
 
 ### 🧪 Database Test Utilities
 
@@ -199,6 +227,9 @@ Apply Row Level Security policies to all existing tables:
 ```bash
 # Preview what would be done without executing
 python supabase_policy_script.py --dry-run
+
+# Detect drift only (read-only; exits non-zero if any table/view drifted)
+python supabase_policy_script.py --check
 
 # Apply policies to all tables (skips tables that already have policies)
 python supabase_policy_script.py

--- a/reporting/process/supabase_policy_script.py
+++ b/reporting/process/supabase_policy_script.py
@@ -130,6 +130,128 @@ def check_table_policies(connection, table_name):
         logger.error(f"❌ Error checking policies for table {table_name}: {e}")
         return None
 
+def check_view_security_invoker(connection, view_name):
+    """
+    Check whether a view runs with security_invoker enabled.
+
+    security_invoker=on makes a view execute with the querying role's
+    permissions, so the underlying tables' RLS applies through the view. It is
+    stored as a reloption on the view's pg_class row.
+
+    Args:
+        connection: Database connection
+        view_name (str): Name of the view to check
+
+    Returns:
+        Optional[bool]: True if security_invoker is on, False if off/unset,
+            None on query error (caller should treat None as drift, fail-closed).
+    """
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                SELECT c.reloptions
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = %s AND c.relkind = 'v'
+            """, (view_name,))
+            row = cursor.fetchone()
+
+        reloptions = row[0] if row else None
+        if not reloptions:
+            return False
+        for opt in reloptions:
+            key, _, value = opt.partition('=')
+            if key.strip().lower() == 'security_invoker':
+                return value.strip().lower() in ('on', 'true', '1', 'yes')
+        return False
+
+    except Exception as e:
+        logger.error(f"❌ Error checking security_invoker for view {view_name}: {e}")
+        return None
+
+def check_policy_drift(connection):
+    """
+    Detect RLS / policy / view-security drift across the public schema.
+
+    Read-only. For every table it asserts RLS is enabled and all four
+    ``anon_*_all`` policies exist (reusing ``check_table_policies``); for every
+    view it asserts ``security_invoker = on``. Query errors on an individual
+    object are treated as drift (fail-closed) so a broken check never reports
+    a clean schema.
+
+    Args:
+        connection: Database connection
+
+    Returns:
+        dict: {
+            'clean': bool,                 # True only when nothing drifted
+            'table_issues': [ {'name', 'rls_missing', 'missing_policies', 'error'} ],
+            'view_issues': [ {'name', 'error'} ],
+            'total_tables': int,
+            'total_views': int,
+        }
+    """
+    tables = get_all_tables(connection)
+    views = get_all_views(connection)
+
+    table_issues = []
+    for table_name in tables:
+        status = check_table_policies(connection, table_name)
+        if status is None:
+            table_issues.append({'name': table_name, 'rls_missing': False,
+                                 'missing_policies': [], 'error': True})
+            continue
+        rls_missing = not status['rls_enabled']
+        missing_policies = status['missing_policies']
+        if rls_missing or missing_policies:
+            table_issues.append({'name': table_name, 'rls_missing': rls_missing,
+                                 'missing_policies': missing_policies, 'error': False})
+
+    view_issues = []
+    for view_name in views:
+        secure = check_view_security_invoker(connection, view_name)
+        if secure is None:
+            view_issues.append({'name': view_name, 'error': True})
+        elif not secure:
+            view_issues.append({'name': view_name, 'error': False})
+
+    return {
+        'clean': not table_issues and not view_issues,
+        'table_issues': table_issues,
+        'view_issues': view_issues,
+        'total_tables': len(tables),
+        'total_views': len(views),
+    }
+
+def summarize_drift(result):
+    """
+    Flatten a ``check_policy_drift`` result into human-readable drift lines.
+
+    Args:
+        result (dict): Output of ``check_policy_drift``.
+
+    Returns:
+        List[Tuple[str, str]]: ``(kind, summary)`` pairs where kind is
+            ``'table'`` or ``'view'`` and summary names the object and what is
+            wrong, suitable for logging or a Slack alert.
+    """
+    items = []
+    for issue in result['table_issues']:
+        if issue.get('error'):
+            reason = 'policy check errored'
+        else:
+            parts = []
+            if issue['rls_missing']:
+                parts.append('RLS disabled')
+            if issue['missing_policies']:
+                parts.append('missing policies: ' + ', '.join(issue['missing_policies']))
+            reason = '; '.join(parts)
+        items.append(('table', f"{issue['name']} ({reason})"))
+    for issue in result['view_issues']:
+        reason = 'security check errored' if issue.get('error') else 'security_invoker off'
+        items.append(('view', f"{issue['name']} ({reason})"))
+    return items
+
 def apply_table_policies(connection, table_name, force=False):
     """
     Apply Row Level Security (RLS) policies to a table.
@@ -377,6 +499,8 @@ def main():
     parser.add_argument("--environment", choices=["local", "cloud"], default="cloud",
                         help="Database environment to use (default: cloud)")
     parser.add_argument("--dry-run", action="store_true", help="Show what would be done without executing")
+    parser.add_argument("--check", action="store_true",
+                        help="Detect RLS / policy / view-security drift and exit non-zero on any drift (read-only, no changes)")
     parser.add_argument("--force", action="store_true", help="Drop existing policies before creating new ones")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
@@ -402,7 +526,27 @@ def main():
         sys.exit(1)
     
     try:
-        if args.dry_run:
+        if args.check:
+            logger.info("🔍 CHECK MODE - detecting RLS / policy / view-security drift (no changes)")
+            result = check_policy_drift(connection)
+            drift = summarize_drift(result)
+            if drift:
+                logger.error(
+                    f"❌ RLS/policy drift detected: {len(result['table_issues'])} table(s), "
+                    f"{len(result['view_issues'])} view(s)"
+                )
+                for kind, summary in drift:
+                    logger.error(f"❌ Drift: {kind} {summary}")
+                logger.error(
+                    "❌ Remediate by re-running reporting/process/supabase_policy_script.sql "
+                    "(or this script without --check), then re-run with --check."
+                )
+                sys.exit(1)
+            logger.info(
+                f"✅ No RLS/policy/view drift — {result['total_tables']} table(s) and "
+                f"{result['total_views']} view(s) all conform"
+            )
+        elif args.dry_run:
             logger.info("🔍 DRY RUN MODE - No changes will be made to database")
             result = dry_run_policy_application(connection)
             if not result.get('success', True):

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -58,15 +58,21 @@ class PipelineFailures:
       absent for the date (recorded by ``check_posts_coverage``); this catches
       the case where the raw file exists but holds no post the consolidator can
       match (e.g. the day's note was dropped before it reached the DB).
+    * ``policy_drift`` — a public table lost RLS / an ``anon_*_all`` policy, or
+      a view lost ``security_invoker`` (recorded by ``check_policy_drift_coverage``);
+      this catches Supabase security drift on the project's own clock instead of
+      waiting for the weekly security-advisor email (issue #50).
     """
 
     def __init__(self) -> None:
         self.step_failures: list[tuple[str, str]] = []
         self.missing_endpoints: list[str] = []
         self.missing_post_metrics: list[str] = []
+        self.policy_drift: list[str] = []
 
     def any(self) -> bool:
-        return bool(self.step_failures or self.missing_endpoints or self.missing_post_metrics)
+        return bool(self.step_failures or self.missing_endpoints
+                    or self.missing_post_metrics or self.policy_drift)
 
 
 def _load_config() -> dict | None:
@@ -142,6 +148,44 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
         logger.error(f"❌ Posts-coverage check failed: {e}")  # type: ignore
 
 
+def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
+    """Record any Supabase RLS / policy / view-security drift for the run.
+
+    Reuses ``supabase_policy_script.check_policy_drift`` (read-only) so a public
+    table that lost RLS or an ``anon_*_all`` policy — or a view that lost
+    ``security_invoker`` — is caught on the daily run instead of via the weekly
+    security-advisor email (issue #50). DB errors degrade gracefully (logged) —
+    mirrors ``check_posts_coverage``; the run is never crashed by this posture
+    check. Remediation stays a deliberate human action: re-run
+    ``reporting/process/supabase_policy_script.sql``, then re-run the pipeline.
+    """
+    try:
+        from reporting.process.supabase_uploader import get_db_connection
+        from reporting.process.supabase_policy_script import check_policy_drift, summarize_drift
+        connection = get_db_connection()
+        if not connection:
+            logger.error("❌ Policy-drift check: no DB connection — skipped")  # type: ignore
+            return
+        try:
+            result = check_policy_drift(connection)
+        finally:
+            connection.close()
+
+        drift = summarize_drift(result)
+        if not drift:
+            logger.info(  # type: ignore
+                f"✅ Policy-drift: RLS + policies intact across {result['total_tables']} "
+                f"tables, {result['total_views']} views"
+            )
+            return
+
+        for kind, summary in drift:
+            failures.policy_drift.append(f"{kind} {summary}")
+            logger.error(f"❌ Policy-drift: {kind} {summary}")  # type: ignore
+    except Exception as e:
+        logger.error(f"❌ Policy-drift check failed: {e}")  # type: ignore
+
+
 def _resolve_reporting_channel(config: dict | None) -> str:
     """Slack target: ``slack.reporting_channel`` → falls back to ``slack.autoheal_channel``."""
     slack_cfg = config.get("slack", {}) if config else {}
@@ -173,8 +217,8 @@ def _load_slack_notify():
 
 
 def _build_alert_message(failures: "PipelineFailures", processing_date: str) -> str:
-    """Deterministic, mobile-skimmable alert body listing date, steps, endpoints."""
-    lines = [f"🚨 Reporting pipeline dropped data — {processing_date}"]
+    """Deterministic, mobile-skimmable alert body: date, steps, endpoints, drift."""
+    lines = [f"🚨 Reporting pipeline finished with failures — {processing_date}"]
     if failures.step_failures:
         lines.append("")
         lines.append("Failed steps:")
@@ -190,6 +234,11 @@ def _build_alert_message(failures: "PipelineFailures", processing_date: str) -> 
         lines.append("No post metrics (platform):")
         for platform in failures.missing_post_metrics:
             lines.append(f"• {platform}")
+    if failures.policy_drift:
+        lines.append("")
+        lines.append("RLS/policy drift:")
+        for entry in failures.policy_drift:
+            lines.append(f"• {entry}")
     return "\n".join(lines)
 
 
@@ -373,6 +422,12 @@ def run_pipeline(debug_mode=False, skip_api=False, skip_processing=False,
                 raise
     else:
         logger.info("⏭️ Skipping Substack Daily Pipeline step")  # type: ignore
+
+    # Posture check: Supabase RLS / policy / view-security drift (issue #50).
+    # Read-only and independent of the daily data; runs every pipeline so drift
+    # surfaces on the project's own clock, not via the weekly advisor email.
+    logger.info("🔒 Step 7: Checking Supabase RLS / policy drift")  # type: ignore
+    check_policy_drift_coverage(failures)
 
     # Notify only on failure: one consolidated alert + a non-zero exit signal.
     if failures.any():


### PR DESCRIPTION
## Summary

Adds a local, on-clock detector for Supabase RLS / policy drift so a public table or view created without protection is caught on the daily reporting run instead of waiting for Supabase's weekly security-advisor email.

- **New read-only `--check` mode** on `reporting/process/supabase_policy_script.py`: for every public table it asserts RLS is enabled **and** all four `anon_*_all` policies exist (reusing `check_table_policies`); for every public view it asserts `security_invoker = on` (new `check_view_security_invoker` reading `pg_class.reloptions`). Exits `0` clean, non-zero with an emoji-prefixed per-object summary naming what drifted. No changes are made.
- **Wired into `reporting_pipeline.py` as Step 7** — a read-only posture check that runs every pipeline. Drift is folded into the pipeline's existing consolidated failure alert and makes the run exit non-zero (new `policy_drift` bucket on `PipelineFailures`). DB errors degrade gracefully, mirroring the existing coverage checks — the run is never crashed by the posture check.
- **Accurate alert header** — the consolidated alert now reads "finished with failures" rather than "dropped data", since a policy-drift-only failure isn't a data drop.
- **README** documents the check and the human remediation runbook. Remediation stays a deliberate human action (no auto-remediation), so an unintended schema change can't be silently papered over.

## Validation

Run against the live cloud schema (34 tables, 117 views):

- ✅ **`--check` in the current post-#49 state → exit 0** ("all conform").
- ✅ **Drift (table):** created a public table with no RLS → the real command exited **1** and named the table plus exactly what was missing (`RLS disabled; missing policies: anon_select_all, …`); table dropped, schema reverted.
- ✅ **Drift (view):** created a public view with `security_invoker` unset → flagged as `security_invoker off`; view dropped; re-check confirmed the schema clean again.
- ✅ **Pipeline wiring:** `check_policy_drift_coverage` against the clean DB records nothing (`any()` stays `False`, logs ✅); `_build_alert_message` renders the drift section and `any()` returns `True` when drift is present.
- ✅ `py_compile` clean on both changed files.

No repo CI (`.github/workflows/` absent) and no tray for this project. No unit/e2e suite covers the reporting pipeline (only the unrelated doc-capture test exists), so validation is the behavioural evidence above.

Closes #50