### PR TITLE
fix: don't fail the reporting pipeline when substack genuinely posted nothing

### DIFF
--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -17,6 +17,7 @@ import importlib.util
 import logging
 from pathlib import Path
 from datetime import datetime, timedelta
+from typing import Optional
 
 # Add the current directory to the Python path
 sys.path.append(str(Path(__file__).parent))
@@ -107,6 +108,37 @@ def check_endpoint_coverage(config: dict, processing_date: str, failures: "Pipel
 COVERAGE_PLATFORMS = ("linkedin", "instagram", "twitter", "threads", "substack")
 
 
+def _substack_had_editorial_content(day_yyyymmdd: str) -> Optional[bool]:
+    """Whether a Substack editorial row with body text existed for ``day_yyyymmdd``.
+
+    Unlike the other platforms, Substack Notes aren't scheduled automation —
+    ``post_substack_note.py`` publishes only when the day's editorial row exists
+    with non-empty body text, and treats a missing row as a normal no-op (rc=4),
+    not a failure. So a day with no editorial row genuinely has nothing to post,
+    and the resulting gap in ``posts`` is expected, not a coverage bug.
+
+    Returns ``True``/``False``, or ``None`` if the check itself couldn't run
+    (Notion unreachable, config missing) — callers should then fall back to
+    treating the missing metrics as a real failure rather than silently
+    downgrading it on an unverifiable guess.
+    """
+    try:
+        from planning.substack.substack_session import load_notion_token, load_substack_config
+        from reporting.notion.editorial import get_field, get_row_by_day, init_notion_client
+        cfg = load_substack_config()
+        notion = init_notion_client(load_notion_token())
+        if notion is None:
+            return None
+        row = get_row_by_day(notion, cfg["editorial_db_id"], day_yyyymmdd, cfg["notion_columns"])
+        if row is None:
+            return False
+        body_text = get_field(row, "text_body", cfg["notion_columns"]) or ""
+        return bool(str(body_text).strip())
+    except Exception as e:
+        logger.warning(f"⚠️ Could not verify Substack editorial content for {day_yyyymmdd}: {e}")  # type: ignore
+        return None
+
+
 def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> None:
     """Record any platform whose consolidated post metrics are absent for the date.
 
@@ -116,6 +148,10 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
     Here we read the consolidated ``posts`` row that actually feeds Notion and
     flag any platform with neither a video nor a non-video ``post_id``. DB
     errors degrade gracefully (logged) — the run is never crashed by the check.
+
+    Substack is special-cased: if the editorial calendar genuinely had nothing
+    queued for the day these metrics would cover (``processing_date - 1``),
+    the gap is logged as an alert, not recorded as a failure (issue #182).
     """
     try:
         from reporting.process.supabase_uploader import get_db_connection
@@ -139,9 +175,16 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
         data = dict(zip(columns, row))
         for platform in COVERAGE_PLATFORMS:
             has_metrics = data.get(f"post_id_{platform}_no_video") or data.get(f"post_id_{platform}_video")
-            if not has_metrics:
-                failures.missing_post_metrics.append(platform)
-                logger.error(f"❌ Posts-coverage: no post metrics for {platform} on {processing_date}")  # type: ignore
+            if has_metrics:
+                continue
+            if platform == "substack":
+                covered_day = (datetime.strptime(processing_date, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y%m%d")
+                had_content = _substack_had_editorial_content(covered_day)
+                if had_content is False:
+                    logger.warning(f"⚠️ Posts-coverage: substack had no editorial content queued for {covered_day} — no post metrics for {processing_date} is expected, not a failure")  # type: ignore
+                    continue
+            failures.missing_post_metrics.append(platform)
+            logger.error(f"❌ Posts-coverage: no post metrics for {platform} on {processing_date}")  # type: ignore
         if not failures.missing_post_metrics:
             logger.info(f"✅ Posts-coverage: all {len(COVERAGE_PLATFORMS)} platforms have post metrics for {processing_date}")  # type: ignore
     except Exception as e:

--- a/tests/test_posts_coverage_substack_gap.py
+++ b/tests/test_posts_coverage_substack_gap.py
@@ -1,0 +1,124 @@
+"""Regression test: substack coverage gaps with no editorial content queued
+must be an alert, not a failure (issue #182).
+
+``check_posts_coverage`` (issue #84) flags any platform in ``COVERAGE_PLATFORMS``
+whose consolidated ``posts`` row has no ``post_id`` for the date. Before this
+fix, that included days where substack's editorial calendar genuinely had no
+Note queued — a normal, expected state (``post_substack_note.py`` treats a
+missing editorial row as a no-op, not an error) — which nonetheless logged an
+``❌`` error, appended to ``failures.missing_post_metrics``, fired the Slack
+failure alert, and exited the pipeline with code 1.
+
+This reproduces both branches against a mocked DB row with every platform
+present except substack:
+
+* editorial content genuinely absent for the covered day -> warning only,
+  substack excluded from ``failures.missing_post_metrics``.
+* editorial content was queued (or unverifiable) -> unchanged legacy
+  behavior: error logged, substack recorded as a failure.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import reporting_pipeline as rp
+
+
+def _row_missing_only(platform: str) -> tuple[list[str], tuple]:
+    """A consolidated ``posts`` row with every ``COVERAGE_PLATFORMS`` post_id
+    populated except the given platform's (both video and non-video)."""
+    columns = ["date"]
+    values = ["2026-07-25"]
+    for p in rp.COVERAGE_PLATFORMS:
+        for suffix in ("no_video", "video"):
+            columns.append(f"post_id_{p}_{suffix}")
+            values.append(None if p == platform else f"https://example.com/{p}/{suffix}")
+    return columns, tuple(values)
+
+
+class _FakeCursor:
+    def __init__(self, columns: list[str], row: tuple):
+        self._columns = columns
+        self._row = row
+        self.description = [(c,) for c in columns]
+
+    def execute(self, *args, **kwargs):
+        pass
+
+    def fetchone(self):
+        return self._row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, columns: list[str], row: tuple):
+        self._columns = columns
+        self._row = row
+
+    def cursor(self):
+        return _FakeCursor(self._columns, self._row)
+
+    def close(self):
+        pass
+
+
+class PostsCoverageSubstackGapTests(unittest.TestCase):
+    def setUp(self):
+        columns, row = _row_missing_only("substack")
+        self.connection_patch = patch(
+            "reporting.process.supabase_uploader.get_db_connection",
+            return_value=_FakeConnection(columns, row),
+        )
+        self.connection_patch.start()
+        self.addCleanup(self.connection_patch.stop)
+        rp.logger = MagicMock()
+
+    def test_no_editorial_content_is_alert_not_failure(self):
+        """Genuinely empty editorial day: warning only, not a recorded failure."""
+        with patch.object(rp, "_substack_had_editorial_content", return_value=False):
+            failures = rp.PipelineFailures()
+            rp.check_posts_coverage("2026-07-25", failures)
+
+        self.assertNotIn("substack", failures.missing_post_metrics)
+        self.assertFalse(failures.any())
+        self.assertTrue(
+            any("expected, not a failure" in call.args[0] for call in rp.logger.warning.call_args_list),
+            f"expected a warning noting the gap is expected; got: {rp.logger.warning.call_args_list}",
+        )
+        rp.logger.error.assert_not_called()
+
+    def test_editorial_content_was_queued_still_fails(self):
+        """Content WAS queued (or can't be verified) — unchanged hard-failure path."""
+        with patch.object(rp, "_substack_had_editorial_content", return_value=True):
+            failures = rp.PipelineFailures()
+            rp.check_posts_coverage("2026-07-25", failures)
+
+        self.assertIn("substack", failures.missing_post_metrics)
+        self.assertTrue(failures.any())
+        self.assertTrue(
+            any("no post metrics for substack" in call.args[0] for call in rp.logger.error.call_args_list),
+            f"expected the existing error log; got: {rp.logger.error.call_args_list}",
+        )
+
+    def test_unverifiable_editorial_check_still_fails(self):
+        """Notion unreachable (None) — fall back to the safer hard-failure path."""
+        with patch.object(rp, "_substack_had_editorial_content", return_value=None):
+            failures = rp.PipelineFailures()
+            rp.check_posts_coverage("2026-07-25", failures)
+
+        self.assertIn("substack", failures.missing_post_metrics)
+        self.assertTrue(failures.any())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`check_posts_coverage` (issue #84) flagged a platform's missing consolidated post metrics as an identical hard failure for every platform in `COVERAGE_PLATFORMS`. Substack Notes are manually-curated per editorial-calendar row (unlike the other platforms' automated daily posts), so a day with genuinely nothing queued correctly produces no post metrics ??? that's expected, not a regression.

Substack is now special-cased: before recording a coverage miss as a failure, it checks whether the shared editorial DB actually had content queued for the day these metrics would cover (`processing_date - 1`, matching the consolidator's `posted_at = date - 1 day` join). A genuinely empty day logs a warning instead of an error and is excluded from `failures.missing_post_metrics`, so it no longer trips the Slack failure alert or the pipeline's non-zero exit. If content was queued (or the check itself can't be verified ??? Notion unreachable), the existing hard-failure behavior is unchanged.

Other platforms (linkedin, instagram, twitter, threads) are unaffected ??? out of scope per the issue, since they use a different editorial config shape and are automated daily posts, not manually-curated content.

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile reporting_pipeline.py` ??? clean.
- Added `tests/test_posts_coverage_substack_gap.py`, a reproduction of the reported bug: mocks the consolidated `posts` row with every platform present except substack, and exercises all three branches ??? (1) editorial calendar genuinely empty ??? warning only, `substack` excluded from `failures.missing_post_metrics`, no failure; (2) content was queued but metrics still missing ??? unchanged hard-failure/error behavior; (3) editorial check itself unverifiable ??? falls back to the safer hard-failure path. All 3 pass.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests -v` ??? 49 tests, all green (0 skips).
- `git diff main...HEAD` reviewed ??? scoped to `reporting_pipeline.py` + the new test file only.

## Test plan
- [x] Reproduction test demonstrates the false-fail and proves the fix
- [x] Full test suite green
- [x] Diff scoped to the reported issue only

Closes #182