### PR TITLE
fix: bind the engagement classifier to the sklearn that pickled it

### DIFF
--- a/app/tab_engagement.py
+++ b/app/tab_engagement.py
@@ -74,6 +74,7 @@ Score ≥ `ai_classification_threshold` (default 0.50) → **AI**. Below → **u
 - Threshold to upgrade to AI: `local_model_ai_threshold` (default 0.70). Conservative so canned replies aren't wrongly staged.
 - Requires `local_model_min_train_per_class` (default 20) of each class before training is allowed.
 - Persisted as `engagement/classify/local_model.joblib` (gitignored — user-specific artifact). If the file isn't on disk yet, the classify pass is lossless: behaviour is identical to rules-only.
+- The pickle is bound to the scikit-learn that wrote it (pinned to one minor line in `requirements.txt`). If you upgrade sklearn, the loader refuses the stale artifact and names both versions — retrain rather than classifying from a degraded model.
 - The featurizer (`local_model.featurize_one`) re-imports the per-comment helpers from `rules.py`, so train-time and inference-time signals **can't drift**. Tune a rule → retrain the model.
 
 **Layer 3 — LLM fallback** (Phase 3, future). Structured-output call to a small LLM (Gemini Flash-Lite or Haiku 4.5) for the ~10% genuine ambiguous middle, cached by `(commenter_url, comment_hash)`. Not implemented yet.

--- a/engagement/README.md
+++ b/engagement/README.md
@@ -43,7 +43,7 @@ flowchart LR
 | `python -m engagement.linkedin.scrape_comments --days 5` | Scrape last 5 calendar days **including today** of LI comments → Supabase. Headful by default. `--days N` means N total days, so `--days 1` = today only. |
 | `python -m engagement.linkedin.scrape_comments --days 1 --limit 1 --dry-run` | Smoke test against 1 post (today only); writes `results/engagement/dryrun-*.json` instead of upserting. |
 | `python -m engagement.classify.rules` | Re-classify all `pending` `unknown` rows using current `phrases.json`. If a local model is on disk, it runs as a second pass on the rows the rules layer left as `unknown`. |
-| `python -m engagement.classify.local_model train` | Train the local sklearn classifier on accumulated whitelist/blacklist labels. Refuses to train below `rules.local_model_min_train_per_class` per class. Writes `engagement/classify/local_model.joblib` (gitignored) + a metadata sidecar. |
+| `python -m engagement.classify.local_model train` | Train the local sklearn classifier on accumulated whitelist/blacklist labels. Refuses to train below `rules.local_model_min_train_per_class` per class. Writes `engagement/classify/local_model.joblib` (gitignored) + a metadata sidecar recording the scikit-learn version that pickled it. |
 | `python -m engagement.classify.local_model eval` | 5-fold stratified CV on the same labeled set; prints AUC + precision/recall/F1 at the configured threshold. |
 | `python -m engagement.reputation.update` | Recompute rolling per-commenter signals + counters + reputation_score from the `comments` table and upsert into `commenters`. Idempotent; preserves manual whitelist/blacklist. |
 | `& .\.venv\Scripts\python.exe -m streamlit run engagement\review_app.py` | Launch the review UI on `http://localhost:8501`. |
@@ -64,9 +64,10 @@ No new secrets needed — uses `config.supabase.service_role_key` and `config.no
 - **Relative time parsing is approximate.** LinkedIn shows `2h`, `5m`, `1d`. We reconstruct an absolute timestamp from scrape time, so `posted_at` drifts up to ~one tick of the LI display unit. Fine for cadence rules.
 - **Unknown ≠ AI.** Comments that score below the AI threshold (and below the local-model threshold, if a model is loaded) stay `unknown` and surface in the real-comments tab by default. Bias is toward human review — better to over-surface than wrongly stage a canned reply.
 - **Local model is lossless when missing.** If `local_model.joblib` isn't on disk yet, the rules pass is the only classifier and the verdict reasons match Phase 1 exactly. Train it by running `python -m engagement.classify.local_model train` once you have ≥20 whitelist + ≥20 blacklist commenters.
+- **The artifact is pinned to its scikit-learn.** `local_model.joblib` is a pickle, and sklearn only guarantees pickle portability across *patch* releases — which is why `requirements.txt` pins `scikit-learn` to one minor line. Crossing a minor boundary used to unpickle with a warning and then score every comment from a degraded model, so nothing errored and nothing got classified (`ai=0 human=0 unknown=N` — the diagnostic tell). `train()` now records the writing version in the sidecar and the loader refuses a mismatch, naming both versions. If you see that error, retrain: `python -m engagement.classify.local_model train`. "No model on disk" stays a soft fallback; a version-skewed model does not.
 - **Featurizer is the single source of truth.** `local_model.featurize_one` re-imports `_seconds_after`, `_is_emoji_only`, `_generic_praise_hits`, `_has_personal_token` from `rules.py` so train-time and inference-time signals can never drift. If you tune one of those rules in `phrases.json` (or the helper logic), retrain before relying on the model.
 - **Whitelist/blacklist cascades.** Marking a commenter triggers a retroactive reclassification of their pending comments (`cascade_blacklist_pending` / `cascade_whitelist_pending`).
-- **No tests yet.** Single-user pipeline; verification is a real scrape + manual eyeball.
+- **Thin test coverage.** `tests/` covers the scrape exit-status contract and the classifier's artifact/runtime version guard; everything else is verified by a real scrape + manual eyeball.
 
 ## Files
 
@@ -82,7 +83,7 @@ engagement/
 │   ├── llm_fallback.py               # Phase 3 — local-hub LLM, fires only inside the local-model uncertainty window
 │   ├── phrases.json                  # generic-praise list, weights, thresholds, reply templates
 │   ├── local_model.joblib            # (gitignored) trained pipeline — user-specific artifact
-│   ├── local_model.json              # (gitignored) training metadata sidecar
+│   ├── local_model.json              # (gitignored) training metadata sidecar, incl. the sklearn version that pickled the artifact
 │   └── .llm_cache.json               # (gitignored) per-machine cache of LLM verdicts
 ├── reputation/
 │   └── update.py                     # rolling signals + reputation_score recomputer (Phase 3)

--- a/engagement/classify/local_model.py
+++ b/engagement/classify/local_model.py
@@ -15,6 +15,16 @@ set never produces a useless model.
 The featurizer (`featurize_one`) is the single source of truth, used at both
 train and inference time. It re-uses the per-comment helpers from `rules.py`
 so the two layers can never drift.
+
+A pickled sklearn pipeline is bound to the version that wrote it, not to the
+version range whose API the training code uses: scikit-learn guarantees pickle
+portability across patch releases only. Crossing a minor boundary unpickles
+with an `InconsistentVersionWarning` and then predicts from a silently degraded
+model — which this pipeline reads as "uncertain batch", so nothing errors and
+nothing gets classified. `train()` therefore records the writing version in the
+sidecar and `_load_model_cached()` refuses to load an artefact whose
+(major, minor) doesn't match the runtime, raising `ModelVersionMismatch`
+instead of degrading quietly.
 """
 
 from __future__ import annotations
@@ -22,6 +32,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import warnings
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -41,6 +52,61 @@ SCALAR_COLS = [
     "sub_2_min",
     "exact_text_duplicate",
 ]
+
+
+# ---------- Artefact / runtime version contract ----------
+
+class ModelVersionMismatch(RuntimeError):
+    """The persisted pipeline was pickled by an incompatible scikit-learn."""
+
+
+def _major_minor(version: str) -> Optional[tuple[int, int]]:
+    parts = version.split(".")
+    try:
+        return int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _versions_compatible(trained: str, runtime: str) -> bool:
+    """True when `trained` can safely unpickle under `runtime`. sklearn keeps
+    pickles portable across patch releases but not across minor ones, so
+    compare (major, minor) — falling back to an exact match if either version
+    string doesn't parse."""
+    a, b = _major_minor(trained), _major_minor(runtime)
+    if a is None or b is None:
+        return trained == runtime
+    return a == b
+
+
+def _recorded_sklearn_version() -> Optional[str]:
+    """The scikit-learn version that pickled the artefact, from the sidecar.
+    None for an artefact trained before the sidecar recorded it — those are
+    caught by sklearn's own unpickle warning instead."""
+    if not META_PATH.exists():
+        return None
+    try:
+        meta = json.loads(META_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as err:
+        logger.warning("⚠️ local_model metadata unreadable: %s", err)
+        return None
+    version = meta.get("sklearn_version")
+    return str(version) if version else None
+
+
+def _version_mismatch_error(trained: str, runtime: str) -> ModelVersionMismatch:
+    """Build the mismatch error, logging it first so the breadcrumb lands in the
+    run's log file even where the caller only sees the traceback."""
+    message = (
+        f"local model artefact was pickled by scikit-learn {trained} but this "
+        f"environment runs scikit-learn {runtime}. A pickled sklearn pipeline is "
+        f"not portable across minor versions — loading it would degrade every "
+        f"prediction without erroring. Retrain with "
+        f"`python -m engagement.classify.local_model train`, or install "
+        f"scikit-learn=={trained}."
+    )
+    logger.error("❌ %s", message)
+    return ModelVersionMismatch(message)
 
 
 # ---------- Features ----------
@@ -149,11 +215,15 @@ def train(platform: str = "linkedin") -> dict:
     pipeline.fit(df, y)
 
     import joblib
+    import sklearn
     MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
     joblib.dump(pipeline, MODEL_PATH)
 
     meta = {
         "trained_at": datetime.now(timezone.utc).isoformat(),
+        # The pickle is bound to this version — the loader compares it against
+        # the runtime and refuses a minor-version skew.
+        "sklearn_version": sklearn.__version__,
         "platform": platform,
         "n_ai": n_ai,
         "n_human": n_human,
@@ -222,19 +292,51 @@ def evaluate(platform: str = "linkedin") -> dict:
 def _load_model_cached():
     """Return the persisted pipeline, or None if no model has been trained.
     Cached for the lifetime of the process — `train()` clears the cache after
-    overwriting the file."""
+    overwriting the file.
+
+    Raises `ModelVersionMismatch` when the artefact was pickled by an
+    incompatible scikit-learn. "Not trained yet" stays a soft None (the rules
+    pass is lossless without a model); a version-skewed artefact is not — it
+    would classify everything as uncertain, so it fails loudly instead."""
     if not MODEL_PATH.exists():
         return None
-    try:
-        import joblib
-        return joblib.load(MODEL_PATH)
-    except Exception as err:
-        logger.warning("⚠️ local_model load failed: %s", err)
-        return None
+
+    import sklearn
+    from sklearn.exceptions import InconsistentVersionWarning
+
+    runtime = sklearn.__version__
+    trained = _recorded_sklearn_version()
+    if trained is not None and not _versions_compatible(trained, runtime):
+        raise _version_mismatch_error(trained, runtime)
+
+    # Second gate for artefacts whose sidecar predates `sklearn_version`:
+    # sklearn announces the writing version through its own unpickle warning.
+    # Recorded rather than raised so a harmless patch-level skew still loads.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", InconsistentVersionWarning)
+        try:
+            import joblib
+            model = joblib.load(MODEL_PATH)
+        except Exception as err:
+            logger.warning("⚠️ local_model load failed: %s", err)
+            return None
+
+    for entry in caught:
+        skew = entry.message
+        if isinstance(skew, InconsistentVersionWarning) and not _versions_compatible(
+            skew.original_sklearn_version, runtime
+        ):
+            raise _version_mismatch_error(skew.original_sklearn_version, runtime)
+
+    return model
 
 
 def predict_one(comment: dict, duplicate_texts: set, phrases: Optional[dict] = None) -> Optional[float]:
-    """Return P(AI) for one comment, or None if no model is loaded."""
+    """Return P(AI) for one comment, or None if no model is loaded.
+
+    Raises `ModelVersionMismatch` if the artefact is version-skewed — the load
+    happens outside the try/except below on purpose, so the skew isn't
+    swallowed into the same silent None that a genuine prediction error gets."""
     model = _load_model_cached()
     if model is None:
         return None
@@ -251,6 +353,10 @@ def predict_one(comment: dict, duplicate_texts: set, phrases: Optional[dict] = N
 
 
 def model_is_available() -> bool:
+    """True if a usable model is on disk. Raises `ModelVersionMismatch` on a
+    version-skewed artefact — `classify_pending` calls this before touching the
+    database, so the skew aborts the run rather than writing 'unknown' verdicts
+    derived from a degraded model."""
     return _load_model_cached() is not None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,9 +40,14 @@ supabase==2.10.0
 streamlit
 # Local sklearn classifier (Phase 2a) trained on accumulated whitelist/blacklist
 # labels; runs as a layered pass after rules.py on rows the rules left as 'unknown'.
-# Lower bound = 1.5 (ColumnTransformer + StratifiedKFold API stability); no upper
-# bound — 1.8 is the first release with Python 3.14 wheels for this venv.
-scikit-learn>=1.5
+# Pinned to one minor line because the trained pipeline is persisted as a pickle
+# (engagement/classify/local_model.joblib) and sklearn only guarantees pickle
+# portability across patch releases. An unbounded range let a venv rebuild
+# resolve past the version that wrote the artefact, which unpickles with a
+# warning and then predicts from a degraded model instead of failing (#176).
+# Floor is 1.8+ anyway — the first release with Python 3.14 wheels for this venv.
+# Moving this line means retraining: `python -m engagement.classify.local_model train`.
+scikit-learn>=1.9,<1.10
 # Anthropic SDK for the engagement Phase-3 LLM fallback classifier. Calls are
 # routed through the local LLM hub at http://127.0.0.1:8000 using the
 # version-free alias "claude_haiku" — no direct vendor traffic.

--- a/tests/test_local_model_version_guard.py
+++ b/tests/test_local_model_version_guard.py
@@ -1,0 +1,192 @@
+"""Regression tests for the classifier artefact/runtime version contract (issue #176).
+
+``engagement/classify/local_model.joblib`` is a pickled sklearn pipeline, and a
+pickle is bound to the scikit-learn that wrote it. Loading one across a minor
+boundary emits ``InconsistentVersionWarning`` and then keeps going, so the
+pipeline scores every comment from a degraded model. Nothing raises — the rows
+just land outside both thresholds and read as ``ai=0 human=0 unknown=N``, which
+is indistinguishable from a genuinely ambiguous batch.
+
+These tests pin the guard that turns that into a loud failure: the sidecar
+records the writing version, the loader compares it against the runtime, and a
+minor-version skew raises ``ModelVersionMismatch`` naming both versions.
+
+Every test builds a real (tiny) pipeline and dumps it to a temp dir — no
+database, no network.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import joblib
+import pandas as pd
+import sklearn
+from sklearn.exceptions import InconsistentVersionWarning
+
+from engagement.classify import local_model
+from engagement.classify.local_model import ModelVersionMismatch
+
+RUNTIME_VERSION = sklearn.__version__
+
+
+def _fit_tiny_pipeline():
+    """Smallest pipeline the real featurizer shape supports, fit on toy rows."""
+    rows = [
+        {"text": "great post thanks for sharing", "label": 1},
+        {"text": "great post thanks so much", "label": 1},
+        {"text": "the handoff between teams was our real bottleneck", "label": 0},
+        {"text": "our real bottleneck was the handoff not the tooling", "label": 0},
+    ]
+    frame = pd.DataFrame(
+        [
+            {
+                "text": r["text"],
+                "text_len": len(r["text"]),
+                "is_emoji_only": 0,
+                "generic_praise_hits": 2 if r["label"] else 0,
+                "has_personal_token": 0 if r["label"] else 1,
+                "sub_2_min": r["label"],
+                "exact_text_duplicate": 0,
+            }
+            for r in rows
+        ]
+    )
+    pipeline = local_model._build_pipeline()
+    pipeline.fit(frame, [r["label"] for r in rows])
+    return pipeline, frame
+
+
+class VersionGuardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        tmp = Path(self._tmp.name)
+        self.model_path = tmp / "local_model.joblib"
+        self.meta_path = tmp / "local_model.json"
+
+        original_model, original_meta = local_model.MODEL_PATH, local_model.META_PATH
+        local_model.MODEL_PATH = self.model_path
+        local_model.META_PATH = self.meta_path
+
+        def restore() -> None:
+            local_model.MODEL_PATH = original_model
+            local_model.META_PATH = original_meta
+            local_model._load_model_cached.cache_clear()
+
+        self.addCleanup(restore)
+        local_model._load_model_cached.cache_clear()
+
+        self.pipeline, self.frame = _fit_tiny_pipeline()
+
+    def _write_artefact(self, sklearn_version: str | None) -> None:
+        joblib.dump(self.pipeline, self.model_path)
+        if sklearn_version is not None:
+            self.meta_path.write_text(
+                json.dumps({"platform": "linkedin", "sklearn_version": sklearn_version}),
+                encoding="utf-8",
+            )
+
+    # ---- the lossless "no model yet" path must stay soft ----
+
+    def test_missing_artefact_returns_none(self) -> None:
+        self.assertIsNone(local_model._load_model_cached())
+        self.assertFalse(local_model.model_is_available())
+
+    # ---- matching version loads and predicts ----
+
+    def test_matching_version_loads(self) -> None:
+        self._write_artefact(RUNTIME_VERSION)
+        model = local_model._load_model_cached()
+        self.assertIsNotNone(model)
+        prob = float(model.predict_proba(self.frame.head(1))[0, 1])
+        self.assertTrue(0.0 <= prob <= 1.0)
+
+    def test_patch_level_skew_is_tolerated(self) -> None:
+        """sklearn keeps pickles portable across patch releases — only minor
+        boundaries are a real break, so a patch bump must not block loading."""
+        major, minor = local_model._major_minor(RUNTIME_VERSION)
+        self._write_artefact(f"{major}.{minor}.999")
+        self.assertIsNotNone(local_model._load_model_cached())
+
+    def test_sidecar_without_recorded_version_still_loads(self) -> None:
+        """Artefacts trained before #176 have no `sklearn_version`; they fall
+        through to sklearn's own unpickle warning rather than being rejected."""
+        joblib.dump(self.pipeline, self.model_path)
+        self.meta_path.write_text(json.dumps({"platform": "linkedin"}), encoding="utf-8")
+        self.assertIsNotNone(local_model._load_model_cached())
+
+    # ---- the actual bug: a minor-version skew must fail loudly ----
+
+    def test_recorded_minor_skew_raises_naming_both_versions(self) -> None:
+        major, minor = local_model._major_minor(RUNTIME_VERSION)
+        stale = f"{major}.{minor - 1}.0"
+        self._write_artefact(stale)
+
+        with self.assertRaises(ModelVersionMismatch) as ctx:
+            local_model._load_model_cached()
+
+        message = str(ctx.exception)
+        self.assertIn(stale, message)
+        self.assertIn(RUNTIME_VERSION, message)
+        self.assertIn("local_model train", message)
+
+    def test_unpickle_warning_skew_raises_without_a_sidecar(self) -> None:
+        """The pre-#176 artefact case: no recorded version, but sklearn warns
+        on unpickle. That warning must become an error, not a log line."""
+        joblib.dump(self.pipeline, self.model_path)
+        major, minor = local_model._major_minor(RUNTIME_VERSION)
+        stale = f"{major}.{minor - 1}.0"
+
+        real_load = joblib.load
+
+        def load_with_skew_warning(path, *args, **kwargs):
+            warnings.warn(
+                InconsistentVersionWarning(
+                    estimator_name="LogisticRegression",
+                    current_sklearn_version=RUNTIME_VERSION,
+                    original_sklearn_version=stale,
+                )
+            )
+            return real_load(path, *args, **kwargs)
+
+        with patch.object(joblib, "load", load_with_skew_warning):
+            with self.assertRaises(ModelVersionMismatch) as ctx:
+                local_model._load_model_cached()
+        self.assertIn(stale, str(ctx.exception))
+
+    def test_predict_one_propagates_the_mismatch(self) -> None:
+        """`predict_one` swallows prediction errors into None by design — the
+        version mismatch must not be swallowed with them, or the caller sees a
+        silent `unknown` again."""
+        major, minor = local_model._major_minor(RUNTIME_VERSION)
+        self._write_artefact(f"{major}.{minor - 1}.0")
+
+        with self.assertRaises(ModelVersionMismatch):
+            local_model.predict_one({"text": "great post"}, set())
+
+
+class VersionComparisonTests(unittest.TestCase):
+    def test_major_minor_parsing(self) -> None:
+        self.assertEqual(local_model._major_minor("1.9.0"), (1, 9))
+        self.assertEqual(local_model._major_minor("1.10.2.post1"), (1, 10))
+        self.assertIsNone(local_model._major_minor("not-a-version"))
+
+    def test_compatibility_rules(self) -> None:
+        self.assertTrue(local_model._versions_compatible("1.9.0", "1.9.4"))
+        self.assertFalse(local_model._versions_compatible("1.8.0", "1.9.0"))
+        self.assertFalse(local_model._versions_compatible("1.9.0", "2.0.0"))
+        # Unparseable on either side falls back to an exact string match.
+        self.assertTrue(local_model._versions_compatible("nightly", "nightly"))
+        self.assertFalse(local_model._versions_compatible("nightly", "1.9.0"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`engagement/classify/local_model.joblib` is a pickled sklearn pipeline, and scikit-learn only guarantees pickle portability across *patch* releases. `requirements.txt` lower-bounded `scikit-learn>=1.5` with no ceiling, so a venv rebuild resolved past the version that wrote the artefact. The unpickle "succeeded" with an `InconsistentVersionWarning` and the pipeline then scored every comment from a degraded model — which the engagement pipeline reads as "uncertain, leave for review". Nothing errored, nothing got classified, and the queue grew.

Three changes close the artefact/runtime version contract:

- **Pin** `scikit-learn>=1.9,<1.10` — one minor line, so a rebuild can't silently cross a pickle boundary. The comment now records *why* the ceiling exists (the artefact), not just why the floor does (the Python 3.14 wheels).
- **Record** the writing version: `train()` writes `sklearn_version` into the metadata sidecar, so the loader can compare rather than infer from a warning.
- **Refuse** a skew: `_load_model_cached()` raises `ModelVersionMismatch` naming both versions plus the retrain command. Two gates — the recorded sidecar version, and (for artefacts written before this change, which have no recorded version) sklearn's own unpickle warning, escalated from a log line to an error. A patch-level skew still loads, because that one is genuinely safe.

"No model on disk" deliberately stays a soft `None` — the rules pass is lossless without a model. Only a *skewed* model fails loudly, because that one is not lossless, just quiet. `model_is_available()` is called before `classify_pending` touches the database, so a skew aborts the run rather than writing 84 bogus `unknown` verdicts.

The local (gitignored) artefact was retrained under the pinned version as the remediation — same `train` CLI, no threshold or hyperparameter change.

## Validation

- **Reproduction, before/after on the same 84 pending rows.** Old artefact (pickled by 1.8.0, loaded under 1.9.0): P(AI) spread `[0.149, 0.693]`, **76 of 84 rows fell below 0.30** and went straight to `unknown` without ever reaching the LLM layer. Retrained artefact: spread `[0.006, 0.661]`, **37 rows reach the LLM fallback window** — 4.6× more rows get to the layer that can actually resolve them. That collapse of the score distribution is the degradation the warning was pointing at.
- **Guard fires on the real stale artefact.** Before retraining, loading the on-disk 1.8.0 pickle under 1.9.0 raised `ModelVersionMismatch` naming both versions and the retrain command — via the unpickle-warning gate, since that artefact's sidecar predates `sklearn_version`.
- **Clean load after retraining.** `InconsistentVersionWarning` count: 0. Sidecar records `"sklearn_version": "1.9.0"`. CV AUC 0.864 (5-fold, n=130/150).
- **End-to-end partition is real.** Spot-checked three in-window rows through the LLM fallback: verdicts `human` (0.85), `ai` (0.72), and one at 0.58 correctly staying `unknown`. A genuine ai/human/unknown mix, not `ai=0 human=0 unknown=N`.
- **Tests.** Added `tests/test_local_model_version_guard.py` — the classifier's first coverage. 9 tests, fully offline (builds and pickles a tiny real pipeline in a temp dir; no database, no network): missing artefact stays soft, matching version loads, patch skew tolerated, versionless sidecar still loads, recorded minor skew raises with both versions, unpickle-warning skew raises, and `predict_one` propagates rather than swallowing it into `None`.
- **Gate.** `py_compile` clean; `pytest tests -q` → **46 passed**, 0 failures, 0 skips (also green under `unittest discover tests`). No ruff config in this repo. No `.github/workflows/` — this repo has no CI, so there is no remote check to await.
- **Scope sweep.** `git diff` reviewed: no dependency bumps beyond the intended pin, no removed tests, no weakened assertions or broadened exception handlers.

Closes #176
