### PR TITLE
fix: propagate pipeline exit codes from the launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ open at the end so you can inspect the output.
 .\launch_planning.bat live auto
 ```
 
+Every launcher **propagates its pipeline's exit code**, so a scheduler records a
+crashed run as failed rather than green. A missing or broken `.venv` is a hard
+stop with a non-zero exit — never a silent fallback to a system Python, which
+would run against unpinned dependencies. `tests/test_launcher_exit_codes.py`
+enforces both, plus the CRLF line endings `cmd` needs to execute a `.bat`
+correctly.
+
 ## 🖼️ Control panel tour
 
 Generated, masked screenshots of each control-panel section — captured by the

--- a/launch_app.bat
+++ b/launch_app.bat
@@ -1,4 +1,27 @@
 @echo off
+REM Launcher for the Streamlit control panel (run_app.py).
 cd /d "%~dp0"
-".venv\Scripts\python.exe" run_app.py
+
+REM Fail closed: reaching :END without a completed run (missing venv) exits
+REM non-zero. Only the Python call overwrites this with its own exit code.
+set RC=1
+set VENV_DIR=.\.venv
+
+REM A missing venv is a hard stop, never a fallback to system Python: the
+REM system interpreter has none of this project's pinned dependencies.
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+    echo [ERROR] Virtual environment not found at %VENV_DIR%\Scripts\python.exe
+    echo [ERROR] Recreate it with: python -m venv .venv ^&^& .venv\Scripts\python.exe -m pip install -r requirements.txt
+    goto END
+)
+
+REM Keep this call at top level, NOT inside an if/else: %ERRORLEVEL% inside a
+REM parenthesised block is expanded at parse time and reads stale.
+"%VENV_DIR%\Scripts\python.exe" run_app.py
+REM Capture on the very next line — any intervening command overwrites it.
+set RC=%ERRORLEVEL%
+
+:END
 pause
+REM Propagate the app's exit code so a failed boot isn't recorded as success.
+exit /b %RC%

--- a/launch_autoheal.bat
+++ b/launch_autoheal.bat
@@ -11,6 +11,9 @@ REM   launch_autoheal.bat twitter          - dry-run, twitter only
 REM   launch_autoheal.bat twitter live     - LIVE, twitter only
 
 setlocal EnableDelayedExpansion
+REM Fail closed: a path reaching :END without a completed Python run (missing
+REM venv) exits non-zero. Only the Python call overwrites this with its own code.
+set RC=1
 set SCOPE=all
 set MODE=--dry-run
 
@@ -32,7 +35,8 @@ goto PARSE_ARGS
 cd /d "%~dp0"
 set VENV_DIR=.\.venv
 if not exist "%VENV_DIR%\Scripts\python.exe" (
-    echo [ERROR] Virtual environment not found at %VENV_DIR%
+    echo [ERROR] Virtual environment not found at %VENV_DIR%\Scripts\python.exe
+    echo [ERROR] Recreate it with: python -m venv .venv ^&^& .venv\Scripts\python.exe -m pip install -r requirements.txt
     goto END
 )
 
@@ -40,10 +44,21 @@ echo ========================================
 echo Self-healing scheduler: /schedule-autoheal %SCOPE% %MODE%
 echo ========================================
 echo.
+REM Keep this call at top level, NOT inside an if/else: %ERRORLEVEL% inside a
+REM parenthesised block is expanded at parse time and reads stale.
 "%VENV_DIR%\Scripts\python.exe" app\autoheal_console.py --skill-cmd "/schedule-autoheal %SCOPE% %MODE%"
+REM Capture on the very next line — any intervening command overwrites it.
+set RC=%ERRORLEVEL%
 
 :END
 echo.
+echo ========================================
+echo Autoheal finished ^(exit %RC%^)
+echo ========================================
+echo.
 echo Press any key to close this window...
 pause >nul
-endlocal
+REM Propagate the exit code so the scheduler records a crashed run as failed.
+REM endlocal discards RC, so both commands must sit on ONE parsed line: %RC%
+REM is substituted before endlocal executes.
+endlocal & exit /b %RC%

--- a/launch_newsletter.bat
+++ b/launch_newsletter.bat
@@ -28,7 +28,8 @@ cd /d "%~dp0"
 
 set VENV_DIR=.\.venv
 if not exist "%VENV_DIR%\Scripts\python.exe" (
-    echo [ERROR] Virtual environment not found at %VENV_DIR%
+    echo [ERROR] Virtual environment not found at %VENV_DIR%\Scripts\python.exe
+    echo [ERROR] Recreate it with: python -m venv .venv ^&^& .venv\Scripts\python.exe -m pip install -r requirements.txt
     pause
     exit /b 1
 )
@@ -49,5 +50,8 @@ echo.
 echo Press any key to close this window...
 pause >nul
 
-endlocal
-exit /b %RC%
+REM Propagate the pipeline's exit code so the scheduler records a crashed run
+REM as failed instead of green. endlocal discards RC, so both commands must sit
+REM on ONE parsed line: %RC% is substituted before endlocal executes. Split
+REM across two lines this silently exits 0 on a failed run.
+endlocal & exit /b %RC%

--- a/launch_planning.bat
+++ b/launch_planning.bat
@@ -13,6 +13,9 @@ REM in one platform does NOT stop the others. The markdown summary lands at
 REM results\planning\YYYY-MM-DD-HHMMSS-summary.md.
 
 setlocal EnableDelayedExpansion
+REM Fail closed: a path reaching :END without a completed Python run (missing
+REM venv) exits non-zero. Only the Python call overwrites this with its own code.
+set RC=1
 set AUTO_MODE=0
 set LIVE_MODE=0
 
@@ -53,22 +56,30 @@ if "%LIVE_MODE%"=="1" (
 )
 
 if not exist "%VENV_DIR%\Scripts\python.exe" (
-    echo [ERROR] Virtual environment not found at %VENV_DIR%
+    echo [ERROR] Virtual environment not found at %VENV_DIR%\Scripts\python.exe
+    echo [ERROR] Recreate it with: python -m venv .venv ^&^& .venv\Scripts\python.exe -m pip install -r requirements.txt
     goto END
 )
 
 echo [INFO] Running: python planning_pipeline.py %EXTRA_ARGS%
 echo.
+REM Keep this call at top level, NOT inside an if/else: %ERRORLEVEL% inside a
+REM parenthesised block is expanded at parse time and reads stale.
 "%VENV_DIR%\Scripts\python.exe" planning_pipeline.py %EXTRA_ARGS%
+REM Capture on the very next line — any intervening command overwrites it.
+set RC=%ERRORLEVEL%
 
 :END
 echo.
 echo ========================================
-echo Planning pipeline finished
+echo Planning pipeline finished ^(exit %RC%^)
 echo ========================================
 if "%AUTO_MODE%"=="1" goto EOL
 echo.
 echo Press any key to close this window...
 pause >nul
 :EOL
-endlocal
+REM Propagate the pipeline's exit code so the scheduler records a crashed run
+REM as failed instead of green. endlocal discards RC, so both commands must sit
+REM on ONE parsed line: %RC% is substituted before endlocal executes.
+endlocal & exit /b %RC%

--- a/launch_reporting.bat
+++ b/launch_reporting.bat
@@ -17,6 +17,11 @@ REM
 REM In auto mode the window still stays open at the end so the output is visible
 REM when you check on it.
 
+REM Fail closed: every path that reaches :END without an explicit result
+REM (bad date, missing venv) exits non-zero. Only a completed Python run
+REM overwrites this with the interpreter's own exit code.
+set RC=1
+
 set AUTO_MODE=0
 if /I "%~1"=="auto"   set AUTO_MODE=1
 if /I "%~1"=="--auto" set AUTO_MODE=1
@@ -93,23 +98,30 @@ echo.
 REM Path to your virtual environment (adjust if different)
 set VENV_DIR=.\.venv
 
-REM Check if virtual environment exists
+REM A missing venv is a hard stop, never a fallback to system Python: the
+REM system interpreter has none of this project's pinned dependencies, so
+REM the run cannot succeed, and a run that *did* limp along would write to
+REM the real datastore with unpinned versions.
 if not exist "%VENV_DIR%\Scripts\python.exe" (
-    echo [WARNING] Virtual environment not found at %VENV_DIR%
-    echo [INFO] Using system Python installation...
-    echo.
-    python reporting_pipeline.py --date %TARGET_DATE% %YES_FLAG%
-) else (
-    echo [INFO] Using virtual environment at %VENV_DIR%
-    echo [INFO] Running script with venv Python...
-    echo.
-    REM Run the script with Python from the venv (no activation needed)
-    "%VENV_DIR%\Scripts\python.exe" reporting_pipeline.py --date %TARGET_DATE% %YES_FLAG%
+    echo [ERROR] Virtual environment not found at %VENV_DIR%\Scripts\python.exe
+    echo [ERROR] Recreate it with: python -m venv .venv ^&^& .venv\Scripts\python.exe -m pip install -r requirements.txt
+    goto FINISH
 )
 
+echo [INFO] Using virtual environment at %VENV_DIR%
+echo [INFO] Running script with venv Python...
+echo.
+REM Run the script with Python from the venv (no activation needed).
+REM This call must stay at top level, NOT inside an if/else: %ERRORLEVEL%
+REM inside a parenthesised block is expanded at parse time and reads stale.
+"%VENV_DIR%\Scripts\python.exe" reporting_pipeline.py --date %TARGET_DATE% %YES_FLAG%
+REM Capture on the very next line — any intervening command overwrites it.
+set RC=%ERRORLEVEL%
+
+:FINISH
 echo.
 echo ========================================
-echo Pipeline finished
+echo Pipeline finished (exit %RC%)
 echo ========================================
 echo.
 
@@ -117,3 +129,8 @@ echo.
 REM Keep the window open so the output can be inspected after the run.
 echo Press any key to close this window...
 pause >nul
+
+REM Propagate the pipeline's exit code so the scheduler records a crashed
+REM run as failed. reporting_pipeline.py deliberately sys.exit(1)s on any
+REM step failure "so the launcher / scheduler can react" — this is that.
+exit /b %RC%

--- a/tests/test_launcher_exit_codes.py
+++ b/tests/test_launcher_exit_codes.py
@@ -1,0 +1,156 @@
+"""Regression test for launcher exit-code propagation (issue #174).
+
+Every ``launch_*.bat`` wrapper is invoked by the scheduler, which derives a
+run's success/failure purely from the process exit code. A wrapper that ends
+without propagating its Python child's code returns the exit status of its
+last ``echo``/``pause`` — always 0 — so a hard crash is recorded as a green
+run. That is exactly how two days of reporting-pipeline crashes were logged as
+successes while ``reporting_pipeline.py`` was faithfully calling ``sys.exit(1)``.
+
+Three shapes are checked, statically, across every tracked ``launch_*.bat``:
+
+1. **Exit-code propagation.** The script must end with an ``exit /b %RC%``.
+2. **The ``endlocal`` trap.** ``endlocal`` restores the pre-``setlocal``
+   environment, discarding ``RC``. Split across two lines, ``exit /b %RC%``
+   degrades to a bare ``exit /b`` and the run reports 0. Verified empirically:
+
+       endlocal            + exit /b %RC%  (two lines) -> child rc 7 became 0
+       endlocal & exit /b %RC%             (one line)  -> child rc 7 stayed 7
+
+   So a script using ``setlocal`` must join them on one parsed line.
+3. **No system-Python fallback.** A missing venv must be a hard stop. Falling
+   back to a bare ``python`` on PATH runs the pipeline against an interpreter
+   without the project's pinned dependencies — it cannot succeed, and if it
+   ever did it would write to the real datastore with unpinned versions.
+4. **CRLF line endings.** ``cmd`` tracks byte offsets as it interprets a batch
+   file; with LF-only endings it resumes at the wrong offset after a ``goto``
+   and executes fragments of lines. Observed while validating this very fix —
+   an LF-saved launcher emitted ``'M' is not recognized``, ``'/d' is not
+   recognized``, read ``%VENV_DIR%`` as empty, and exited 0 on a broken venv.
+   The failure is silent and looks like unrelated corruption.
+
+This scans the tracked files rather than re-checking today's four, so a
+launcher added later that forgets the convention is caught too.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+# `exit /b %RC%` / `exit /b !RC!`, optionally preceded by `endlocal &` on the
+# same line. Trailing `exit /b 1` guard clauses elsewhere in the file don't
+# count — this must be the script's final propagation.
+_PROPAGATES_RE = re.compile(r"^\s*(endlocal\s*&\s*)?exit\s*/b\s*[%!]\w+[%!]\s*$", re.IGNORECASE)
+_ENDLOCAL_JOINED_RE = re.compile(r"^\s*endlocal\s*&\s*exit\s*/b\s*[%!]\w+[%!]", re.IGNORECASE)
+_BARE_ENDLOCAL_RE = re.compile(r"^\s*endlocal\s*$", re.IGNORECASE)
+_SETLOCAL_RE = re.compile(r"^\s*setlocal\b", re.IGNORECASE)
+# A bare `python foo.py` invocation — i.e. not `"%VENV_DIR%\Scripts\python.exe"`.
+# Anchored at line start so mentions inside REM/echo help text don't trip it.
+_SYSTEM_PYTHON_RE = re.compile(r"^\s*(python|py)(\.exe)?\s+\S+\.py\b", re.IGNORECASE)
+
+
+def _tracked_launcher_scripts() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "launch_*.bat"],
+        cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+        creationflags=_NO_WINDOW,
+    )
+    return [REPO_ROOT / line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _code_lines(path: Path) -> list[tuple[int, str]]:
+    """Numbered lines with REM comments and blank lines stripped."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines: list[tuple[int, str]] = []
+    for n, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+        if not stripped or re.match(r"^rem\b", stripped, re.IGNORECASE) or stripped.startswith("::"):
+            continue
+        lines.append((n, raw))
+    return lines
+
+
+class LauncherExitCodeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scripts = _tracked_launcher_scripts()
+        self.assertTrue(self.scripts, "no tracked launch_*.bat files found")
+
+    def test_every_launcher_propagates_its_exit_code(self):
+        offenders: list[str] = []
+        for path in self.scripts:
+            lines = _code_lines(path)
+            if not any(_PROPAGATES_RE.match(text) for _, text in lines):
+                offenders.append(
+                    f"{path.name}: no final 'exit /b %RC%' — the scheduler will "
+                    f"record every run, including crashes, as success"
+                )
+        self.assertEqual(
+            offenders, [],
+            "launcher(s) discarding their child's exit code (issue #174):\n  "
+            + "\n  ".join(offenders),
+        )
+
+    def test_setlocal_launchers_join_endlocal_and_exit(self):
+        offenders: list[str] = []
+        for path in self.scripts:
+            lines = _code_lines(path)
+            if not any(_SETLOCAL_RE.match(text) for _, text in lines):
+                continue
+            if any(_ENDLOCAL_JOINED_RE.match(text) for _, text in lines):
+                continue
+            bare = [n for n, text in lines if _BARE_ENDLOCAL_RE.match(text)]
+            if bare:
+                offenders.append(
+                    f"{path.name}:{bare[-1]} bare 'endlocal' with setlocal in effect — "
+                    f"RC is discarded before 'exit /b %RC%' reads it, so a failed "
+                    f"run exits 0. Use 'endlocal & exit /b %RC%' on one line."
+                )
+        self.assertEqual(
+            offenders, [],
+            "launcher(s) losing RC across endlocal (issue #174):\n  " + "\n  ".join(offenders),
+        )
+
+    def test_every_launcher_uses_crlf_line_endings(self):
+        offenders: list[str] = []
+        for path in self.scripts:
+            data = path.read_bytes()
+            bare_lf = sum(
+                1 for i, byte in enumerate(data)
+                if byte == 0x0A and (i == 0 or data[i - 1] != 0x0D)
+            )
+            if bare_lf:
+                offenders.append(
+                    f"{path.name}: {bare_lf} bare-LF line ending(s) — cmd will "
+                    f"mis-execute this file after a goto and can exit 0 on failure"
+                )
+        self.assertEqual(
+            offenders, [],
+            "launcher(s) with LF line endings (issue #174):\n  " + "\n  ".join(offenders),
+        )
+
+    def test_no_launcher_falls_back_to_system_python(self):
+        offenders: list[str] = []
+        for path in self.scripts:
+            for n, text in _code_lines(path):
+                if _SYSTEM_PYTHON_RE.match(text):
+                    offenders.append(f"{path.name}:{n} {text.strip()}")
+        self.assertEqual(
+            offenders, [],
+            "launcher(s) invoking a system Python instead of the project venv "
+            "(issue #174) — a missing venv must be a hard stop, not a silent "
+            "fallback to an interpreter without the pinned dependencies:\n  "
+            + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The reporting job recorded five consecutive days as **success, exit 0** while the pipeline crashed on import for two of them. `reporting_pipeline.py` was never the problem — it accumulates step failures and ends with `sys.exit(1)`, commented *"so the launcher / scheduler can react"*. `launch_reporting.bat` discarded that code, so `cmd` returned the exit status of its trailing `echo` and the scheduler faithfully recorded green.

The trigger was environmental: the project `.venv` was emptied on 2026-07-23 20:50. The LinkedIn scrape job, invoked as a direct `python` target with no `.bat` wrapper, reported `failed, exit 1` from the very next run. The reporting job, wrapped in the launcher, reported success throughout. That asymmetry is the whole bug.

Changes:

- **No system-Python fallback.** A missing venv is a hard stop with a recreate hint, not a `[WARNING]`. The system interpreter has none of the pinned dependencies so the fallback could never succeed — and had it succeeded, it would have written to the real datastore with unpinned versions.
- **Capture and propagate `%ERRORLEVEL%`** immediately after each Python call. The call stays at top level because `%ERRORLEVEL%` inside a parenthesised `if/else` is expanded at parse time and reads stale.
- **`endlocal & exit /b %RC%` on one line.** `endlocal` restores the pre-`setlocal` environment, discarding `RC`, so the two-line form degrades to a bare `exit /b` and reports 0.
- **`RC=1` default** so any path reaching the exit label without a completed run fails closed.
- **`launch_app.bat` converted to CRLF.** With LF endings `cmd` mis-tracks byte offsets after a `goto` and executes line fragments.
- **New static sweep** `tests/test_launcher_exit_codes.py` over tracked `launch_*.bat`, asserting all four properties.

Two defects were found during the work that were **not** in the original report:

`launch_newsletter.bat` had the same bug while appearing to implement the pattern correctly — its `endlocal` and `exit /b %RC%` sat on separate lines. Measured directly:

```
endlocal            + exit /b %RC%   (two lines)  ->  child rc 7 propagated as 0
endlocal & exit /b %RC%              (one line)   ->  child rc 7 propagated as 7
```

`launch_app.bat` had LF line endings, which made `cmd` emit `'M' is not recognized`, read `%VENV_DIR%` as empty, and exit 0 on a broken venv. Caught only because the new test swept it.

## Validation

**Reproduction, before vs after.** Ran the pre-fix launcher from `main` and the fixed one side by side against a deliberately broken venv. The BEFORE run reproduces the reported console output verbatim, including the `psycopg2` traceback:

```
BEFORE  [WARNING] Virtual environment not found at .\.venv
        [INFO] Using system Python installation...
        ModuleNotFoundError: No module named 'psycopg2'
        Pipeline finished
        ==> EXIT 0          <- recorded as success

AFTER   [ERROR] Virtual environment not found at .\.venv\Scripts\python.exe
        [ERROR] Recreate it with: python -m venv .venv && ...
        Pipeline finished (exit 1)
        ==> EXIT 1          <- recorded as failed
```

**All five launchers, broken venv** — each exits 1 with a clear error and no fallback:

```
launch_reporting.bat   ==> EXIT 1   PASS
launch_planning.bat    ==> EXIT 1   PASS
launch_autoheal.bat    ==> EXIT 1   PASS
launch_newsletter.bat  ==> EXIT 1   PASS
launch_app.bat         ==> EXIT 1   PASS
```

**Success path preserved** — verified separately so the fix cannot have turned every run red:

```
child exits 0, setlocal form   -> 0
child exits 0, plain form      -> 0
child exits 7, setlocal form   -> 7
```

**Test suite:** `python -m unittest discover tests` — 19 tests, all pass. The new sweep was confirmed to *fail* against the pre-fix launchers (3 checks red) before the fix was applied, so it is not vacuously green.

**Live end-to-end, both jobs run for today through the real scheduler path:**

- **LinkedIn scrape** — `success, exit 0`, 2 posts / 20 comments / 16 commenters. Real data, not a green-on-empty run.
- **Reporting pipeline** — `failed, exit 1` after a complete 134 s run. Notion updated with follower counts across all five platforms, post metrics written, Supabase reachable, daily Substack Note published. The non-zero exit is a **true positive**: `check_posts_coverage` matches `posted_at = date - 1 day`, so today requires a Substack note dated 2026-07-24 — the day the crash prevented one from being published. Correctly reported instead of hidden. This run is the fix demonstrating itself: identical circumstances on 2026-07-24 and 07-25 were recorded as success.

**Historical replay** — recorded status vs. what the logs show actually happened:

| date | recorded | actual |
| --- | --- | --- |
| 07-18, 07-19 | success | ok |
| **07-20** | **success** | **FAILED** (posts-coverage) |
| 07-21 → 07-23 | success | ok |
| **07-24, 07-25 06:00** | **success** | **crash on import** |
| 07-25 09:31 (this branch) | **failed, exit 1** | FAILED — correct |

2026-07-20 had already failed for real and been recorded green, five days before the crash. Nobody could have known.

**Scope sweep.** `git diff main...HEAD` touches only the five launchers, `README.md`, and the new test. No dependency changes, no removed tests, no weakened assertions, no `.gitignore` edits.

## Not included

Two independently-revertable defects found during validation, filed separately rather than bundled here:

- #175 — the LinkedIn comment scraper exits 0 on a fully-failed scrape. A DOM-drift outage ran 18 consecutive times scraping nothing, every run green.
- #176 — `scikit-learn>=1.5` has no upper bound, so the venv rebuild resolved 1.9.0 against a classifier pickled under 1.8.0, silently degrading it.

Also observed, in a different repo so not actioned here: a run killed mid-flight leaves its record stamped `status: running` permanently, since the executor never reaches finalisation. A third false-status mode.

Closes #174
