### PR TITLE
fix: fail LinkedIn scrape when extraction is structurally broken

### DIFF
--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -439,8 +439,15 @@ def _dump_debug(page: Page, post_url: str, *, prefix: str) -> None:
         logger.warning("dump failed: %s", err)
 
 
-def scrape_post_comments(page: Page, post_url: str, post_posted_at: Optional[str]) -> tuple[list[dict], list[dict]]:
-    """Return (comments_rows, commenters_rows) for a single post URL."""
+def scrape_post_comments(
+    page: Page, post_url: str, post_posted_at: Optional[str]
+) -> tuple[list[dict], list[dict], Optional[str]]:
+    """Return (comments_rows, commenters_rows, structural_error) for a single post URL.
+
+    `structural_error` is the extractor's `error` key (e.g. `no_list_container`)
+    when the DOM didn't match expected shape at all — the discriminator `run()`
+    uses to tell a quiet day (0 comments, no error) from a broken scrape (0
+    comments because extraction never found what it was looking for)."""
     logger.info("➡️ scraping %s", post_url)
     page.goto(post_url, wait_until="domcontentloaded", timeout=45_000)
 
@@ -526,7 +533,7 @@ def scrape_post_comments(page: Page, post_url: str, post_posted_at: Optional[str
     if result.get("error"):
         logger.warning("⚠️ extractor reported %s on %s — dumping page for inspection", result["error"], post_url)
         _dump_debug(page, post_url, prefix="miss")
-        return [], []
+        return [], [], result["error"]
 
     records = result.get("records") or []
     if not records:
@@ -574,10 +581,22 @@ def scrape_post_comments(page: Page, post_url: str, post_posted_at: Optional[str
     # Stamp post_posted_at into each row's verdict_reasons-friendly side channel for the classifier.
     for r in comments_rows:
         r["_post_posted_at"] = post_posted_at  # consumed by classifier only; stripped before upsert
-    return comments_rows, list(commenters_seen.values())
+    return comments_rows, list(commenters_seen.values()), None
 
 
 # ---------- Orchestrator ----------
+
+def _evaluate_scrape_health(total_posts: int, structural_errors: list[str]) -> str:
+    """Return `"broken"` when every attempted post's outcome was a structural
+    extractor error (or an unhandled exception) rather than a legitimate empty
+    result. This is the discriminator that separates a dead selector (18
+    consecutive `no_list_container` runs went unnoticed — issue #175) from an
+    ordinary quiet day where posts were visited and simply have no comments
+    yet. Comment count alone is deliberately not part of the check — only the
+    extractor's own `error` key is, since it is the one signal that tells
+    "the DOM didn't match" apart from "there was nothing to find"."""
+    return "broken" if total_posts > 0 and len(structural_errors) == total_posts else "ok"
+
 
 def run(days: int, *, headless: bool = False, dry_run: bool = False, limit: Optional[int] = None) -> dict:
     li_cfg = load_linkedin_config()
@@ -586,10 +605,18 @@ def run(days: int, *, headless: bool = False, dry_run: bool = False, limit: Opti
         posts = posts[:limit]
     if not posts:
         logger.warning("⚠️ no posts to scrape")
-        return {"posts": 0, "comments": 0, "commenters": 0}
+        return {
+            "posts": 0, "comments": 0, "commenters": 0,
+            "structural_failures": 0, "status": _evaluate_scrape_health(0, []),
+        }
 
     all_comments: list[dict] = []
     all_commenters: dict[str, dict] = {}
+    # Per-post structural-error tracking (issue #175) — the extractor's `error`
+    # key, not comment count, is the reliable "did extraction actually work"
+    # signal. A post-level exception counts as structural too: the scrape never
+    # produced a real result for it either.
+    structural_errors: list[str] = []
 
     with LinkedInSession(li_cfg, headless=headless) as session:
         try:
@@ -600,13 +627,18 @@ def run(days: int, *, headless: bool = False, dry_run: bool = False, limit: Opti
 
         for p in posts:
             try:
-                comments, commenters = scrape_post_comments(session.page, p["post_url"], p["post_posted_at"])
+                comments, commenters, structural_error = scrape_post_comments(
+                    session.page, p["post_url"], p["post_posted_at"]
+                )
                 all_comments.extend(comments)
                 for c in commenters:
                     all_commenters.setdefault(c["account_url"], c)
+                if structural_error:
+                    structural_errors.append(structural_error)
             except Exception as err:
                 logger.exception("❌ failed scraping %s: %s", p["post_url"], err)
                 session.screenshot_failure(f"scrape-fail-{p.get('day') or 'na'}")
+                structural_errors.append(f"exception:{type(err).__name__}")
 
     # Strip side-channel fields before persisting comments.
     persistable_comments = [{k: v for k, v in c.items() if not k.startswith("_")} for c in all_comments]
@@ -644,7 +676,20 @@ def run(days: int, *, headless: bool = False, dry_run: bool = False, limit: Opti
         except Exception as err:  # never let classify failure mask scrape success
             logger.warning("post-scrape classify failed: %s", err)
 
-    return {"posts": len(posts), "comments": len(persistable_comments), "commenters": len(all_commenters)}
+    status = _evaluate_scrape_health(len(posts), structural_errors)
+    if status == "broken":
+        logger.error(
+            "❌ scrape structurally broken — all %d attempted post(s) failed with a structural error: %s",
+            len(posts), ", ".join(structural_errors),
+        )
+
+    return {
+        "posts": len(posts),
+        "comments": len(persistable_comments),
+        "commenters": len(all_commenters),
+        "structural_failures": len(structural_errors),
+        "status": status,
+    }
 
 
 def main() -> None:  # pragma: no cover
@@ -668,6 +713,12 @@ def main() -> None:  # pragma: no cover
     days = args.days if args.days is not None else cfg.get("default_days", 5)
     result = run(days=days, headless=args.headless, dry_run=args.dry_run, limit=args.limit)
     print(json.dumps(result, indent=2))
+
+    # Issue #175: a scrape where every attempted post came back structurally
+    # broken (extractor error / exception on all of them) must fail the run
+    # instead of reporting green — that's what let an 18-run outage go unseen.
+    if result.get("status") == "broken":
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_scrape_comments_exit_status.py
+++ b/tests/test_scrape_comments_exit_status.py
@@ -1,0 +1,87 @@
+"""Regression test for the LinkedIn comment scraper's silent-outage bug (issue #175).
+
+Every failure inside ``scrape_post_comments`` was downgraded to a ``WARNING``
+and an empty return, and ``main()`` had no exit-status logic at all — a run
+that visited N posts and extracted 0 comments from all of them was
+indistinguishable, to the scheduler, from a run that worked. A LinkedIn DOM
+change broke extraction for six days; 18 consecutive scheduled runs all
+reported ``"status": "success"``, ``"exit_code": 0``.
+
+``_evaluate_scrape_health()`` is the extracted decision function ``run()``
+now calls to decide the aggregate outcome. It is deliberately pure (no
+Playwright/Notion/Supabase dependency) so this scenario is testable without a
+live LinkedIn session — the fix is the decision logic, not the DOM walk.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Optional
+from unittest import mock
+
+import engagement.linkedin.scrape_comments as scrape_comments
+from engagement.linkedin.scrape_comments import _evaluate_scrape_health
+
+
+class ScrapeHealthTests(unittest.TestCase):
+    def test_broken_when_every_post_hits_a_structural_error(self):
+        """Replays the 2026-07-15 -> 07-20 outage: every visited post's
+        extractor reported `no_list_container`. Must be reported broken so
+        the run fails on post #1 of the outage, not the 18th."""
+        errors = ["no_list_container"] * 18
+        self.assertEqual(_evaluate_scrape_health(18, errors), "broken")
+
+    def test_ok_when_posts_have_zero_comments_but_no_structural_error(self):
+        """A quiet day — posts were visited, the comment list container was
+        found, there just aren't any comments yet. Must NOT be flagged
+        broken: comment count alone is not the discriminator."""
+        self.assertEqual(_evaluate_scrape_health(5, []), "ok")
+
+    def test_ok_when_only_some_posts_structurally_fail(self):
+        """Partial failure (1 of 3 posts errored) is not the full-outage
+        signal this check exists to catch."""
+        self.assertEqual(_evaluate_scrape_health(3, ["no_list_container"]), "ok")
+
+    def test_ok_when_no_posts_were_attempted(self):
+        """Nothing to scrape (e.g. an empty lookback window) is not an
+        outage — there's nothing for the extractor to have failed on."""
+        self.assertEqual(_evaluate_scrape_health(0, []), "ok")
+
+    def test_broken_counts_exceptions_as_structural(self):
+        """A per-post exception (network error, crash mid-scrape) is as much
+        a structural failure as an extractor-reported DOM miss — both mean
+        the post never produced a real result."""
+        errors = ["exception:TimeoutError", "no_list_container"]
+        self.assertEqual(_evaluate_scrape_health(2, errors), "broken")
+
+
+class MainExitCodeTests(unittest.TestCase):
+    """`main()` is what the scheduler actually observes — the health check
+    only matters if it reaches `sys.exit`. `run()` is mocked so this exercises
+    just the wiring, with no live LinkedIn/Notion/Supabase dependency."""
+
+    def _run_main(self, run_result: dict) -> Optional[int]:
+        with mock.patch.object(scrape_comments, "run", return_value=run_result), \
+             mock.patch.object(scrape_comments, "load_config", return_value={"engagement": {}}), \
+             mock.patch.object(scrape_comments, "setup_logger"), \
+             mock.patch.object(scrape_comments, "force_utf8_stdio"), \
+             mock.patch("sys.argv", ["scrape_comments.py", "--dry-run"]):
+            try:
+                scrape_comments.main()
+            except SystemExit as exc:
+                return exc.code
+            return None
+
+    def test_main_exits_nonzero_on_broken_status(self):
+        code = self._run_main({"posts": 3, "comments": 0, "commenters": 0, "structural_failures": 3, "status": "broken"})
+        self.assertEqual(code, 1)
+
+    def test_main_does_not_exit_on_ok_status(self):
+        code = self._run_main({"posts": 3, "comments": 0, "commenters": 0, "structural_failures": 0, "status": "ok"})
+        self.assertIsNone(code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`engagement/linkedin/scrape_comments.py` exited 0 whether it scraped comments or nothing at all ??? every extractor miss was downgraded to a `WARNING` and an empty return, and `main()` had no exit-status logic. This let an 18-run, 6-day scraping outage go completely unnoticed: every run reported `"status": "success"`, `"exit_code": 0`.

- `scrape_post_comments()` now returns the extractor's `error` key (e.g. `no_list_container`) alongside its comments/commenters, instead of discarding it.
- `run()` tracks each attempted post's outcome and calls a new pure `_evaluate_scrape_health()` to decide `"broken"` vs `"ok"` ??? a post-level exception counts as structural too. The result dict gains `structural_failures` (count) and `status`, so the reason is visible in run history JSON, not only the log file.
- `main()` exits 1 when `status == "broken"`.
- The discriminator is deliberately the extractor's `error` key, not comment count ??? a quiet day with zero real comments must stay exit 0. "Broken" only fires when **every** attempted post came back with a structural error.

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile engagement\linkedin\scrape_comments.py` ??? clean.
- `& .\.venv\Scripts\python.exe -m unittest discover tests -v` ??? 37/37 passing (5 new tests added in `tests/test_scrape_comments_exit_status.py`), covering all three "How to verify" scenarios from the issue:
  - all posts structurally failing (replays the 2026-07-15 ??? 07-20 outage) ??? `"broken"`
  - posts visited with zero real comments, no extractor error ??? `"ok"`
  - partial failure (not every post) ??? `"ok"`
  - per-post exceptions counted as structural
- `main()`'s exit-code wiring verified directly (mocked `run()`): `status: "broken"` ??? `SystemExit(1)`; `status: "ok"` ??? no exit raised.
- `git diff main...HEAD` reviewed ??? scoped to the one module + its new test file, no unrelated changes.
- No README update needed: the script's flags/usage are unchanged, and its JSON output shape was never documented there. `app/tab_engagement.py`'s subprocess runner already surfaces `proc.poll()` generically, so the new exit code propagates to the UI with no code change needed there.

Closes #175