### PR TITLE
fix: suppress orphaned native file-chooser dialog on LinkedIn photo/video upload

### DIFF
--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -61,6 +61,8 @@ from planning.linkedin.linkedin_carousel_pdf import (  # noqa: E402
     locate_pdf,
 )
 from planning.linkedin.linkedin_composer import (  # noqa: E402
+    FEED_ENTRY_CLICK_TIMEOUT_MS,
+    FEED_ENTRY_EFFECT_TIMEOUT_MS,
     click_feed_entry,
     fill_caption_with_mentions,
     wait_for_upload_complete,
@@ -415,7 +417,22 @@ def _click_add_photo(page: Page) -> None:
     # swallowed, so `_upload_photo`'s `input[type="file"]` wait times out with
     # no composer ever having opened (issue #150). `click_feed_entry` retries
     # in that case instead of returning a false success.
-    click_feed_entry(page, PHOTO_TEXT_RE, "Photo", expect_selector='input[type="file"]')
+    #
+    # LinkedIn's 'Photo' click fires a native <input type="file"> click under
+    # the hood. Without an active file-chooser listener, Playwright doesn't
+    # intercept that at the CDP level, so Chrome renders the real OS "Open"
+    # dialog on screen. `_upload_photo` below sets the file directly on the
+    # hidden input via CDP, which works regardless — so the post still
+    # succeeds — but the orphaned native dialog never gets dismissed and
+    # lingers on the desktop. `expect_file_chooser` suppresses it before it
+    # can render, mirroring the guard `_share_document_choose_file` already
+    # uses for the carousel/PDF route. A timeout here is non-fatal: it just
+    # means LinkedIn didn't trigger a native chooser this time.
+    try:
+        with page.expect_file_chooser(timeout=FEED_ENTRY_CLICK_TIMEOUT_MS + FEED_ENTRY_EFFECT_TIMEOUT_MS):
+            click_feed_entry(page, PHOTO_TEXT_RE, "Photo", expect_selector='input[type="file"]')
+    except PWTimeoutError:
+        logger.debug("No native file chooser observed for the 'Photo' click.")
 
 
 def _upload_photo(page: Page, image_path: Path) -> None:

--- a/planning/videos/videos_linkedin.py
+++ b/planning/videos/videos_linkedin.py
@@ -22,6 +22,8 @@ from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from planning.linkedin.linkedin_composer import (  # noqa: E402
+    FEED_ENTRY_CLICK_TIMEOUT_MS,
+    FEED_ENTRY_EFFECT_TIMEOUT_MS,
     click_feed_entry,
     fill_caption_with_mentions,
     wait_for_upload_complete,
@@ -77,8 +79,21 @@ def _click_video_button(page: Page) -> None:
     cold-start race on the first feed action of a freshly-navigated session
     (issue #27) and the share-box rehydration swap; a warm affordance still
     returns on the first attempt in ~1 s.
+
+    Also mirrors ``_click_add_photo``'s ``expect_file_chooser`` guard: this
+    click can fire a native ``<input type="file">`` click under the hood, and
+    without an active listener Playwright doesn't intercept it at the CDP
+    level, so Chrome renders the real OS "Open" dialog and it's left
+    dangling on screen (``_upload_video`` below sets the file directly on the
+    hidden input via CDP regardless, so the post still succeeds). A timeout
+    here is non-fatal — it just means this click didn't trigger a native
+    chooser this time.
     """
-    click_feed_entry(page, VIDEO_TEXT_RE, "Video")
+    try:
+        with page.expect_file_chooser(timeout=FEED_ENTRY_CLICK_TIMEOUT_MS + FEED_ENTRY_EFFECT_TIMEOUT_MS):
+            click_feed_entry(page, VIDEO_TEXT_RE, "Video")
+    except PWTimeoutError:
+        logger.debug("No native file chooser observed for the 'Video' click.")
 
 
 def _upload_video(page: Page, video_path: Path) -> None:


### PR DESCRIPTION
## Summary
- LinkedIn's 'Photo' and 'Video' feed clicks fire a native `<input type="file">` click under the hood; with no active file-chooser listener, Playwright doesn't intercept it, so Chrome renders the real OS "Open" dialog and leaves it dangling on screen even though `set_input_files()` sets the media via CDP regardless and the post still succeeds.
- Wraps both clicks (`_click_add_photo` in `schedule_linkedin_posts.py`, `_click_video_button` in `videos_linkedin.py`) in `page.expect_file_chooser()`, mirroring the guard the carousel/PDF path already had. Timeout is non-fatal since the upload still happens via the direct CDP call either way.

## Test plan
- [x] `python -m planning.linkedin.schedule_linkedin_posts --all-wip --dry-run --debug` — ILL (photo) route reached the schedule dialog cleanly, no native dialog appeared (screenshot: `results/linkedin/20260724-dryrun.png`)
- [x] `python -m planning.videos.schedule_videos_posts --all-wip --dry-run --debug --skip-ig --skip-tw --skip-th` — LinkedIn video route reached the schedule dialog cleanly, no native dialog appeared (screenshot: `results/videos/20260721-li-dryrun.png`)

Closes #164