### PR TITLE
fix: flatten identifier construction and redundant error wrappers

### DIFF
--- a/reporting/process/supabase_policy_script.py
+++ b/reporting/process/supabase_policy_script.py
@@ -274,35 +274,36 @@ def apply_table_policies(connection, table_name, force=False):
             logger.debug(f"🔒 Table {table_name} already has all required policies")
             return True
         
+        table_ident = sql.Identifier('public', table_name)
+
         # Drop existing policies if force=True or if some policies exist
         if force or policy_status['existing_policies']:
-            drop_policies_sql = f"""
-            DROP POLICY IF EXISTS anon_select_all ON public."{table_name}";
-            DROP POLICY IF EXISTS anon_insert_all ON public."{table_name}";
-            DROP POLICY IF EXISTS anon_update_all ON public."{table_name}";
-            DROP POLICY IF EXISTS anon_delete_all ON public."{table_name}";
-            """
-            
+            drop_policies_sql = [
+                sql.SQL('DROP POLICY IF EXISTS anon_select_all ON {};').format(table_ident),
+                sql.SQL('DROP POLICY IF EXISTS anon_insert_all ON {};').format(table_ident),
+                sql.SQL('DROP POLICY IF EXISTS anon_update_all ON {};').format(table_ident),
+                sql.SQL('DROP POLICY IF EXISTS anon_delete_all ON {};').format(table_ident),
+            ]
+
             with connection.cursor() as cursor:
-                cursor.execute(drop_policies_sql)
-            
+                for statement in drop_policies_sql:
+                    cursor.execute(statement)
+
             logger.debug(f"🗑️  Dropped existing policies from table {table_name}")
-        
+
         # Enable RLS and create new policies
-        policies_sql = f"""
-        -- Enable RLS on the table
-        ALTER TABLE public."{table_name}" ENABLE ROW LEVEL SECURITY;
-        
-        -- Create policies for anon access
-        CREATE POLICY anon_select_all ON public."{table_name}" FOR SELECT TO anon USING (true);
-        CREATE POLICY anon_insert_all ON public."{table_name}" FOR INSERT TO anon WITH CHECK (true);
-        CREATE POLICY anon_update_all ON public."{table_name}" FOR UPDATE TO anon USING (true) WITH CHECK (true);
-        CREATE POLICY anon_delete_all ON public."{table_name}" FOR DELETE TO anon USING (true);
-        """
-        
+        policies_sql = [
+            sql.SQL('ALTER TABLE {} ENABLE ROW LEVEL SECURITY;').format(table_ident),
+            sql.SQL('CREATE POLICY anon_select_all ON {} FOR SELECT TO anon USING (true);').format(table_ident),
+            sql.SQL('CREATE POLICY anon_insert_all ON {} FOR INSERT TO anon WITH CHECK (true);').format(table_ident),
+            sql.SQL('CREATE POLICY anon_update_all ON {} FOR UPDATE TO anon USING (true) WITH CHECK (true);').format(table_ident),
+            sql.SQL('CREATE POLICY anon_delete_all ON {} FOR DELETE TO anon USING (true);').format(table_ident),
+        ]
+
         with connection.cursor() as cursor:
-            cursor.execute(policies_sql)
-        
+            for statement in policies_sql:
+                cursor.execute(statement)
+
         logger.info(f"🔒 Applied RLS policies to table {table_name}")
         return True
         

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -398,28 +398,18 @@ def run_pipeline(debug_mode=False, skip_api=False, skip_processing=False,
     if not skip_notion:
         logger.info("📘 Step 5: Running Notion Update")  # type: ignore
         configure_notion_logger(debug_mode)
-        try:
-            logger.info(f"🗓️  Using date for Notion update: {processing_date}")  # type: ignore
-            notion_extra_args = [processing_date]
-            if auto_confirm:
-                notion_extra_args.append('--yes')
-            run_module(run_notion_update, "Notion Update", debug_mode, notion_extra_args, failures=failures)
-        except Exception as e:
-            logger.error(f"❌ Error in Notion Update: {e}")  # type: ignore
-            if debug_mode:
-                raise
+        logger.info(f"🗓️  Using date for Notion update: {processing_date}")  # type: ignore
+        notion_extra_args = [processing_date]
+        if auto_confirm:
+            notion_extra_args.append('--yes')
+        run_module(run_notion_update, "Notion Update", debug_mode, notion_extra_args, failures=failures)
     else:
         logger.info("⏭️ Skipping Notion Update step")  # type: ignore
 
     # Step 6: Publish Substack Note (follower scrape now happens in step 1 via reporting/scrape_client/substack.py)
     if not skip_substack:
         logger.info("📰 Step 6: Running Substack Daily Pipeline")  # type: ignore
-        try:
-            run_module(run_substack_daily_pipeline, "Substack Daily Pipeline", debug_mode, extra_args=date_args, failures=failures)
-        except Exception as e:
-            logger.error(f"❌ Error in Substack Daily Pipeline: {e}")  # type: ignore
-            if debug_mode:
-                raise
+        run_module(run_substack_daily_pipeline, "Substack Daily Pipeline", debug_mode, extra_args=date_args, failures=failures)
     else:
         logger.info("⏭️ Skipping Substack Daily Pipeline step")  # type: ignore
 


### PR DESCRIPTION
## Summary
- `apply_table_policies()` in `reporting/process/supabase_policy_script.py` now builds DDL identifiers via `psycopg2.sql.Identifier`, matching the sibling `apply_security_invoker_to_all_views()` pattern instead of hand-interpolating table names into raw f-string SQL (each multi-statement block is now issued per-statement, as required by the `sql.SQL` composition).
- `reporting_pipeline.py` drops the two outer `try/except` wrappers around `run_module()` in the Notion and Substack steps — `run_module()` already records failures and only re-raises in debug mode, so the wrappers were unreachable and only double-logged.

## Test plan
- [x] `python -m py_compile reporting/process/supabase_policy_script.py reporting_pipeline.py`
- [x] `python -m unittest discover tests -v` — 15 tests, all pass

Closes #169