### PR TITLE
fix: remove stale dead code flagged by audit

### DIFF
--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -391,28 +391,6 @@ def _expand_all_comments(page: Page, *, max_clicks: int = 30, settle_ms: int = 1
     return top + replies
 
 
-def _parse_relative_time(text: str, now: Optional[datetime] = None) -> Optional[str]:
-    """LinkedIn shows '2h', '5m', '3d', '1w', '2mo', '1y'. Best-effort absolute ISO timestamp."""
-    if not text:
-        return None
-    now = now or datetime.now(timezone.utc)
-    m = re.match(r"(\d+)\s*(s|m|h|d|w|mo|y)\b", text.strip().lower())
-    if not m:
-        return None
-    n = int(m.group(1))
-    unit = m.group(2)
-    delta = {
-        "s": timedelta(seconds=n),
-        "m": timedelta(minutes=n),
-        "h": timedelta(hours=n),
-        "d": timedelta(days=n),
-        "w": timedelta(weeks=n),
-        "mo": timedelta(days=30 * n),
-        "y": timedelta(days=365 * n),
-    }[unit]
-    return (now - delta).isoformat()
-
-
 _URN_RE = re.compile(r"urn:li:comment:\(.+?\)")
 
 
@@ -428,16 +406,6 @@ def _extract_comment_id(component_key: Optional[str], fallback_seed: str) -> str
             return m.group(0)
     import hashlib
     return "fallback:" + hashlib.sha1(fallback_seed.encode("utf-8", errors="replace")).hexdigest()[:24]
-
-
-def _canon_account_url(href: str) -> str:
-    if not href:
-        return ""
-    h = href.split("?", 1)[0].rstrip("/")
-    # Make absolute if relative
-    if h.startswith("/"):
-        h = "https://www.linkedin.com" + h
-    return h
 
 
 def _my_handle_from_config() -> str:

--- a/reporting/process/supabase_policy_script.py
+++ b/reporting/process/supabase_policy_script.py
@@ -11,10 +11,8 @@ import logging
 from pathlib import Path
 import sys
 import psycopg2
-import psycopg2.extras
 from psycopg2 import sql
 import argparse
-from typing import Dict, List, Any, Optional, Tuple, Set
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))


### PR DESCRIPTION
## Summary
- `engagement/linkedin/scrape_comments.py`: removed `_parse_relative_time()` (superseded by the in-page JS `parseRelative` extractor) and `_canon_account_url()` (superseded by the JS extractor's own href canonicalization) — both were dead, uncalled Python helpers left behind after relative-time parsing and URL canonicalization moved into the single `page.evaluate()` extractor.
- `reporting/process/supabase_policy_script.py`: dropped the unused `import psycopg2.extras` and `from typing import Dict, List, Any, Optional, Tuple, Set` — neither was referenced anywhere in the module (the typing names appeared only in docstring prose).

## Test plan
- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 15 tests, all pass

Closes #168