### PR TITLE
feat(newsletter): create Substack draft editions from Notion content

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Four pipelines, one repo:
   tweet domains. **Build** emits the ready-to-paste HTML at
   `results/newsletter/N{NNN}.html`, opens it in the browser, and lets you
   compose the must-read line (interactively in a console, or via the
-  app's picker fed by a topics sidecar).
+  app's picker fed by a topics sidecar). **substack-draft** (optional,
+  separate step) pushes those same grouped lists into a *private*
+  Substack draft edition over the native HTTP API — closing the last
+  manual copy-paste. It never publishes.
 - **Engagement** (`engagement/`) — defends comment threads against
   AI-generated noise using a layered classifier (rules → local sklearn
   model → LLM fallback via the local hub). Scrapes LinkedIn comments
@@ -96,6 +99,7 @@ content-management/                   # repo root
 ├── newsletter/                       # weekly newsletter pipeline (archive + normalize + build)
 │                                     # archive=chrome tabs → notion; normalize_names + normalize_url
 │                                     # rewrite titles + clean URLs; build_newsletter renders HTML
+│                                     # substack_draft pushes the same lists to a private Substack draft
 ├── engagement/                       # anti-AI comment triage (rules → sklearn → LLM fallback)
 │   ├── linkedin/                     # LinkedIn comment scraper
 │   ├── classify/                     # layered classifier + phrase config

--- a/app/tab_newsletter.py
+++ b/app/tab_newsletter.py
@@ -1,10 +1,15 @@
-"""Newsletter pipeline tab — bootstrap → archive → normalize → build HTML.
+"""Newsletter pipeline tab — bootstrap → archive → normalize → build HTML,
+plus the optional Substack draft step.
 
 Each step is an independent, non-interactive subcommand of
 ``newsletter_pipeline.py`` (issue #59). All buttons share the single
 ``"newsletter"`` process slot, so the status badge / log panel / sidebar
 status work unchanged. The must-read picker reads the topics sidecar that
 ``build`` writes, so it never blocks on stdin.
+
+⑤ Substack draft (issue #184) is deliberately outside the ▶ combo — it writes
+to an external platform, so it stays an explicit, separately-clicked action. It
+creates a **private** draft and never publishes.
 """
 
 from __future__ import annotations
@@ -28,7 +33,8 @@ def run() -> None:
     st.subheader("📰 newsletter — weekly archive + build")
     st.caption(
         "① Bootstrap Chrome → open your article tabs → ② Archive into Notion → "
-        "③ Normalize titles + URLs → ④ Build HTML. Run any step alone, or ▶ for ②③④."
+        "③ Normalize titles + URLs → ④ Build HTML. Run any step alone, or ▶ for ②③④. "
+        "⑤ pushes the same lists into a private Substack draft."
     )
 
     cols = st.columns([2, 2, 2])
@@ -114,33 +120,78 @@ def run() -> None:
     render_status_badge(PIPELINE_NAME)
     render_log_panel(PIPELINE_NAME)
 
-    _render_must_read_picker(num)
+    must_read = _render_must_read_picker(num)
+    _render_substack_draft(num, has_num, running, base, dbg, must_read)
 
 
-def _render_must_read_picker(newsletter_number: str) -> None:
+def _render_substack_draft(
+    newsletter_number: str,
+    has_num: bool,
+    running: bool,
+    base: list[str],
+    dbg: list[str],
+    must_read: int | None,
+) -> None:
+    """⑤ Create a private Substack draft edition from the built lists.
+
+    Sits below the must-read picker so the chosen line can be folded into the
+    draft as its opening paragraph. Never publishes — there is no ``--confirm``
+    on this path at all (see ``newsletter/substack_draft.py``).
+    """
+    st.divider()
+    st.markdown("**⑤ Substack draft**")
+
+    args = base + ["substack-draft", "--newsletter", newsletter_number]
+    if must_read is not None:
+        args += ["--must-read", str(must_read)]
+    args += dbg
+
+    st.button(
+        "⑤ Create Substack draft",
+        key="newsletter-substack-draft",
+        disabled=running or not has_num,
+        on_click=start_pipeline,
+        args=(PIPELINE_NAME, args),
+        help="Build a private Substack draft edition from this newsletter's "
+             "articles. Nothing is sent to subscribers — you review and publish "
+             "from the Substack editor.",
+    )
+
+    if not has_num:
+        st.caption("ℹ️ enter a newsletter number to enable ⑤.")
+    elif must_read is not None:
+        st.caption(f"→ creates a **private** draft, opening with must-read #{must_read}. Never publishes.")
+    else:
+        st.caption("→ creates a **private** draft (no must-read line). Never publishes.")
+
+
+def _render_must_read_picker(newsletter_number: str) -> int | None:
     """Compose the must-read line from the topics sidecar a build wrote.
 
     Reads ``results/newsletter/N{NNN}.topics.json`` and lets the user pick which
     of the three top articles is the "must read"; the composed line is shown in
     a copyable ``st.code`` block. No subprocess, no clipboard — pure UI.
+
+    Returns the chosen 1-based index so ⑤ can pass it to the draft step, or
+    ``None`` when no sidecar exists / the line is unavailable.
     """
     if not newsletter_number:
-        return
+        return None
     # Imported here (not at module load) to keep app startup light.
     from newsletter.build_newsletter import format_must_read_line, topics_sidecar_path
 
     try:
         path = topics_sidecar_path(newsletter_number)
     except ValueError:
-        return  # not a valid number yet (e.g. "59") — nothing to show
+        return None  # not a valid number yet (e.g. "59") — nothing to show
     if not path.exists():
-        return
+        return None
 
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         st.warning("⚠️ couldn't read the topics sidecar.")
-        return
+        return None
 
     st.divider()
     st.markdown("**must-read line**")
@@ -148,7 +199,7 @@ def _render_must_read_picker(newsletter_number: str) -> None:
     top_names = data.get("top_names")
     if not top_names:
         st.warning("⚠️ must-read unavailable — a topic has no articles in this issue.")
-        return
+        return None
 
     headings = data.get("headings") or []
     labels = [
@@ -165,3 +216,4 @@ def _render_must_read_picker(newsletter_number: str) -> None:
     line = format_must_read_line(top_names, int(choice))
     st.code(line, language=None)
     st.caption("copy the line above ☝️")
+    return int(choice)

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -18,7 +18,7 @@ flowchart TB
 
   RPIPE["reporting_pipeline.py"]
   PPIPE["planning_pipeline.py --all-wip"]
-  NPIPE["newsletter_pipeline.py\nbootstrap / archive / normalize / build"]
+  NPIPE["newsletter_pipeline.py\nbootstrap / archive / normalize / build /\nsubstack-draft"]
   APP["app/app.py — Streamlit control panel\ntab_reporting · tab_planning · tab_newsletter ·\ntab_editorial · tab_engagement"]
   AUTOHEAL["app/autoheal_console.py"]
 
@@ -70,11 +70,15 @@ flowchart TB
     NARCHIVE["chrome_tabs + extractor +\nauthor_resolver + summarizer/llm"]
     NNORM["normalize_names + normalize_url"]
     NBUILD["build_newsletter.py"]
+    NSBDRAFT["substack_draft.py\n(optional, explicit step)"]
   end
   NPIPE --> NBOOT --> NARCHIVE --> NNORM --> NBUILD
   NARCHIVE -->|"readability-lxml extraction"| NOTION
   NARCHIVE --> LLMHUB[("local LLM hub\n127.0.0.1:8000\ntopic + 3-line summary")]
   NBUILD --> RESULTSNEWS[["results/newsletter/N{NNN}.html"]]
+  NPIPE -->|"substack-draft"| NSBDRAFT
+  NSBDRAFT -->|"same grouped articles"| NOTION
+  NSBDRAFT -->|"create_draft_from_sections\n(cookie auth, no browser)"| SBAPI[("Substack private HTTP API\nprivate draft — never published")]
 
   subgraph engagement_mod["engagement/ — anti-AI comment triage"]
     ESCRAPE["linkedin/scrape_comments.py"]

--- a/docs/substack-native-api.md
+++ b/docs/substack-native-api.md
@@ -64,6 +64,7 @@ to avoid the library's construction-time round-trips.
 | List published posts | `GET /<pub>/post_management/published` | Returns an envelope `{posts, total, …}`; posts carry `title`/`slug`/`post_date`/`type`/`audience` but **no** body or `canonical_url`. |
 | Full post body | `GET /<pub>/posts/by-id/{id}` | Adds `body_html` + `canonical_url`. One extra GET per post (`--with-body`). |
 | Create draft | `POST /<pub>/drafts` | Private; emails no one. |
+| Read draft back | `GET /<pub>/drafts/{id}` | Used to verify the stored body round-trips (see *Body shape* below). |
 | Edit draft | `PUT /<pub>/drafts/{id}` | |
 | Pre-publish validate | `GET /<pub>/drafts/{id}/prepublish` | Returns `{errors, suggestions}`; does not publish. |
 | Publish | `POST /<pub>/drafts/{id}/publish` | **Irreversible** — emails the whole list. Gated behind explicit `--confirm`; never in the cron. |
@@ -84,6 +85,34 @@ envelope, so `save_results` → `data_processor` → `profile_aggregator` →
 back to the browser scrape. The block keeps its `api_url`/`api_key` keys because
 the endpoint loop only iterates blocks that have an `api_url`.
 
+## Body shape: ProseMirror, built explicitly
+
+A draft body is ProseMirror JSON, not HTML or markdown. The weekly newsletter's
+sectioned layout (a heading per topic, a bullet list of linked article titles) is
+built node-by-node in `planning/substack/api_client.py::build_section_nodes`:
+
+```
+paragraph    — optional intro (the must-read line)
+heading      — attrs.level = 2, one per topic
+bullet_list  — list_item > paragraph > text node carrying a `link` mark
+```
+
+Two findings from building it, both verified against the live API:
+
+- **`Post.from_markdown` cannot express this shape.** Given a `##` heading
+  followed by `- [title](url)` lines, it folds the bullet lines into the
+  *heading's own text node* — the list and every link are destroyed, silently.
+  The nodes are therefore constructed directly. `tests/test_substack_draft_sections.py`
+  pins the resulting structure so a refactor back to `from_markdown` fails loudly.
+- **Node names are snake_case** (`bullet_list`, `list_item`), not the camelCase
+  many ProseMirror schemas use. Confirmed by creating a draft and reading it back
+  via `GET /drafts/{id}`: the stored body matched what was sent, link marks
+  intact.
+
+Article titles are emitted as **literal text nodes**, never run through
+`parse_inline`. Titles are scraped from arbitrary sites and routinely contain
+`*`, `[` or backticks that markdown parsing would mangle.
+
 ## Known fragility (be honest)
 
 - Endpoints are undocumented and can change without notice. Concrete example: the
@@ -101,6 +130,14 @@ the endpoint loop only iterates blocks that have an `api_url`.
 ## Scope today vs. follow-ups
 
 Shipped: native follower count (daily default) + manual archive pull + manual
-draft create/edit/prepublish/publish. Deferred: wiring create/publish to the
-Notion editorial database; migrating Note posting + note-engagement off Playwright;
-"like" support. Tracked on issue #91.
+draft create/edit/prepublish/publish (issue #91), and the weekly newsletter's
+`substack-draft` step (issue #184) — `newsletter/substack_draft.py` builds a
+private draft edition from the Notion articles DB, never publishing.
+
+Note that the *editorial* database was the wrong source for an edition: it has no
+newsletter/edition columns (its Substack columns drive the daily short-form
+Note). The newsletter's own articles + newsletter DBs are the real source, which
+is why the step lives in `newsletter/` rather than `planning/substack/`.
+
+Deferred: migrating Note posting + note-engagement off Playwright (#185);
+"like" support (#186).

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -31,7 +31,12 @@ flowchart LR
         L --> M[render HTML<br/>results/newsletter/N{NNN}.html]
         M --> N[prompt must-read<br/>copy line to clipboard]
     end
+    subgraph S5[5. Substack draft — optional]
+        O[same grouped articles] --> P[native HTTP API<br/>cookie auth]
+        P --> Q[private draft edition<br/>never published]
+    end
     S1 --> S2 --> S3 --> S4
+    S4 -.-> S5
 ```
 
 ## One-time setup
@@ -112,6 +117,7 @@ The pipeline is split into independent, non-interactive subcommands (issue #59)
 | `newsletter_pipeline.py build --newsletter 057 [--no-open] [--must-read 1\|2\|3 \| --no-must-read]` | Render HTML + write the topics sidecar. |
 | `newsletter_pipeline.py create --newsletter 057 [--days 14]` | archive → normalize → build (non-interactive). |
 | `newsletter_pipeline.py all [--newsletter 057] [--days 14]` | Full interactive console sequence (default when no subcommand). |
+| `newsletter_pipeline.py substack-draft --newsletter 057 [--title T] [--subtitle S] [--must-read 1\|2\|3] [--delete-after]` | Create a **private** Substack draft edition from the same Notion content. Never publishes. |
 
 Lower-level module entry points:
 
@@ -126,6 +132,7 @@ Lower-level module entry points:
 | `python -m newsletter.normalize_names --days 14 [--dry-run]` | Rewrite article titles to sentence case. |
 | `python -m newsletter.normalize_url --days 14 [--dry-run] [--testing]` | Strip URL query params; `--testing` HEAD/GETs each cleaned URL. |
 | `python -m newsletter.build_newsletter --newsletter 057` | Render HTML for newsletter 057 and copy the must-read line to clipboard. |
+| `python -m newsletter.substack_draft --newsletter 057` | Create the private Substack draft edition directly. |
 
 Add `--debug` to any of the above for verbose logs. All runs append to
 `logs/newsletter_archive.log` (archive entry points) or stdout (the
@@ -219,3 +226,37 @@ byline. The fallback exists so the pipeline never invents people.
   cases + common words.
 - `normalize_url.py` — URL query-param stripper with preserve list.
 - `build_newsletter.py` — HTML builder + must-read line; writes the `N{NNN}.topics.json` sidecar the app's must-read picker reads.
+- `substack_draft.py` — pushes the same grouped article lists into a private Substack draft edition over the native HTTP API.
+
+## Substack draft edition
+
+The last step of the weekly run used to be manual: open
+`results/newsletter/N{NNN}.html`, copy it, paste into the Substack editor.
+`substack-draft` does that over Substack's native HTTP API instead — no browser,
+no DOM selectors.
+
+```powershell
+& .\.venv\Scripts\python.exe newsletter_pipeline.py substack-draft --newsletter 057 --must-read 1
+```
+
+It reads exactly what `build` reads (the Notion articles + newsletter DBs) and
+reuses the same grouping/sorting, so the draft and the HTML can't drift. Each
+topic becomes an `<h2>`-equivalent heading followed by a bullet list of linked
+article titles; `--must-read N` prepends the composed must-read line as the
+opening paragraph.
+
+- **It never publishes.** The draft is private and emails no one — publishing
+  stays a deliberate action in the Substack editor. There is no `--confirm`
+  flag here by design (`planning/substack/api_create.py` is the manual path that
+  can publish).
+- **Not part of `create` / `all`.** It writes to an external platform, so it
+  stays an explicit, separately re-runnable step.
+- `--delete-after` creates and immediately deletes the draft — the smoke test
+  for "is my cookie still good and does the body build cleanly?".
+- Needs the harvested API session (`planning/substack/api_session.json`, ~89-day
+  cookie). On expiry the step exits `2` with a single line telling you to re-run
+  `python -m planning.substack.extract_session`.
+
+Article titles are inserted as **literal text**, never parsed as markdown —
+titles scraped from arbitrary sites routinely contain `*`, `[` or backticks that
+markdown parsing would mangle.

--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -265,7 +265,7 @@ def format_must_read_line(three_names: Sequence[str], must_read: int) -> str:
 
 def topics_sidecar_path(newsletter_number: str) -> Path:
     """Path of the topics sidecar JSON for a newsletter number (``057``/``N057``)."""
-    return RESULTS_DIR / f"{_normalize_newsletter_number(newsletter_number)}.topics.json"
+    return RESULTS_DIR / f"{normalize_newsletter_number(newsletter_number)}.topics.json"
 
 
 def _write_topics_sidecar(
@@ -339,7 +339,9 @@ def prompt_must_read_line(topics: Sequence[str],
 # ---------------------------------------------------------------- entry points
 
 
-def _normalize_newsletter_number(raw: str) -> str:
+def normalize_newsletter_number(raw: str) -> str:
+    """Normalise ``057``/``N057`` to the canonical ``N057``. Shared with
+    :mod:`newsletter.substack_draft`, which keys the draft title off it."""
     val = raw.strip().upper()
     if re.fullmatch(r"\d{3}", val):
         return f"N{val}"
@@ -364,7 +366,7 @@ def run(newsletter_number: str, debug: bool = False, *,
     * else → write the HTML + sidecar only (the app's non-blocking path).
     """
     _setup_logging(debug)
-    nl_num = _normalize_newsletter_number(newsletter_number)
+    nl_num = normalize_newsletter_number(newsletter_number)
     builder = NotionNewsletterBuilder()
     _, grouped = builder.build_newsletter(nl_num)
 

--- a/newsletter/substack_draft.py
+++ b/newsletter/substack_draft.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Create a Substack DRAFT edition from a newsletter's Notion content.
+
+Closes the last manual step of the weekly newsletter run: instead of
+copy-pasting ``results/newsletter/N{NNN}.html`` into the Substack editor by
+hand, this builds the same grouped article lists straight into a Substack draft
+over the native HTTP API (cookie auth — no browser, no DOM selectors).
+
+Reads exactly what ``build_newsletter`` reads (the Notion articles + newsletter
+databases) and reuses its grouping/sorting, so the draft and the HTML can never
+drift apart.
+
+**Never publishes.** The draft is private and emails no one; publishing stays a
+deliberate human action in the Substack editor. There is no ``--confirm`` here
+by design — see ``planning/substack/api_create.py`` for the manual path that
+can publish.
+
+Requires a harvested API session (``planning/substack/api_session.json``, ~89
+day cookie). If it has expired, ``SessionExpiredError`` is reported as a single
+actionable line pointing at ``planning.substack.extract_session``.
+
+CLI:
+    python -m newsletter.substack_draft --newsletter 057
+    python -m newsletter.substack_draft --newsletter 057 --must-read 2
+    python -m newsletter.substack_draft --newsletter 057 --delete-after
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from config.loader import load_block
+from newsletter.build_newsletter import (
+    NotionNewsletterBuilder,
+    format_must_read_line,
+    normalize_newsletter_number,
+    top_article_names_by_topic,
+)
+
+# NOTE: config comes from ``config.loader`` rather than
+# ``planning.substack.substack_session.load_substack_config`` on purpose — the
+# latter transitively imports Playwright, and this path is pure HTTP.
+from planning.substack.api_client import SessionExpiredError, SubstackAPI
+
+Grouped = Dict[str, List[Tuple[str, str]]]
+Sections = List[Tuple[str, List[Tuple[str, str]]]]
+
+
+def build_sections(grouped: Grouped, topics: Sequence[str]) -> Sections:
+    """Map ``{topic: [(title, url)]}`` to ``[(heading, [(title, url)])]``.
+
+    The heading derivation mirrors ``build_newsletter.generate_html_lists`` so
+    the draft's section titles match the HTML build exactly. Topics with no
+    articles are kept (as an empty list) for the same reason — the HTML emits an
+    empty ``<ul>`` rather than dropping the heading.
+
+    Pure — no Notion, no Substack — so it is unit-testable on its own.
+    """
+    return [
+        (topic[0].upper() + topic[1:], list(grouped.get(topic) or []))
+        for topic in topics
+    ]
+
+
+def compose_intro(
+    topics: Sequence[str], grouped: Grouped, must_read: Optional[int]
+) -> Optional[str]:
+    """The must-read line to use as the draft's opening paragraph, if available.
+
+    ``None`` when no choice was made, or when a topic has no articles (the same
+    condition under which ``build_newsletter`` reports the line unavailable).
+    """
+    if must_read is None:
+        return None
+    top_names = top_article_names_by_topic(topics, grouped)
+    if top_names is None:
+        logging.warning("⚠️ Cannot compose must-read line: a topic has no articles")
+        return None
+    return format_must_read_line(top_names, must_read)
+
+
+def run(
+    newsletter_number: str,
+    *,
+    title: Optional[str] = None,
+    subtitle: str = "",
+    must_read: Optional[int] = None,
+    delete_after: bool = False,
+    debug: bool = False,
+) -> Optional[str]:
+    """Build the newsletter's Substack draft. Returns the draft edit URL.
+
+    Returns ``None`` when ``delete_after`` removed the throwaway draft.
+    """
+    _setup_logging(debug)
+    nl_num = normalize_newsletter_number(newsletter_number)
+
+    builder = NotionNewsletterBuilder()
+    _, grouped = builder.build_newsletter(nl_num)
+    sections = build_sections(grouped, builder.topics)
+    intro = compose_intro(builder.topics, grouped, must_read)
+
+    total = sum(len(articles) for _, articles in sections)
+    logging.info("📝 Building Substack draft for %s — %d articles across %d sections",
+                 nl_num, total, len(sections))
+
+    cfg = load_block("substack")
+    publish_url = cfg.get("publish_url", "")
+    api = SubstackAPI(publication_url=publish_url)
+    draft = api.create_draft_from_sections(
+        title=title or nl_num,
+        subtitle=subtitle,
+        sections=sections,
+        intro=intro,
+    )
+    draft_id = draft.get("id")
+    logging.info("✅ Draft created — id=%s", draft_id)
+
+    verdict = api.prepublish(draft_id)
+    errors = verdict.get("errors") if isinstance(verdict, dict) else None
+    logging.info("🔎 Prepublish — errors=%s", errors or "none")
+
+    if delete_after:
+        api.delete_draft(draft_id)
+        logging.info("🗑️ Draft %s deleted (smoke test).", draft_id)
+        return None
+
+    edit_url = f"{publish_url.rsplit('/publish/', 1)[0]}/publish/post/{draft_id}"
+    logging.info("🛑 Draft only — nothing was sent. Review, then publish from Substack:")
+    logging.info("   %s", edit_url)
+    return edit_url
+
+
+def _setup_logging(debug: bool = False) -> None:
+    level = logging.DEBUG if debug else logging.INFO
+    from config.console import force_utf8_stdio
+    force_utf8_stdio()
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stdout)],
+        )
+    else:
+        logging.getLogger().setLevel(level)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a Substack DRAFT edition from a newsletter's Notion content."
+    )
+    parser.add_argument("--newsletter", required=True,
+                        help="Newsletter number (057 or N057).")
+    parser.add_argument("--title", default=None,
+                        help="Draft title (defaults to the newsletter number).")
+    parser.add_argument("--subtitle", default="")
+    parser.add_argument("--must-read", type=int, choices=(1, 2, 3), default=None,
+                        help="Compose the must-read line as the opening paragraph.")
+    parser.add_argument("--delete-after", action="store_true",
+                        help="Delete the draft after creating it (smoke test).")
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        run(
+            args.newsletter,
+            title=args.title,
+            subtitle=args.subtitle,
+            must_read=args.must_read,
+            delete_after=args.delete_after,
+            debug=args.debug,
+        )
+    except SessionExpiredError as err:
+        logging.error("❌ %s", err)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter_pipeline.py
+++ b/newsletter_pipeline.py
@@ -14,6 +14,8 @@ Subcommands::
                                      [--must-read 1|2|3 | --no-must-read]
     newsletter_pipeline.py create    --newsletter NNN [--days 14] [--debug]
     newsletter_pipeline.py all       [--newsletter NNN] [--days 14] [--debug]
+    newsletter_pipeline.py substack-draft --newsletter NNN [--title T] [--subtitle S]
+                                     [--must-read 1|2|3] [--delete-after] [--debug]
 
 * ``bootstrap`` launches the dedicated newsletter Chrome on :9222 **without**
   killing the everyday browser (see ``newsletter/bootstrap_chrome.py``).
@@ -23,6 +25,9 @@ Subcommands::
   "open your tabs, press Enter" pause (you can't archive tabs that aren't open
   yet) -> archive -> normalize -> build with the interactive must-read prompt.
 * No subcommand defaults to ``all`` so existing muscle memory keeps working.
+* ``substack-draft`` pushes the built lists into a private Substack draft over
+  the native HTTP API. Deliberately **not** part of ``create`` / ``all``: it
+  writes to an external platform, so it stays an explicit, re-runnable step.
 
 Mirrors the shape of ``reporting_pipeline.py`` / ``planning_pipeline.py``.
 """
@@ -45,6 +50,7 @@ force_utf8_stdio()
 from newsletter import bootstrap_chrome  # noqa: E402
 from newsletter import build_newsletter, normalize_names, normalize_url  # noqa: E402
 from newsletter import pipeline as archive_pipeline  # noqa: E402
+from newsletter import substack_draft  # noqa: E402
 
 logger = logging.getLogger("newsletter_pipeline")
 
@@ -113,6 +119,21 @@ def step_build(newsletter_number: str | None, debug: bool, *,
         open_browser=open_browser, must_read=must_read,
     )
     print(f"🎉 Newsletter HTML: {out_path}")
+    return 0
+
+
+def step_substack_draft(newsletter_number: str, debug: bool, *,
+                        title: str | None, subtitle: str,
+                        must_read: int | None, delete_after: bool) -> int:
+    _banner("create Substack draft edition (private — nothing is sent)")
+    try:
+        substack_draft.run(
+            newsletter_number, title=title, subtitle=subtitle,
+            must_read=must_read, delete_after=delete_after, debug=debug,
+        )
+    except substack_draft.SessionExpiredError as err:
+        print(f"❌ {err}")
+        return 2
     return 0
 
 
@@ -203,6 +224,18 @@ def main(argv: list[str] | None = None) -> int:
     _add_days(p_create)
     p_create.add_argument("--debug", action="store_true")
 
+    p_sbd = sub.add_parser("substack-draft",
+                           help="Create a private Substack draft edition from the newsletter")
+    _add_newsletter(p_sbd, required=True)
+    p_sbd.add_argument("--title", default=None,
+                       help="Draft title (defaults to the newsletter number)")
+    p_sbd.add_argument("--subtitle", default="")
+    p_sbd.add_argument("--must-read", type=int, choices=(1, 2, 3), default=None,
+                       help="Compose the must-read line as the opening paragraph")
+    p_sbd.add_argument("--delete-after", action="store_true",
+                       help="Delete the draft after creating it (smoke test)")
+    p_sbd.add_argument("--debug", action="store_true")
+
     p_all = sub.add_parser("all", help="Full interactive console sequence")
     _add_newsletter(p_all, required=False)
     _add_days(p_all)
@@ -226,6 +259,12 @@ def main(argv: list[str] | None = None) -> int:
             interactive_must_read=interactive,
             open_browser=not args.no_open,
             must_read=args.must_read,
+        )
+    if cmd == "substack-draft":
+        return step_substack_draft(
+            args.newsletter, debug=debug,
+            title=args.title, subtitle=args.subtitle,
+            must_read=args.must_read, delete_after=args.delete_after,
         )
     if cmd == "create":
         return run_create(days=args.days, newsletter_number=args.newsletter, debug=debug)

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -42,6 +42,12 @@ api_pull.py          — manual CLI: dump a post archive to JSON
 api_create.py        — manual CLI: create a draft edition (publish only with --confirm)
 ```
 
+The weekly newsletter has its own consumer of this client:
+`newsletter/substack_draft.py` (`newsletter_pipeline.py substack-draft`) builds a
+private draft edition from the Notion articles DB via
+`SubstackAPI.create_draft_from_sections`. It never publishes — see
+[`newsletter/README.md`](../../newsletter/README.md).
+
 One-time / once-per-~89-days setup (the `substack.sid` cookie lives ~89 days):
 
 ```powershell
@@ -86,10 +92,16 @@ substack/
 ├── README.md                       — this file
 ├── substack_session.py             — Playwright context + storage_state lifecycle
 ├── bootstrap_session.py            — one-time headed login; writes storage_state.json
-├── notion_editorial.py             — read/write editorial rows (role→column map)
 ├── post_substack_note.py           — publish Note
+├── post_substack_video_note.py     — video-day branch for the weekly clip
 └── daily_pipeline.py               — orchestrator; CLI entry
 ```
+
+Editorial rows are read through the shared helper
+`reporting/notion/editorial.py` (`get_row_by_day` / `get_field` / `set_field`,
+resolved against the `notion_columns` role map below) — this package has no
+Notion module of its own. The native-API modules are listed in the section
+above.
 
 ## Prerequisites
 

--- a/planning/substack/api_client.py
+++ b/planning/substack/api_client.py
@@ -61,6 +61,7 @@ __all__ = [
     "SessionExpiredError",
     "load_session",
     "fetch_follower_count",
+    "build_section_nodes",
     "SubstackAPI",
     "SESSION_FILE",
 ]
@@ -120,6 +121,60 @@ def fetch_follower_count(session_file: Path = SESSION_FILE) -> int:
             f"(got {type(count).__name__}). Endpoint may have changed."
         )
     return count
+
+
+def _text_node(text: str, href: Optional[str] = None) -> dict:
+    """One ProseMirror text node, optionally carrying a link mark."""
+    node: dict = {"type": "text", "text": text}
+    if href:
+        node["marks"] = [{"type": "link", "attrs": {"href": href}}]
+    return node
+
+
+def build_section_nodes(
+    sections: list[tuple[str, list[tuple[str, str]]]],
+    *,
+    intro: Optional[str] = None,
+) -> list[dict]:
+    """Build the ProseMirror body nodes for a sectioned edition.
+
+    ``sections`` is ``[(heading, [(link_text, url), ...]), ...]`` — one heading
+    per topic, one linked bullet per article. ``intro``, when given, becomes the
+    first paragraph.
+
+    Text is emitted as **literal** text nodes rather than parsed as markdown:
+    article titles come from arbitrary web pages and routinely contain ``[``,
+    ``*`` or backticks, which markdown parsing would silently mangle.
+
+    Pure (no session, no network) so it can be unit-tested on its own.
+
+    NOTE: the library's ``Post.from_markdown`` cannot express this shape — it
+    folds bullet lines that follow a heading into the heading's own text node,
+    destroying the links. Hence the explicit node construction here.
+    """
+    nodes: list[dict] = []
+    if intro:
+        nodes.append({"type": "paragraph", "content": [_text_node(intro)]})
+    for heading, articles in sections:
+        nodes.append(
+            {
+                "type": "heading",
+                "content": [_text_node(heading)],
+                "attrs": {"level": 2},
+            }
+        )
+        items = [
+            {
+                "type": "list_item",
+                "content": [{"type": "paragraph", "content": [_text_node(name, url)]}],
+            }
+            for name, url in articles
+        ]
+        # An empty bullet_list is not valid ProseMirror — emit the heading alone
+        # for a topic that collected no articles.
+        if items:
+            nodes.append({"type": "bullet_list", "content": items})
+    return nodes
 
 
 class SubstackAPI:
@@ -224,6 +279,28 @@ class SubstackAPI:
             url = uploaded.get("url")
             if url:
                 post.add({"type": "captionedImage", "src": url})
+        return self._api.post_draft(post.get_draft())
+
+    def create_draft_from_sections(
+        self,
+        title: str,
+        subtitle: str,
+        sections: list[tuple[str, list[tuple[str, str]]]],
+        *,
+        intro: Optional[str] = None,
+        audience: str = "everyone",
+    ) -> dict:
+        """Create a newsletter edition DRAFT laid out as headed link sections.
+
+        The weekly-newsletter counterpart to :meth:`create_draft` (which is
+        paragraph-shaped and drives the manual ``api_create`` CLI). Private —
+        emails no one. Returns the created draft dict (carries ``id``).
+
+        See :func:`build_section_nodes` for the body shape and why the nodes are
+        built explicitly rather than through the library's markdown path.
+        """
+        post = Post(title, subtitle, self.user_id, audience=audience)
+        post.draft_body["content"].extend(build_section_nodes(sections, intro=intro))
         return self._api.post_draft(post.get_draft())
 
     def update_draft(self, draft_id: int, **fields) -> dict:

--- a/tests/test_substack_draft_sections.py
+++ b/tests/test_substack_draft_sections.py
@@ -1,0 +1,114 @@
+"""The newsletter -> Substack draft body must be structurally correct (issue #184).
+
+``newsletter/substack_draft.py`` turns ``build_newsletter``'s grouped articles
+into a Substack draft. The body is ProseMirror JSON, and a malformed body fails
+silently — it produces a draft that *exists* but renders as plain text with dead
+links, which you only notice by eye in the Substack editor.
+
+Two things are pinned here, both pure (no Notion, no Substack, no network):
+
+* ``build_sections`` mirrors the HTML builder — same headings, same order, empty
+  topics kept rather than dropped.
+* ``build_section_nodes`` emits real ``bullet_list``/``list_item`` nodes with
+  ``link`` marks, and treats article titles as **literal text**. The library's
+  ``Post.from_markdown`` cannot express this shape (it folds bullets that follow
+  a heading into the heading's own text node), which is why the nodes are built
+  explicitly — this test is what stops a well-meaning refactor back to it.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from newsletter.substack_draft import build_sections, compose_intro
+from planning.substack.api_client import build_section_nodes
+
+TOPICS = ["personal development", "innovation", "leadership and management"]
+
+
+class BuildSectionsTests(unittest.TestCase):
+    def test_headings_match_the_html_builder(self):
+        grouped = {t: [] for t in TOPICS}
+        headings = [h for h, _ in build_sections(grouped, TOPICS)]
+        self.assertEqual(
+            headings,
+            ["Personal development", "Innovation", "Leadership and management"],
+        )
+
+    def test_topic_order_and_articles_preserved(self):
+        grouped = {
+            "personal development": [("A", "https://a"), ("B", "https://b")],
+            "innovation": [("C", "https://c")],
+            "leadership and management": [],
+        }
+        sections = build_sections(grouped, TOPICS)
+        self.assertEqual([len(a) for _, a in sections], [2, 1, 0])
+        self.assertEqual(sections[0][1][0], ("A", "https://a"))
+
+    def test_empty_topic_keeps_its_heading(self):
+        """The HTML build emits an empty <ul> rather than dropping the topic."""
+        sections = build_sections({t: [] for t in TOPICS}, TOPICS)
+        self.assertEqual(len(sections), 3)
+
+
+class BuildSectionNodesTests(unittest.TestCase):
+    def test_linked_bullets_carry_link_marks(self):
+        nodes = build_section_nodes([("Innovation", [("The new stack", "https://x/c")])])
+        self.assertEqual([n["type"] for n in nodes], ["heading", "bullet_list"])
+        self.assertEqual(nodes[0]["attrs"]["level"], 2)
+
+        items = nodes[1]["content"]
+        self.assertEqual(len(items), 1)
+        text_node = items[0]["content"][0]["content"][0]
+        self.assertEqual(text_node["text"], "The new stack")
+        self.assertEqual(
+            text_node["marks"], [{"type": "link", "attrs": {"href": "https://x/c"}}]
+        )
+
+    def test_empty_topic_emits_heading_without_empty_bullet_list(self):
+        """An empty bullet_list is not valid ProseMirror."""
+        nodes = build_section_nodes([("Innovation", [])])
+        self.assertEqual([n["type"] for n in nodes], ["heading"])
+
+    def test_titles_are_literal_text_not_markdown(self):
+        """Article titles come from arbitrary web pages — markdown-ish characters
+        must survive verbatim rather than being parsed into marks or eaten."""
+        title = "Why *args and [brackets] break `parsers`"
+        nodes = build_section_nodes([("Innovation", [(title, "https://x")])])
+        text_node = nodes[1]["content"][0]["content"][0]["content"][0]
+        self.assertEqual(text_node["text"], title)
+        self.assertEqual([m["type"] for m in text_node["marks"]], ["link"])
+
+    def test_intro_becomes_the_first_paragraph(self):
+        nodes = build_section_nodes([("Innovation", [])], intro="Read this first.")
+        self.assertEqual(nodes[0]["type"], "paragraph")
+        self.assertEqual(nodes[0]["content"][0]["text"], "Read this first.")
+        self.assertNotIn("marks", nodes[0]["content"][0])
+
+    def test_no_intro_means_no_leading_paragraph(self):
+        nodes = build_section_nodes([("Innovation", [])])
+        self.assertEqual(nodes[0]["type"], "heading")
+
+
+class ComposeIntroTests(unittest.TestCase):
+    FULL = {
+        "personal development": [("A", "https://a")],
+        "innovation": [("B", "https://b")],
+        "leadership and management": [("C", "https://c")],
+    }
+
+    def test_none_when_no_choice_made(self):
+        self.assertIsNone(compose_intro(TOPICS, self.FULL, None))
+
+    def test_none_when_a_topic_has_no_articles(self):
+        sparse = dict(self.FULL, innovation=[])
+        self.assertIsNone(compose_intro(TOPICS, sparse, 1))
+
+    def test_choice_reorders_the_named_topic_first(self):
+        self.assertTrue(compose_intro(TOPICS, self.FULL, 2).startswith("B"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The weekly newsletter run ended with a manual step: open `results/newsletter/N{NNN}.html`, copy it, paste it into the Substack editor. `newsletter_pipeline.py substack-draft` now does that over Substack's native HTTP API (cookie auth — no browser, no DOM selectors), reading exactly what `build` reads and reusing its grouping/sorting so the draft and the HTML can't drift apart.

**Scope correction worth flagging.** The issue (inheriting #91's wording) said to build editions from the Notion *editorial* database. That turned out to be unbuildable as written: the editorial DB has no newsletter/edition columns — its Substack columns (`text SB`, `link SB`) drive the daily short-form Note, so an "edition" built from them would just duplicate the Note. The real source is the newsletter's own articles + newsletter DBs, which `build_newsletter` already queries. Confirmed against the schema before changing course, agreed with the owner, and recorded in `docs/substack-native-api.md` so it isn't re-litigated. This is why the step lives in `newsletter/` rather than `planning/substack/`.

**The body is built as explicit ProseMirror nodes, and that is load-bearing.** The obvious implementation — render markdown and hand it to the library's `Post.from_markdown` — is silently broken for this layout: given a `##` heading followed by `- [title](url)` lines, it folds the bullet lines into the *heading's own text node*, destroying the list and every link. Draft creation still returns 200 and prepublish still reports `errors=none`, so it fails invisibly and would only surface as a mangled draft in the editor. An offline probe caught this before any of the feature was written; `tests/test_substack_draft_sections.py` now pins the node structure so a well-meaning refactor back to `from_markdown` fails loudly instead.

Article titles are emitted as **literal text nodes**, never run through `parse_inline` — titles are scraped from arbitrary sites and routinely contain `*`, `[` or backticks that markdown parsing would mangle.

Safety properties, by design:

- **It never publishes.** There is no `--confirm` on this path at all. The draft is private and emails no one; publishing stays a deliberate action in the Substack editor. (`planning/substack/api_create.py` remains the manual path that *can* publish.)
- **It is excluded from `create` / `all`.** It writes to an external platform, so it stays an explicit, separately re-runnable step rather than firing as a side effect of a build.
- An expired session cookie exits `2` with one actionable line pointing at `extract_session`, not a traceback.

Also adds the matching ⑤ button to the control panel's newsletter tab, wired to the existing must-read picker so the chosen line becomes the draft's opening paragraph.

## Validation

- **Offline ProseMirror probe** (no network) comparing explicit node construction against `Post.from_markdown` — this is what surfaced the `from_markdown` defect described above. Explicit construction produced the correct `paragraph` / `heading` / `bullet_list` tree with link marks intact.
- **Live round-trip against the real account**, twice: created a draft from a real newsletter (24 articles across 3 sections) → `Prepublish — errors=none` → deleted. Both throwaway drafts were removed; nothing was left behind and nothing was ever published or sent.
- **Stored-body verification.** Read the created draft back via `GET /drafts/{id}` and compared it to what was sent: Substack stored `paragraph` / `heading` / `bullet_list` exactly as submitted, link marks intact, and a deliberately hostile title (`Why *args break [parsers]`) survived verbatim. This is the check that would have caught a `bullet_list` vs `bulletList` schema mismatch.
- **UI verified in the running app**, not just compiled: the ⑤ button fires end-to-end (log panel shows draft created → prepublish clean → exit 0), and the must-read radio is reactive — switching it updates the button's arguments. This mattered because `app/tab_newsletter.py` documents issue #155, where buttons under `st.tabs` silently fail to fire.
- `py_compile` clean on every changed file.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests` — **60 tests, all green** (11 new, all pure/offline: no Notion, no Substack, no network).
- Confirmed the existing `api_create.py` CLI is unaffected — `create_draft`'s signature is unchanged; the new sectioned builder is a separate method.

## Known gap

`docs/screenshots/newsletter-desktop.png` in the README tour is now **stale**, because `config/doc_capture` is broken: it captures the first tab then times out clicking the second. Verified pre-existing by stashing this branch's work and reproducing the identical failure on unmodified `main` — filed as #187. Screenshots were deliberately left untouched rather than committing a half-regenerated set, which would leave one tab updated and four stale.

## Test plan

- [x] Offline probe proves the node-construction choice before implementing
- [x] Live create → prepublish → delete round-trip, twice, nothing left behind
- [x] Stored draft body read back and compared field-by-field
- [x] ⑤ button fires end-to-end in the running control panel
- [x] Must-read choice flows from the picker into the draft
- [x] Full suite green (60 tests, 11 new)
- [x] `api_create.py` unaffected
- [x] `docs/architecture.mmd` updated in the same PR, per the repo's anti-staleness contract

Closes #184
