### PR TITLE
fix: suppress console window on 7 subprocess spawn sites

### DIFF
--- a/app/autoheal_console.py
+++ b/app/autoheal_console.py
@@ -152,6 +152,7 @@ def run(skill_cmd: str, log_path: Path, model: str, claude_exe: str,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
+                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
         except OSError as exc:
             _emit(fh, f"[autoheal spawn error] {exc} — is the `claude` CLI on PATH?")

--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -106,8 +106,9 @@ def start_pipeline(name: str, cmd: list[str], *, cwd: Optional[Path] = None) -> 
 
     creationflags = 0
     if sys.platform == "win32":
-        # CREATE_NEW_PROCESS_GROUP so we can send CTRL_BREAK_EVENT for graceful stop.
-        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+        # CREATE_NEW_PROCESS_GROUP so we can send CTRL_BREAK_EVENT for graceful stop;
+        # CREATE_NO_WINDOW so the console-less Streamlit host doesn't flash a window.
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
 
     proc = subprocess.Popen(
         cmd,

--- a/config/chrome_profile_lock.py
+++ b/config/chrome_profile_lock.py
@@ -89,6 +89,7 @@ def pids_holding_profile(user_data_dir: Path) -> list[int]:
         proc = subprocess.run(
             [powershell, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
             capture_output=True, text=True, timeout=20,
+            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
     except (OSError, subprocess.SubprocessError) as err:
         logging.getLogger("chrome_profile_lock").warning(

--- a/newsletter/bootstrap_chrome.py
+++ b/newsletter/bootstrap_chrome.py
@@ -80,6 +80,7 @@ def _kill_pids(pids: list[int]) -> None:
         subprocess.run(
             ["taskkill", "/PID", str(pid), "/F", "/T"],
             capture_output=True, text=True,
+            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
 
 

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -45,6 +45,13 @@ from reporting.notion.editorial import (  # noqa: E402
 
 logger = logging.getLogger("videos_session")
 
+
+def _no_window_flags() -> int:
+    """creationflags for a short-lived helper spawn (attrib/ffprobe/ffmpeg) so the
+    console-less Streamlit host doesn't flash a window per call (fleet convention)."""
+    return subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
+
+
 # Per-platform role suffixes on the editorial DB. The roles are wired in
 # config under ``videos.editorial_columns`` as e.g. ``clip_rel_li`` and
 # ``post_url_li``.
@@ -223,6 +230,7 @@ def _trigger_download(path: Path) -> None:
             subprocess.run(
                 ["attrib", "+P", "-U", str(path)],
                 check=True, capture_output=True, timeout=30,
+                creationflags=_no_window_flags(),
             )
         except (OSError, subprocess.SubprocessError) as err:
             logger.debug("attrib pin failed (%s) — relying on read-through.", err)
@@ -321,6 +329,7 @@ def _probe_video(path: Path) -> Optional[dict]:
             [ffprobe, "-v", "error", "-show_format", "-show_streams",
              "-of", "json", str(path)],
             check=True, capture_output=True, timeout=120,
+            creationflags=_no_window_flags(),
         )
         data = json.loads(proc.stdout or b"{}")
     except (OSError, subprocess.SubprocessError, ValueError) as err:
@@ -392,7 +401,7 @@ def _run_ffmpeg_transcode(src: Path, dst: Path, tcfg: dict) -> bool:
     ]
     logger.info("🎞️ Transcoding %s → platform-safe (%d Mbps cap)…", src.name, target)
     try:
-        subprocess.run(cmd, check=True, capture_output=True, timeout=1800)
+        subprocess.run(cmd, check=True, capture_output=True, timeout=1800, creationflags=_no_window_flags())
     except (OSError, subprocess.SubprocessError) as err:
         stderr = getattr(err, "stderr", b"") or b""
         logger.error(

--- a/tests/test_subprocess_no_window.py
+++ b/tests/test_subprocess_no_window.py
@@ -1,0 +1,81 @@
+"""Regression test for the fleet-wide CREATE_NO_WINDOW convention (issue #166).
+
+Any ``subprocess.Popen``/``.run``/``.call``/``.check_output``/``.check_call`` (or
+``asyncio.create_subprocess_exec``) call that launches an external executable must
+pass a ``creationflags=`` keyword on Windows, or a console-less parent (Streamlit
+run under the app-launcher, a scheduled task, a detached wrapper) flashes a new
+console window on screen for every spawn. See ``fleet-config``'s global
+``CLAUDE.md`` ("Subprocess spawns must suppress the console window (Windows)").
+
+This statically scans every tracked ``.py`` file (via ``git ls-files``, mirroring
+``design_lint``'s convention) for the relevant call shapes and asserts each one
+carries a ``creationflags`` keyword argument — catching a future call site that
+forgets the flag, not just re-checking today's fixed sites.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_SUBPROCESS_SPAWN_ATTRS = {"Popen", "run", "call", "check_output", "check_call"}
+_ASYNCIO_SPAWN_ATTRS = {"create_subprocess_exec", "create_subprocess_shell"}
+
+
+def _tracked_python_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+        creationflags=subprocess.CREATE_NO_WINDOW if hasattr(subprocess, "CREATE_NO_WINDOW") else 0,
+    )
+    return [REPO_ROOT / line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _spawn_calls_missing_creationflags(path: Path) -> list[str]:
+    """Return "line:call" strings for spawn calls in ``path`` with no creationflags kwarg."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    missing: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        attr = node.func.attr
+        base = node.func.value
+        base_name = base.id if isinstance(base, ast.Name) else None
+
+        is_subprocess_spawn = base_name == "subprocess" and attr in _SUBPROCESS_SPAWN_ATTRS
+        is_asyncio_spawn = base_name == "asyncio" and attr in _ASYNCIO_SPAWN_ATTRS
+        if not (is_subprocess_spawn or is_asyncio_spawn):
+            continue
+
+        has_creationflags = any(kw.arg == "creationflags" for kw in node.keywords)
+        # A bare **kwargs forward could legitimately carry it — don't flag those.
+        has_kwargs_forward = any(kw.arg is None for kw in node.keywords)
+        if not has_creationflags and not has_kwargs_forward:
+            missing.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno} {base_name}.{attr}(...)")
+    return missing
+
+
+class NoWindowConventionTests(unittest.TestCase):
+    def test_every_subprocess_spawn_has_creationflags(self):
+        offenders: list[str] = []
+        for path in _tracked_python_files():
+            offenders.extend(_spawn_calls_missing_creationflags(path))
+        self.assertEqual(
+            offenders, [],
+            "subprocess/asyncio spawn call(s) missing creationflags=... "
+            "(CREATE_NO_WINDOW convention, fleet-config#399):\n  " + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fleet-wide sweep (origin: `fleet-config#399`) fixing every subprocess spawn site in this repo that was missing `creationflags=CREATE_NO_WINDOW` on Windows — a console-less parent (the Streamlit control panel run via the app-launcher, a scheduled task, a detached wrapper) otherwise flashes a new console window per spawn.
- 7 sites across 5 files fixed: `app/process_runner.py` (pipeline launcher — combined with the existing `CREATE_NEW_PROCESS_GROUP`), `app/autoheal_console.py` (`claude -p` spawn), `config/chrome_profile_lock.py` (PowerShell PID probe), `newsletter/bootstrap_chrome.py` (`taskkill`), and `planning/videos/videos_session.py` (`attrib`/`ffprobe`/`ffmpeg` — factored into a shared `_no_window_flags()` helper since it had 3 sites).
- Two call sites were deliberately left as-is: `process_runner.py`'s `start_skill_console` (intentionally visible `CREATE_NEW_CONSOLE` window) and `bootstrap_chrome.py`'s Chrome launch (`DETACHED_PROCESS`, mutually exclusive with `CREATE_NO_WINDOW`, and a GUI app that's meant to show a window). `newsletter/build_newsletter.py`'s `clip` call already had the flag.
- Added `tests/test_subprocess_no_window.py`, a static AST scan over every tracked `.py` file asserting every `subprocess`/`asyncio` spawn call carries `creationflags=`, so a future call site can't silently regress.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 15/15 tests pass (14 pre-existing + the new regression test).
- [x] `& .\.venv\Scripts\python.exe -m py_compile` on every touched file — clean.
- [x] Confirmed no pre-existing/unrelated test failures on `main` before starting (ran the same gate on the unmodified branch tip first).

Closes #166
