### PR TITLE
docs: fix stale step count and trim README boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,13 +278,16 @@ flowchart LR
     E --> F[reporting.process<br/>profile_aggregator<br/>posts_consolidator]
     F --> G[reporting.notion.notion_update<br/>daily numbers]
     G --> H[planning.substack.daily_pipeline<br/>publish daily Note]
+    H --> I[check_policy_drift_coverage<br/>Supabase RLS / policy posture]
     classDef rapidapi fill:#fff4e6,stroke:#c47f17
     classDef playwright fill:#e6f4ea,stroke:#1e8e3e
 ```
 
 - Idempotent upserts: re-running for the same date is a no-op.
-- All six steps run as one script (`reporting_pipeline.py`) with
-  per-step `--skip-*` flags for partial reruns.
+- All seven steps run as one script (`reporting_pipeline.py`). Steps 1-6 have
+  per-step `--skip-*` flags for partial reruns; step 7 (the Supabase RLS /
+  policy-drift posture check, issue #50) always runs — read-only and
+  independent of the daily data, so it has no `--skip-*` flag.
 - Each of the 10 `<platform>_<data_type>` endpoints in `config/config.json`
   carries a `"source"` key picking which collector runs — `"rapidapi"`
   (paid HTTP fetcher) or `"playwright"` (free logged-in-Chrome scraper).
@@ -441,256 +444,13 @@ Only after a sustained period (≥ 1 week) of clean Playwright runs:
 .\launch_planning.bat
 ```
 
-## 📊 Data Schema & Structure
+## 📊 Data Schema
 
-### Database Architecture
-
-The system uses PostgreSQL (via Supabase) with a normalized schema that separates raw data collection from aggregated analytics. All tables use `date` as the primary key for efficient time-series queries.
-
-### Raw Data Tables
-
-The system creates individual tables for each platform and data type to store raw API responses:
-
-#### Profile Tables
-- **`linkedin_profile`**: LinkedIn follower counts and profile data
-- **`instagram_profile`**: Instagram follower counts and profile data
-- **`twitter_profile`**: Twitter/X follower counts and profile data
-- **`threads_profile`**: Threads follower counts and profile data
-- **`substack_profile`**: Substack subscriber counts and profile data
-
-**Common Profile Fields:**
-- `date` (date, PRIMARY KEY): Date of data collection
-- `platform` (text): Platform identifier
-- `data_type` (text): Data type identifier ('profile')
-- `num_followers` (integer): Number of followers/subscribers
-
-#### Posts Tables
-- **`linkedin_posts`**: LinkedIn post performance metrics
-- **`instagram_posts`**: Instagram post performance metrics
-- **`twitter_posts`**: Twitter/X post performance metrics
-- **`threads_posts`**: Threads post performance metrics
-- **`substack_posts`**: Substack post performance metrics
-
-**Common Posts Fields:**
-- `date` (date, PRIMARY KEY): Date of data collection
-- `platform` (text): Platform identifier
-- `data_type` (text): Data type identifier ('posts')
-- `post_id` (text): Unique post identifier
-- `posted_at` (date): Date when post was published
-- `is_video` (integer): Boolean flag (1 for video, 0 for non-video)
-- `num_likes` (integer): Number of likes/reactions
-- `num_comments` (integer): Number of comments
-- `num_reshares` (integer): Number of reshares/reposts
-
-### Aggregated Tables
-
-#### Profile Summary Table
-**`profile`** - Consolidated daily follower counts across all platforms:
-- `date` (date, PRIMARY KEY): Date of data collection
-- `num_followers_linkedin` (integer): LinkedIn follower count
-- `num_followers_instagram` (integer): Instagram follower count
-- `num_followers_twitter` (integer): Twitter follower count
-- `num_followers_substack` (integer): Substack subscriber count
-- `num_followers_threads` (integer): Threads follower count
-
-#### Posts Summary Table
-**`posts`** - Daily post performance metrics separated by content type:
-- `date` (date, PRIMARY KEY): Date of data collection
-
-**Non-Video Posts (by platform):**
-- `post_id_*_no_video`: Post ID for latest non-video content
-- `posted_at_*_no_video`: Publication date
-- `num_likes_*_no_video`: Engagement metrics
-- `num_comments_*_no_video`: Comment counts
-- `num_reshares_*_no_video`: Share counts
-
-**Video Posts (by platform):**
-- `post_id_*_video`: Post ID for latest video content
-- `posted_at_*_video`: Publication date
-- `num_likes_*_video`: Engagement metrics
-- `num_comments_*_video`: Comment counts
-- `num_reshares_*_video`: Share counts
-
-*(* = linkedin, instagram, twitter, substack, threads)
-
-## 🗄️ Database Architecture & Integration
-
-### Two-Stage Data Pipeline
-
-The system implements a sophisticated two-stage data pipeline designed for scalability and analysis:
-
-#### Stage 1: Raw Data Ingestion
-**Social Media Data:**
-- Platform-specific tables store raw API responses
-- Automatic table creation based on data structure
-- Preserves original data integrity before transformation
-
-**Notion Integration:**
-- Dynamic schema detection from Notion databases
-- Bidirectional sync with change tracking
-- Complex data types stored as JSONB for flexibility
-
-#### Stage 2: Data Consolidation
-- SQL aggregation scripts process raw data into analysis-ready tables
-- Platform-specific data merged into unified views
-- Optimized for time-series analysis and cross-platform comparisons
-
-### Notion Database Integration
-
-#### Common Notion Table Structure
-All Notion-synced tables share standardized columns:
-
-| Column | Data Type | Description |
-| :--- | :--- | :--- |
-| `notion_id` | `text` | Notion page ID (UUID) - **Primary Key** |
-| `created_time` | `timestamp with time zone` | When page was created in Notion |
-| `last_edited_time` | `timestamp with time zone` | When page was last edited |
-| `archived` | `boolean` | Whether page is archived |
-| `notion_data_jsonb` | `jsonb` | Complex data types and unmapped properties |
-
-#### Dynamic Schema Generation
-Tables are automatically created with columns derived from Notion properties:
-- **Property names** → normalized column names (lowercase, underscores)
-- **Data types** automatically mapped from Notion to PostgreSQL
-- **Complex types** (relations, arrays) stored in JSONB column
-
-#### Notion to PostgreSQL Type Mapping
-
-| Notion Property Type | PostgreSQL Data Type |
-| :--- | :--- |
-| Title, Rich Text, URL, Email, Phone | `text` |
-| Number | `bigint` or `double precision` |
-| Select, Status | `text` |
-| Date | `timestamp with time zone` |
-| Checkbox | `boolean` |
-| Formula (various) | Mapped to appropriate types |
-| Multi-Select, Relation, People, Files | `jsonb` |
-
-### Integrated Notion Databases
-
-The system syncs data from **15+ Notion databases** for comprehensive content management:
-
-**Content & Publishing:**
-- `notion_posts` - Social media posts and content
-- `notion_articles` - Blog articles and written content
-- `notion_newsletter` - Newsletter content and campaigns
-
-**Media & Assets:**
-- `notion_clips` - Video/audio clips and media assets
-- `notion_illustrations` - Images and visual content
-- `notion_visual_types` - Media categorization
-
-**Business & Analytics:**
-- `notion_companies` - Company profiles and relationships
-- `notion_connections` - Network and relationship data
-- `notion_interactions` - User engagement and interactions
-
-**Content Strategy:**
-- `notion_editorial` - Editorial calendar and planning
-- `notion_concepts` - Content ideas and brainstorming
-- `notion_books` - Book recommendations and reviews
-- `notion_books_recommendations` - Reading lists and suggestions
-
-**Additional Databases:**
-- `notion_episodes` - Podcast episodes and series
-- `notion_comments` - User comments and feedback
-- `notion_wins_and_features` - Success metrics and feature tracking
-
-### Database Relationships & Constraints
-
-**Social Media Data:**
-- Raw platform tables feed into consolidated tables
-- Foreign key relationships based on `date` field
-- No traditional foreign keys between Notion tables
-
-**Notion Data:**
-- Relationships stored as Notion page ID arrays in JSONB
-- Application-layer joins required for complex queries
-- Preserves Notion's flexible relationship model
-
-**Data Integrity:**
-- Primary keys ensure uniqueness
-- Timestamp tracking for change detection
-- Archive status management for data lifecycle
-
-## 📈 Analytics & Query Examples
-
-### Growth Analysis Queries
-
-**Monthly follower growth by platform:**
-```sql
-SELECT
-    DATE_TRUNC('month', date) as month,
-    platform,
-    AVG(num_followers) as avg_followers,
-    MAX(num_followers) - MIN(num_followers) as growth
-FROM (
-    SELECT date, 'linkedin' as platform, num_followers_linkedin as num_followers FROM profile
-    UNION ALL
-    SELECT date, 'instagram' as platform, num_followers_instagram as num_followers FROM profile
-    UNION ALL
-    SELECT date, 'twitter' as platform, num_followers_twitter as num_followers FROM profile
-) combined
-GROUP BY month, platform
-ORDER BY month, platform;
-```
-
-### Engagement Analysis
-
-**Average engagement by content type and platform:**
-```sql
-SELECT
-    'linkedin' as platform,
-    'video' as content_type,
-    AVG(num_likes_linkedin_video) as avg_likes,
-    AVG(num_comments_linkedin_video) as avg_comments,
-    AVG(num_reshares_linkedin_video) as avg_reshares
-FROM posts
-WHERE num_likes_linkedin_video IS NOT NULL;
-```
-
-### Performance Prediction Features
-
-**Features for ML model training:**
-```sql
-SELECT
-    p.date,
-    -- Historical performance (7-day average)
-    AVG(ps.num_likes_linkedin_no_video) OVER (
-        ORDER BY p.date ROWS BETWEEN 7 PRECEDING AND 1 PRECEDING
-    ) as avg_likes_7d,
-    -- Growth momentum
-    p.num_followers_linkedin - LAG(p.num_followers_linkedin, 7) OVER (ORDER BY p.date) as follower_growth_7d,
-    -- Engagement rate
-    CASE
-        WHEN p.num_followers_linkedin > 0
-        THEN (ps.num_likes_linkedin_no_video + ps.num_comments_linkedin_no_video) / p.num_followers_linkedin
-        ELSE NULL
-    END as engagement_rate
-FROM profile p
-LEFT JOIN posts ps ON p.date = ps.date
-WHERE ps.num_likes_linkedin_no_video IS NOT NULL;
-```
-
-### Cross-Platform Analysis
-
-**Total audience reach across platforms:**
-```sql
-SELECT
-    date,
-    num_followers_linkedin + num_followers_instagram + num_followers_twitter +
-    num_followers_substack + num_followers_threads as total_followers,
-    -- Engagement rates
-    CASE WHEN num_followers_linkedin > 0
-         THEN (num_likes_linkedin_no_video + num_comments_linkedin_no_video) / num_followers_linkedin
-         ELSE 0 END as linkedin_engagement_rate,
-    CASE WHEN num_followers_instagram > 0
-         THEN (num_likes_instagram_no_video + num_comments_instagram_no_video) / num_followers_instagram
-         ELSE 0 END as instagram_engagement_rate
-FROM profile p
-LEFT JOIN posts ps ON p.date = ps.date
-ORDER BY date DESC;
-```
+The Supabase (PostgreSQL) schema — raw per-platform tables, the consolidated
+daily `profile` / `posts` aggregates, and the Notion sync tables (columns,
+type mapping, the 15+ synced databases) — is documented in
+[`docs/data-schema.md`](docs/data-schema.md) rather than here, so this
+orientation map stays short. See that file for column-level detail.
 
 ## 🔧 Advanced Configuration
 
@@ -721,7 +481,6 @@ Override default configuration files:
 
 1. **API Rate Limits**
    - Use `--skip-existing` flag to avoid re-fetching data
-   - Implement delays between API calls
 
 2. **Database Connection Errors**
    - Verify credentials in `.env` file
@@ -756,7 +515,6 @@ Override default configuration files:
 
 ## 📈 Performance Optimization
 
-- **Batch Processing**: Data is processed in batches to handle large datasets
 - **Incremental Sync**: Only new/modified data is synced — `reporting_pipeline.py` skips re-fetch when today's JSON file already exists (`check_file_exists_for_date`), acting as an idempotent re-run guard
 
 ## 🔐 Security Best Practices
@@ -772,7 +530,6 @@ Override default configuration files:
    - Reporting connects via direct psycopg2 (port 5432), not the REST API — no Supabase API key is involved. Engagement uses the Supabase client library at table-level (`/rest/v1/<table>`) with `service_role_key` preferred, falling back to the anon key; the bare `/rest/v1/` root endpoint is never called.
 
 3. **Implement access controls**
-   - Use read-only database users where possible
    - Limit API key permissions
    - Enable Supabase Row Level Security (RLS)
 
@@ -810,12 +567,6 @@ Idempotent by input hash — a rerun with unchanged `app/tab_*.py` sources
 captures nothing and leaves the README untouched. Hard safety invariant: a
 manifest entry without `mask` selectors is refused (skipped with a warning),
 never captured raw. Tests: `& .\.venv\Scripts\python.exe -m unittest discover tests -v`.
-
-### Extending Functionality
-
-- Create custom processors in the `process` module
-- Add new Notion property type handlers
-- Implement additional aggregation queries
 
 ## 📝 License and contact
 

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -1,0 +1,153 @@
+# Data schema
+
+The Supabase (PostgreSQL) schema behind the reporting pipeline: raw per-platform
+tables, the consolidated daily aggregates, and the Notion sync tables. Moved out
+of `README.md`'s orientation map into its own reference file (issue #170) — the
+README links here rather than carrying the column-level detail.
+
+## Database architecture
+
+The system uses PostgreSQL (via Supabase) with a normalized schema that separates raw data collection from aggregated analytics. All tables use `date` as the primary key for efficient time-series queries.
+
+## Raw data tables
+
+The system creates individual tables for each platform and data type to store raw API responses:
+
+### Profile tables
+- **`linkedin_profile`**: LinkedIn follower counts and profile data
+- **`instagram_profile`**: Instagram follower counts and profile data
+- **`twitter_profile`**: Twitter/X follower counts and profile data
+- **`threads_profile`**: Threads follower counts and profile data
+- **`substack_profile`**: Substack subscriber counts and profile data
+
+**Common profile fields:**
+- `date` (date, PRIMARY KEY): Date of data collection
+- `platform` (text): Platform identifier
+- `data_type` (text): Data type identifier ('profile')
+- `num_followers` (integer): Number of followers/subscribers
+
+### Posts tables
+- **`linkedin_posts`**: LinkedIn post performance metrics
+- **`instagram_posts`**: Instagram post performance metrics
+- **`twitter_posts`**: Twitter/X post performance metrics
+- **`threads_posts`**: Threads post performance metrics
+- **`substack_posts`**: Substack post performance metrics
+
+**Common posts fields:**
+- `date` (date, PRIMARY KEY): Date of data collection
+- `platform` (text): Platform identifier
+- `data_type` (text): Data type identifier ('posts')
+- `post_id` (text): Unique post identifier
+- `posted_at` (date): Date when post was published
+- `is_video` (integer): Boolean flag (1 for video, 0 for non-video)
+- `num_likes` (integer): Number of likes/reactions
+- `num_comments` (integer): Number of comments
+- `num_reshares` (integer): Number of reshares/reposts
+
+## Aggregated tables
+
+### Profile summary table
+**`profile`** - Consolidated daily follower counts across all platforms:
+- `date` (date, PRIMARY KEY): Date of data collection
+- `num_followers_linkedin` (integer): LinkedIn follower count
+- `num_followers_instagram` (integer): Instagram follower count
+- `num_followers_twitter` (integer): Twitter follower count
+- `num_followers_substack` (integer): Substack subscriber count
+- `num_followers_threads` (integer): Threads follower count
+
+### Posts summary table
+**`posts`** - Daily post performance metrics separated by content type:
+- `date` (date, PRIMARY KEY): Date of data collection
+
+**Non-video posts (by platform):**
+- `post_id_*_no_video`: Post ID for latest non-video content
+- `posted_at_*_no_video`: Publication date
+- `num_likes_*_no_video`: Engagement metrics
+- `num_comments_*_no_video`: Comment counts
+- `num_reshares_*_no_video`: Share counts
+
+**Video posts (by platform):**
+- `post_id_*_video`: Post ID for latest video content
+- `posted_at_*_video`: Publication date
+- `num_likes_*_video`: Engagement metrics
+- `num_comments_*_video`: Comment counts
+- `num_reshares_*_video`: Share counts
+
+*(* = linkedin, instagram, twitter, substack, threads)
+
+## Notion database integration
+
+### Two-stage data pipeline
+- **Stage 1 (raw ingestion):** platform-specific tables store raw API responses; Notion sync uses dynamic schema detection with bidirectional sync and change tracking; complex data types are stored as JSONB.
+- **Stage 2 (consolidation):** SQL aggregation scripts merge platform-specific raw data into the unified `profile` / `posts` tables above, optimized for time-series analysis and cross-platform comparisons.
+
+### Common Notion table structure
+All Notion-synced tables share standardized columns:
+
+| Column | Data Type | Description |
+| :--- | :--- | :--- |
+| `notion_id` | `text` | Notion page ID (UUID) - **Primary Key** |
+| `created_time` | `timestamp with time zone` | When page was created in Notion |
+| `last_edited_time` | `timestamp with time zone` | When page was last edited |
+| `archived` | `boolean` | Whether page is archived |
+| `notion_data_jsonb` | `jsonb` | Complex data types and unmapped properties |
+
+### Dynamic schema generation
+Tables are automatically created with columns derived from Notion properties:
+- **Property names** → normalized column names (lowercase, underscores)
+- **Data types** automatically mapped from Notion to PostgreSQL
+- **Complex types** (relations, arrays) stored in JSONB column
+
+### Notion to PostgreSQL type mapping
+
+| Notion Property Type | PostgreSQL Data Type |
+| :--- | :--- |
+| Title, Rich Text, URL, Email, Phone | `text` |
+| Number | `bigint` or `double precision` |
+| Select, Status | `text` |
+| Date | `timestamp with time zone` |
+| Checkbox | `boolean` |
+| Formula (various) | Mapped to appropriate types |
+| Multi-Select, Relation, People, Files | `jsonb` |
+
+### Integrated Notion databases
+
+The system syncs data from **15+ Notion databases** for comprehensive content management:
+
+**Content & Publishing:**
+- `notion_posts` - Social media posts and content
+- `notion_articles` - Blog articles and written content
+- `notion_newsletter` - Newsletter content and campaigns
+
+**Media & Assets:**
+- `notion_clips` - Video/audio clips and media assets
+- `notion_illustrations` - Images and visual content
+- `notion_visual_types` - Media categorization
+
+**Business & Analytics:**
+- `notion_companies` - Company profiles and relationships
+- `notion_connections` - Network and relationship data
+- `notion_interactions` - User engagement and interactions
+
+**Content Strategy:**
+- `notion_editorial` - Editorial calendar and planning
+- `notion_concepts` - Content ideas and brainstorming
+- `notion_books` - Book recommendations and reviews
+- `notion_books_recommendations` - Reading lists and suggestions
+
+**Additional databases:**
+- `notion_episodes` - Podcast episodes and series
+- `notion_comments` - User comments and feedback
+- `notion_wins_and_features` - Success metrics and feature tracking
+
+### Database relationships & constraints
+
+**Social media data:**
+- Raw platform tables feed into consolidated tables
+- Foreign key relationships based on `date` field
+- No traditional foreign keys between Notion tables
+
+**Notion data:**
+- Relationships stored as Notion page ID arrays in JSONB
+- Application-layer joins required for complex queries
+- Preserves Notion's flexible relationship model


### PR DESCRIPTION
## Summary
- README claimed six pipeline steps and omitted step 7 (the Supabase RLS / policy-drift posture check, issue #50); updated the count and overview mermaid to include it
- Moved the generic Data Schema / Database Architecture / speculative SQL examples out of the README orientation map into `docs/data-schema.md`, trimming non-repo-specific filler along the way

## Test plan
- [x] Docs-only change; reviewed rendered README and docs/data-schema.md for accuracy against current pipeline code

Closes #170