### PR TITLE
feat(substack): move Notes off Playwright to the native HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ flowchart TB
 
 ## Supported platforms
 
-LinkedIn · Instagram · Twitter/X · Threads · Substack (Note + scraped
-follower count). All five have a Notion editorial column set; four have a
+LinkedIn · Instagram · Twitter/X · Threads · Substack (Note posting, follower
+count and note engagement — all three with a browser-free path over Substack's
+own HTTP API). All five have a Notion editorial column set; four have a
 native-scheduler driver under `planning/`.
 
 ## Project structure
@@ -301,7 +302,8 @@ flowchart LR
   independent of the daily data, so it has no `--skip-*` flag.
 - Each of the 10 `<platform>_<data_type>` endpoints in `config/config.json`
   carries a `"source"` key picking which collector runs — `"rapidapi"`
-  (paid HTTP fetcher) or `"playwright"` (free logged-in-Chrome scraper).
+  (paid HTTP fetcher), `"playwright"` (free logged-in-Chrome scraper), or
+  `"native"` (the platform's own HTTP API with cookie auth — Substack only).
   See [Choosing the data source](#choosing-the-data-source-rapidapi-vs-playwright)
   for how to flip per platform and roll back.
 - **Fails loudly when it drops data.** The run sends **one** Slack alert and
@@ -367,14 +369,22 @@ either makes the HTTP call (`"rapidapi"`), delegates to the matching
 delegates to `reporting.scrape_client.<platform>_native.fetch_<data_type>`
 (`"native"` — the platform's own HTTP API with cookie auth, no browser).
 
-**Substack native API:** `substack_profile.source` defaults to `"native"`,
-fetching the follower count via a single authenticated GET instead of a headed
-Chrome scrape. It needs a one-time cookie harvest
-(`python -m planning.substack.extract_session`, re-run ~quarterly when the
-cookie expires); flip back to `"playwright"` to use the browser scrape. See
-[`docs/substack-native-api.md`](docs/substack-native-api.md) and
-[`planning/substack/README.md`](planning/substack/README.md). `"native"` is
-Substack-only for now (the follower count); other platforms use rapidapi/playwright.
+**Substack native API:** both Substack blocks can run natively —
+`substack_profile` (follower count, one authenticated GET) and `substack_posts`
+(note engagement, a couple of GETs instead of a feed scroll plus one page load
+per note). The note path was verified record-for-record against the Playwright
+scrape on the live account — 10/10 identical, 0.9 s vs 37.0 s. Both need the
+one-time cookie harvest (`python -m planning.substack.extract_session`, re-run
+~quarterly when the cookie expires); flip either back to `"playwright"` to use
+the browser scrape. See [`docs/substack-native-api.md`](docs/substack-native-api.md)
+and [`planning/substack/README.md`](planning/substack/README.md). `"native"` is
+Substack-only for now; other platforms use rapidapi/playwright.
+
+Note *posting* has its own flag, `substack.note_source` (`"playwright"` default
+/ `"native"`), because it is a **write** to a public platform rather than a
+read. The native backend publishes the daily Note over the same HTTP API and
+records the permalink of the note it just created, instead of re-reading the
+profile and taking whatever is topmost. Video notes stay Playwright-only.
 
 The downstream pipeline is source-agnostic — `data_processor` reads the
 JSON envelope from `results/raw/<platform>_<data_type>_<YYYY-MM-DD>.json`

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -203,6 +203,7 @@
         }
     },
     "substack": {
+        "note_source": "playwright",
         "handle": "your_substack_handle",
         "publish_url": "https://your-publication.substack.com/publish/home",
         "profile_url": "https://substack.com/@your_substack_handle",

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -37,6 +37,7 @@ flowchart TB
   RPIPE --> SC
   SC -->|"source: rapidapi"| RAPIDAPI[("RapidAPI\n(paid HTTP)")]
   SC -->|"source: playwright / native"| SCRAPE
+  SCRAPE -->|"followers + note engagement\n(cookie auth, no browser)"| SBAPI[("Substack private HTTP API")]
   SC --> RAW[["results/raw/*.json"]]
   RAW --> PROC
   PROC --> SUPA[("Supabase / PostgreSQL")]
@@ -49,7 +50,7 @@ flowchart TB
     IG["instagram/\nschedule_instagram_posts +\nclone_to_other_platforms"]
     TW["twitter/schedule_twitter_posts"]
     TH["threads/schedule_threads_posts"]
-    SUBSTACKDAILY["substack/\ndaily_pipeline (invoked from reporting) +\npost_substack_note / post_substack_video_note"]
+    SUBSTACKDAILY["substack/\ndaily_pipeline (invoked from reporting) +\npost_substack_note (note_source: playwright | native) /\npost_substack_video_note (playwright only)"]
     VIDEOS["videos/schedule_videos_posts\n(weekly cross-platform clip: LI+IG+TW+TH @19:00)"]
   end
   NOTION -->|"WIP-* checkboxes"| PPIPE
@@ -57,6 +58,7 @@ flowchart TB
   IG -.->|"clone captions/illustrations\nTW/TH/SB Notion columns"| TW
   IG -.-> TH
   IG -.-> SUBSTACKDAILY
+  SUBSTACKDAILY -->|"note_source: native\npublish Note, no browser"| SBAPI
   LI --> CHROME[("Real Chrome\nper-platform persistent profile\nplanning/<p>/chrome_user_data/")]
   IG --> CHROME
   TW --> CHROME
@@ -78,7 +80,7 @@ flowchart TB
   NBUILD --> RESULTSNEWS[["results/newsletter/N{NNN}.html"]]
   NPIPE -->|"substack-draft"| NSBDRAFT
   NSBDRAFT -->|"same grouped articles"| NOTION
-  NSBDRAFT -->|"create_draft_from_sections\n(cookie auth, no browser)"| SBAPI[("Substack private HTTP API\nprivate draft — never published")]
+  NSBDRAFT -->|"create_draft_from_sections\nprivate draft — never published"| SBAPI
 
   subgraph engagement_mod["engagement/ — anti-AI comment triage"]
     ESCRAPE["linkedin/scrape_comments.py"]

--- a/docs/playwright-social-scraping.md
+++ b/docs/playwright-social-scraping.md
@@ -14,9 +14,12 @@ section in the main README. This document is the *implementation* memory.
 
 Every endpoint key in `config/config.json`
 (`linkedin_profile`, `linkedin_posts`, …, `substack_posts`) carries a
-`"source": "rapidapi" | "playwright"` field. `social_api_client.get_api_data`
-inspects it and either makes the HTTP call (RapidAPI) or imports
-`reporting.scrape_client.<platform>` and calls `fetch_<profile|posts>(date)`.
+`"source": "rapidapi" | "playwright" | "native"` field. `social_api_client.get_api_data`
+inspects it and either makes the HTTP call (RapidAPI), or imports
+`reporting.scrape_client.<platform>` and calls `fetch_<profile|posts>(date)`, or
+— for `"native"` — imports `reporting.scrape_client.<platform>_native` and calls
+the same function name there (Substack only; see
+[`substack-native-api.md`](substack-native-api.md)).
 The scraper returns just the `data` payload dict — the outer envelope
 (`{date, platform, data_type, data}`) is added by the existing
 `save_results`. Downstream, `data_processor` reads the JSON file and
@@ -71,6 +74,11 @@ not look like a bot" rule in `~/.claude/CLAUDE.md` reinforces it.
 * **Video detection:** `<video>` element on the permalink page.
 
 ### Substack
+
+> **Both Substack scrapes now have a native-API path** (`source: "native"` →
+> `substack_native.py`), which is the recommended source: no browser, no
+> selectors, and verified record-for-record identical to the scrape below. The
+> DOM notes here remain the memory for the `"playwright"` rollback path.
 
 * **Follower count = "Total followers", not "subscribers":** these are two distinct metrics on Substack. RapidAPI returned `subscriberCountNumber` (mailing list, ~9.8K). The Playwright scraper returns the "Total followers (N)" line from `stats_audience_url` (~14.6K) — that's the metric the legacy `planning/substack/update_substack_followers.py` always reported. The fold-in keeps the legacy semantic; if you ever need the subscriber-list count again, that's a separate field/mapping. The relevant config key is `substack.stats_audience_url` (per-publication URL — not the same as the public profile URL).
 * **Posts — skip only a true teaser, not the first note (issue #84):** we *used* to drop the first unique `c-<id>` code unconditionally as "the newsletter teaser". That was wrong for the daily-Note workflow — the scrape (pipeline step 1) runs *before* the day's Note is published (step 6), so the top entry is *yesterday's* real note, which is exactly the row the posts consolidator needs (`posted_at = date - 1 day`). Dropping it left every `*_substack_no_video` column NULL → blank Notion fields. Now we keep all notes and drop a note **only** when it embeds a `/p/` newsletter post preview (`<a href*='/p/'>` inside the note container) — the signal a genuine announcement/restack note carries and ordinary daily notes never do.

--- a/docs/substack-native-api.md
+++ b/docs/substack-native-api.md
@@ -68,6 +68,93 @@ to avoid the library's construction-time round-trips.
 | Edit draft | `PUT /<pub>/drafts/{id}` | |
 | Pre-publish validate | `GET /<pub>/drafts/{id}/prepublish` | Returns `{errors, suggestions}`; does not publish. |
 | Publish | `POST /<pub>/drafts/{id}/publish` | **Irreversible** — emails the whole list. Gated behind explicit `--confirm`; never in the cron. |
+| Own Notes + engagement | `GET /reader/feed/profile/{user_id}?types[]=note` | Paginated by `nextCursor` (12 items/page). Each item's `comment` **is** the Note. Daily path — see *Notes* below. |
+| Upload an image | `POST /image` | Body `{"image": "data:<mime>;base64,…"}` → `{url}`. Shared with the post editor. |
+| Make a Note attachment | `POST /comment/attachment` | Body `{"url": <cdn url>, "type": "image"}` → `{id}`. |
+| Publish a Note | `POST /comment/feed` | Body `{"bodyJson": …, "attachmentIds": […], "replyMinimumRole": "everyone"}`. **Immediately public** — Notes have no draft state. |
+| Delete a Note | `DELETE /comment/{id}` | Returns `{}`. |
+
+## Notes: a Note is a `comment`, and engagement comes free
+
+A Substack Note is not its own entity type — it is a `comment` with
+`type == "feed"` and a `null` `post_id`, surfaced through the reader feed. Asking
+the profile feed for `types[]=note` returns our own Notes newest-first, and each
+payload already carries the engagement numbers, so there is **no** per-note
+request: what the Playwright path did with a feed scroll plus one page load per
+note is `1 + ceil(n/12)` GETs.
+
+The field mapping (issue #185), against `reporting/scrape_client/substack.py`'s
+scrape:
+
+| Record field | Native source | Was (Playwright) |
+| --- | --- | --- |
+| `post_id` | `https://substack.com/@<handle>/note/c-{comment.id}` | same URL, read off the feed anchor |
+| `posted_at` | `comment.date`, **converted UTC → local** | the timestamp anchor's `title`, rendered in browser-local time |
+| `num_likes` | `comment.reaction_count` | `button[aria-label='Like']` text |
+| `num_comments` | `comment.children_count` | `button[aria-label='Comment']` text |
+| `num_reshares` | `comment.restacks` | `button[aria-label='Restack']` text |
+| `is_video` | an attachment with `type == "video"` | a `<video>` in the note container |
+| `is_teaser` | a `post` attachment, or a `link` attachment whose `linkMetadata.url` contains `/p/` | an `<a href*='/p/'>` card in the container |
+
+Three things worth keeping in mind:
+
+- **The engagement triple is the same source the UI renders.** Substack's own
+  feed bundle draws the note toolbar from `reaction_count` / `children_count` /
+  `restacks` — we are reading the numbers the DOM scrape was reading *off*, not a
+  parallel statistic that could diverge.
+- **`posted_at` must be converted to local time before the date is taken.** The
+  API returns UTC; the Playwright path read a browser-local rendering, and the
+  posts consolidator matches on local days (`posted_at = date - 1 day`). Slicing
+  the first ten characters of the UTC string would silently shift late-evening
+  notes onto the wrong day. `note_posted_date` does the conversion and
+  `tests/test_substack_native_notes.py` pins it.
+- **Teaser detection keys on the `/p/` URL, not merely on "has a link".**
+  Ordinary daily notes *do* carry `link` attachments (an outbound article link),
+  so testing for an attachment type alone would drop real notes. Caveat: no
+  teaser note existed in the 144 most recent, so this branch is implemented from
+  the shape of the `link`/`post` attachments rather than verified against a live
+  specimen — the one part of the mapping without direct evidence.
+
+### Publishing a Note natively
+
+`substack.note_source = "native"` swaps `post_substack_note.py`'s publish step
+from the Chrome composer to three HTTP calls (`/image` →
+`/comment/attachment` → `/comment/feed`); everything else in that script — the
+Notion read, the idempotence guard, the empty-body refusal, the `post_url`
+write-back — is shared. Rollback is the same one key back to `"playwright"`.
+
+Two things this fixes beyond removing the browser:
+
+- **The permalink is exact.** The Playwright path published, then re-loaded the
+  profile and took the topmost `/note/` anchor — a race against anything else
+  posting. The native path uses the id the create call returns.
+- **`bodyJson` is built literally.** The body is a Notion column that can contain
+  `*`, `[` or backticks; it is inserted as plain text nodes, never markdown-parsed.
+  Blank lines become separate `paragraph` nodes, matching how the composer
+  stores multi-paragraph notes.
+
+Caveats worth knowing:
+
+- **The create response does not echo `handle`** (verified live), so the
+  permalink is built from `config.substack.handle`, falling back to
+  `fetch_self_handle()` — the same source the reporting path uses, so a publish
+  and a later scrape cannot key on different URLs.
+- **Substack rewrites the body server-side.** A posted note whose text contains
+  something URL-shaped comes back with the doc split into extra text nodes
+  carrying `link` marks. The rendered text is unchanged and the browser composer
+  behaves identically — so this is parity, not a defect — but do not expect the
+  stored `body_json` to be byte-identical to what was sent.
+- **There is no dry-run at the API layer**, because a Note has no draft state.
+  `--dry-run` is enforced in `post_substack_note.py` *before* the publish call.
+- **Video notes are not supported natively.** They upload through a separate mux
+  pipeline (`mux_asset_id` / `mux_playback_id` on the attachment) that was not
+  reverse-engineered; `post_substack_video_note.py` stays on Playwright.
+
+### Verified by A/B against the browser path
+
+Both `fetch_posts` implementations were run back-to-back against the live
+account: **10/10 records identical on every field**, no set difference either
+way, in **0.9 s (native) vs 37.0 s (Playwright)**.
 
 ## How it wires into the reporting pipeline
 
@@ -121,11 +208,17 @@ Article titles are emitted as **literal text nodes**, never run through
   a `subscribers` *list*). We don't rely on that helper.
 - The library's `get_published_posts` returns the raw envelope; callers must
   unwrap `["posts"]` (`SubstackAPI.list_published` does this).
-- Notes (the daily Note posting + note-engagement scrape) use a different endpoint
-  family that the spike did **not** reverse-engineer; those stay on Playwright for
-  now.
-- No rate limiting was observed across the spike's calls, but it is unmeasured at
-  daily-cron scale.
+- The Note write routes are **not discoverable by reading the JS bundles** — the
+  composer is a lazily-imported webpack chunk, so nothing served on `/home` or
+  `/notes` contains them. They were captured by driving the real composer once
+  with a network listener attached. A future breakage is diagnosed the same way,
+  not by grepping bundles.
+- Beware: a `GET` on a POST-only route returns **404, not 405** (Express routes
+  per method), so "GET says 404" is *not* evidence that a write route is absent.
+  An early pass in the spike drew the wrong conclusion from exactly this.
+- Video Notes remain Playwright-only (separate mux upload pipeline).
+- No rate limiting was observed across the spike's calls (including a 12-page
+  cursor walk over 144 notes), but it is unmeasured at daily-cron scale.
 
 ## Scope today vs. follow-ups
 
@@ -139,5 +232,10 @@ newsletter/edition columns (its Substack columns drive the daily short-form
 Note). The newsletter's own articles + newsletter DBs are the real source, which
 is why the step lives in `newsletter/` rather than `planning/substack/`.
 
-Deferred: migrating Note posting + note-engagement off Playwright (#185);
+Also shipped (#185): native **note engagement**
+(`substack_posts.source = "native"` → `substack_native.fetch_posts`) and native
+**Note posting** (`substack.note_source = "native"` → `post_substack_note.py`).
+Both keep Playwright as a one-key rollback.
+
+Deferred: native **video** Note posting (mux upload pipeline, still Playwright);
 "like" support (#186).

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -36,7 +36,9 @@ See `docs/substack-native-api.md` for the design, endpoint map, and fragility no
 Modules:
 
 ```
-api_client.py        — session loader + fetch_follower_count() + SubstackAPI (pull/create/publish)
+api_client.py        — session loader + fetch_follower_count() + fetch_own_notes()
+                       + publish_note()/delete_note()
+                       + SubstackAPI (pull/create/publish)
 extract_session.py   — harvest cookies+UA from the Chrome profile → api_session.json (gitignored)
 api_pull.py          — manual CLI: dump a post archive to JSON
 api_create.py        — manual CLI: create a draft edition (publish only with --confirm)
@@ -60,15 +62,35 @@ the browser User-Agent that `cf_clearance` is bound to). When the cookie expires
 the API returns 401/403 and the helpers raise `SessionExpiredError` telling you to
 re-run `extract_session`.
 
-### Daily follower count via the API
+### Daily follower count + note engagement via the API
 
 Set `substack_profile.source` to `"native"` in `config.json` (leave the other
 keys — the endpoint loop still needs `api_url` present). The reporting pipeline
 then routes the follower count through
 `reporting/scrape_client/substack_native.py::fetch_profile`, which returns the
 same `{"num_followers": N}` envelope as the Playwright scraper. Flip back to
-`"playwright"` to use the browser scrape. (`substack_posts` / note engagement
-stays on Playwright — the Notes endpoints aren't reverse-engineered yet.)
+`"playwright"` to use the browser scrape.
+
+The same flag on `substack_posts` routes the daily **note engagement** through
+`substack_native.py::fetch_posts` (issue #185), returning the identical
+`{"posts": [...]}` envelope. Verified by running both paths back-to-back against
+the live account: 10/10 records identical on every field, 0.9 s vs 37.0 s. Same
+one-flag rollback.
+
+### Posting the daily Note via the API
+
+Set `substack.note_source` to `"native"` in `config.json` to publish the daily
+Note over the HTTP API instead of driving the Chrome composer (default stays
+`"playwright"`; flip back to roll it back). The Notion read, the idempotence
+guard, the empty-body refusal and the `post_url` write-back are shared by both
+backends — only the publish step differs. The native one also records the
+permalink of the note it *just created* rather than re-reading the profile and
+taking whatever is topmost.
+
+Because a Note has no draft state, publishing is immediate and public;
+`--dry-run` is enforced before the publish call, so it never reaches Substack.
+**Video** notes (`post_substack_video_note.py`) remain Playwright-only — they
+upload through a separate mux pipeline that isn't reverse-engineered.
 
 ### Manual archive + create
 
@@ -132,6 +154,7 @@ above.
 | `illustrations_folder` | Absolute folder containing the daily image. Joined with `image_filename`. |
 | `editorial_db_id` | Notion editorial database id. |
 | `notion_columns` | Role-to-column map. Roles: `title_day`, `text_body`, `image_filename`, `post_url`. The `follow SB` follower column is **not** in this map — it is populated by the reporting pipeline (`reporting/scrape_client/substack.py::fetch_profile` → `data_processor` → `notion_update`, mapped from `profile.num_followers_substack`) like every other platform's follower count. |
+| `note_source` | Optional, `"playwright"` (default) or `"native"`. Which backend publishes the daily Note — the Chrome composer, or the HTTP API with the harvested cookie. Video notes ignore this and always use Playwright. |
 | `headless` | Optional bool (default `false`). |
 | `dry_run_default` | Optional bool (default `false`). When `true`, step 1 always runs as a dry-run unless `--force` is passed. |
 
@@ -147,7 +170,7 @@ first filename is used.
 ```
 - Default date is today (local).
 - Idempotent: if the editorial row's `post_url` is already populated, the script exits 0 unless `--force` is supplied.
-- `--dry-run` composes the Note (text + image) but **does not** click Post. A screenshot is saved under `results/substack/<date>-dryrun.png`.
+- `--dry-run` composes the Note (text + image) but **does not** click Post. A screenshot is saved under `results/substack/<date>-dryrun.png`. Under `note_source: "native"` there is no browser to screenshot, so the dry-run logs what *would* be published and returns before any HTTP write.
 
 ### Follower scrape (now in the reporting pipeline)
 The Substack follower count is no longer scraped from here. See

--- a/planning/substack/api_client.py
+++ b/planning/substack/api_client.py
@@ -32,9 +32,12 @@ must never be committed (public repo).
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
+import mimetypes
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Optional
@@ -61,10 +64,23 @@ __all__ = [
     "SessionExpiredError",
     "load_session",
     "fetch_follower_count",
+    "fetch_own_notes",
+    "fetch_self_handle",
+    "build_note_body_json",
+    "note_permalink",
+    "publish_note",
+    "delete_note",
     "build_section_nodes",
     "SubstackAPI",
     "SESSION_FILE",
 ]
+
+# The profile feed pages at 12 items; cap the cursor walk so a pagination
+# change can never spin forever.
+NOTES_PAGE_CAP = 12
+
+# Who may reply to a published Note. "everyone" is what the web composer sends.
+NOTE_REPLY_ROLE = "everyone"
 
 
 class SessionExpiredError(RuntimeError):
@@ -121,6 +137,193 @@ def fetch_follower_count(session_file: Path = SESSION_FILE) -> int:
             f"(got {type(count).__name__}). Endpoint may have changed."
         )
     return count
+
+
+def _fetch_self(session: requests.Session) -> dict:
+    """``/user/profile/self`` with the two fields we depend on validated."""
+    data = _check(session.get(f"{BASE_URL}/user/profile/self", timeout=30)).json()
+    if not data.get("id") or not data.get("handle"):
+        raise RuntimeError(
+            "Unexpected /user/profile/self shape — no 'id'/'handle'. "
+            "Endpoint may have changed."
+        )
+    return data
+
+
+def fetch_self_handle(*, session_file: Path = SESSION_FILE) -> str:
+    """Our own handle, straight from the API.
+
+    Authoritative fallback for building note permalinks: the note-create
+    response does **not** echo the handle, and this is the same source
+    ``fetch_own_notes`` uses, so permalinks written at publish time and
+    permalinks read back by the reporting pipeline cannot diverge.
+    """
+    session, _ = load_session(session_file)
+    return _fetch_self(session)["handle"]
+
+
+def fetch_own_notes(
+    limit: int = 20, *, session_file: Path = SESSION_FILE
+) -> tuple[str, list[dict]]:
+    """Return ``(handle, comments)`` — our own published Notes, newest first.
+
+    Walks ``/reader/feed/profile/{user_id}?types[]=note``, following ``nextCursor``
+    until ``limit`` notes are collected or the feed is exhausted. Each element is
+    the raw ``comment`` payload (a Note is a ``comment`` of ``type == "feed"``);
+    :func:`reporting.scrape_client.substack_native.note_record` maps it to the
+    reporting record shape.
+
+    The handle comes from ``/user/profile/self`` rather than ``config.json`` so
+    the permalinks we build are guaranteed to match the account the cookie
+    belongs to.
+
+    Equivalent to the Playwright feed-walk + per-note permalink visit, but as
+    ``1 + ceil(limit/12)`` GETs instead of one browser launch and ~12 page loads.
+    """
+    session, _ = load_session(session_file)
+    self_data = _fetch_self(session)
+    user_id = self_data["id"]
+    handle = self_data["handle"]
+
+    url = f"{BASE_URL}/reader/feed/profile/{user_id}?types%5B%5D=note"
+    comments: list[dict] = []
+    cursor: Optional[str] = None
+    for _ in range(NOTES_PAGE_CAP):
+        page_url = url if cursor is None else f"{url}&cursor={cursor}"
+        data = _check(session.get(page_url, timeout=30)).json()
+        for item in data.get("items") or []:
+            comment = item.get("comment")
+            if comment:
+                comments.append(comment)
+        if len(comments) >= limit:
+            break
+        cursor = data.get("nextCursor")
+        if not cursor:
+            break
+    return handle, comments[:limit]
+
+
+def note_permalink(handle: str, note_id) -> str:
+    """The public URL of a Note — the same value the editorial ``post_url`` holds."""
+    return f"https://substack.com/@{handle}/note/c-{note_id}"
+
+
+def build_note_body_json(text: str) -> dict:
+    """Build a Note's ProseMirror ``bodyJson`` from plain text.
+
+    Blank-line-separated blocks become separate ``paragraph`` nodes, which is
+    exactly how Substack's own composer stores a multi-paragraph Note (verified
+    against published notes' stored ``body_json``).
+
+    Text is inserted **literally** — no markdown parsing — for the same reason
+    the newsletter's section builder does it: the body comes from a Notion
+    column and may legitimately contain ``*``, ``[`` or backticks.
+
+    Pure (no session, no network) so it can be unit-tested on its own.
+    """
+    blocks = [b.strip() for b in re.split(r"\n\s*\n", (text or "").strip()) if b.strip()]
+    if not blocks:
+        raise ValueError("Refusing to build an empty Note body.")
+    return {
+        "type": "doc",
+        "attrs": {"schemaVersion": "v1", "title": None},
+        "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": block}]}
+            for block in blocks
+        ],
+    }
+
+
+def _image_data_uri(image_path: Path) -> str:
+    """Read an image file into the ``data:<mime>;base64,…`` form the API expects."""
+    mime = mimetypes.guess_type(str(image_path))[0] or "image/png"
+    encoded = base64.b64encode(Path(image_path).read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+def _upload_note_image(session: requests.Session, image_path: Path) -> str:
+    """Upload an image and return its CDN URL (step 1 of the attachment flow)."""
+    resp = _check(session.post(
+        f"{BASE_URL}/image",
+        json={"image": _image_data_uri(image_path)},
+        timeout=120,
+    ))
+    url = (resp.json() or {}).get("url")
+    if not url:
+        raise RuntimeError("Substack /image returned no 'url' — endpoint may have changed.")
+    return url
+
+
+def _create_note_attachment(session: requests.Session, image_url: str) -> str:
+    """Turn an uploaded image URL into a Note attachment id (step 2)."""
+    resp = _check(session.post(
+        f"{BASE_URL}/comment/attachment",
+        json={"url": image_url, "type": "image"},
+        timeout=60,
+    ))
+    attachment_id = (resp.json() or {}).get("id")
+    if not attachment_id:
+        raise RuntimeError(
+            "Substack /comment/attachment returned no 'id' — endpoint may have changed."
+        )
+    return attachment_id
+
+
+def publish_note(
+    text: str,
+    *,
+    image_path: Optional[Path] = None,
+    session_file: Path = SESSION_FILE,
+) -> dict:
+    """Publish a Substack Note over the native API. Returns the created note dict.
+
+    **This is immediately public** — a Note has no draft state, so there is no
+    dry-run at this layer; callers own that gate (``post_substack_note.py``
+    short-circuits before reaching here).
+
+    A Note is a ``comment`` of ``type == "feed"``. With an image it is three
+    calls, mirroring exactly what the web composer sends:
+
+    1. ``POST /image`` — the file as a base64 data URI → a CDN URL.
+    2. ``POST /comment/attachment`` — that URL → an attachment id.
+    3. ``POST /comment/feed`` — ``bodyJson`` + ``attachmentIds``.
+
+    Unlike the Playwright path this returns the created note's **own** id, so
+    the permalink is exact rather than "whatever is topmost on the profile a
+    moment later".
+
+    Video notes are **not** supported here — they upload through a separate mux
+    pipeline that is not reverse-engineered; ``post_substack_video_note.py``
+    stays on Playwright.
+    """
+    body_json = build_note_body_json(text)  # validate before any network call
+    session, _ = load_session(session_file)
+
+    payload: dict = {"bodyJson": body_json, "replyMinimumRole": NOTE_REPLY_ROLE}
+    if image_path:
+        image_path = Path(image_path)
+        if not image_path.exists():
+            raise FileNotFoundError(f"Note image not found: {image_path}")
+        logger.info("📤 Uploading note image: %s", image_path.name)
+        payload["attachmentIds"] = [
+            _create_note_attachment(session, _upload_note_image(session, image_path))
+        ]
+
+    resp = _check(session.post(f"{BASE_URL}/comment/feed", json=payload, timeout=60))
+    data = resp.json() or {}
+    note = data.get("comment") if isinstance(data.get("comment"), dict) else data
+    if not note.get("id"):
+        raise RuntimeError(
+            f"Note POST succeeded but no id in the response (keys: {sorted(data)}) — "
+            "endpoint may have changed."
+        )
+    return note
+
+
+def delete_note(note_id, *, session_file: Path = SESSION_FILE) -> None:
+    """Delete a published Note. Used to clean up throwaway verification notes."""
+    session, _ = load_session(session_file)
+    _check(session.delete(f"{BASE_URL}/comment/{note_id}", timeout=30))
 
 
 def _text_node(text: str, href: Optional[str] = None) -> dict:

--- a/planning/substack/post_substack_note.py
+++ b/planning/substack/post_substack_note.py
@@ -6,6 +6,21 @@ CLI:
 Default date is today (local). The script is idempotent: if the editorial
 row's ``post_url`` column is already populated, it exits 0 unless ``--force``
 is set.
+
+**Two publish backends**, chosen by ``substack.note_source`` in ``config.json``
+(same pattern as the reporting pipeline's ``source`` flag, and the same one-key
+rollback):
+
+* ``"playwright"`` (default) — drives the real-Chrome Note composer.
+* ``"native"`` — posts over Substack's HTTP API with the harvested cookie (no
+  browser). Also *exact*: it writes the permalink of the note it just created,
+  where the Playwright path re-reads the profile afterwards and takes whatever
+  is topmost.
+
+Everything either side of publishing — the Notion read, the idempotence guard,
+the empty-body refusal, the image resolution and the ``post_url`` write-back —
+is shared, so the two backends differ only in how the Note reaches Substack.
+Video notes are Playwright-only (see ``post_substack_video_note.py``).
 """
 
 from __future__ import annotations
@@ -38,6 +53,30 @@ from planning.substack.substack_session import (  # noqa: E402
 )
 
 logger = logging.getLogger("substack_post_note")
+
+
+def _publish_native(cfg: dict, body_text: str, image_path: Path) -> str:
+    """Publish the Note over the HTTP API; return its permalink.
+
+    Raises rather than returning ``None`` — every failure mode here (expired
+    cookie, upload rejected, no resolvable handle) is a real error the caller
+    turns into a non-zero exit code.
+
+    Imported lazily so the Playwright path never pays for it and a missing
+    ``api_session.json`` can't break the default backend.
+    """
+    from planning.substack.api_client import (
+        fetch_self_handle,
+        note_permalink,
+        publish_note,
+    )
+
+    note = publish_note(body_text, image_path=image_path)
+    # The create response does NOT echo the handle (verified live), so fall back
+    # to config and then to the API — the same source the reporting pipeline
+    # builds its post_id from, so the two can't disagree.
+    handle = note.get("handle") or cfg.get("handle") or fetch_self_handle()
+    return note_permalink(handle, note["id"])
 
 
 def parse_args() -> argparse.Namespace:
@@ -267,6 +306,33 @@ def post_note(
     image_path = _resolve_image_path(cfg["illustrations_folder"], image_filename)
     logger.info("🖼️ Using image: %s", image_path)
     logger.info("📝 Body length: %d chars", len(str(body_text)))
+
+    note_source = str(cfg.get("note_source", "playwright")).lower()
+    if note_source not in ("playwright", "native"):
+        logger.error(
+            "❌ Unknown substack.note_source %r — expected 'playwright' or 'native'.",
+            note_source,
+        )
+        return 2
+
+    if note_source == "native":
+        if dry_run:
+            logger.info(
+                "✅ DRY-RUN (native): would publish %d chars + %s — nothing was posted.",
+                len(str(body_text)), image_path.name,
+            )
+            return 0
+        logger.info("🔌 Publishing the Note via the native HTTP API (no browser).")
+        try:
+            note_url = _publish_native(cfg, str(body_text), image_path)
+        except Exception as err:  # noqa: BLE001
+            logger.error("❌ Native note publish failed: %s", err)
+            return 9
+        logger.info("🔗 Published note URL: %s", note_url)
+        prop_type = get_property_type(row, "post_url", columns)
+        set_field(notion, page_id, "post_url", note_url, columns, prop_type)
+        logger.info("✅ Wrote post_url to Notion editorial row.")
+        return 0
 
     owned_session = session is None
     s = session or SubstackSession(cfg)

--- a/reporting/scrape_client/substack_native.py
+++ b/reporting/scrape_client/substack_native.py
@@ -6,17 +6,23 @@ browser-free alternative to the Playwright scraper in
 ``reporting/scrape_client/substack.py`` — which is kept as the ``"playwright"``
 source and is not removed.
 
-Only ``fetch_profile`` (follower count) is implemented natively today; note
-engagement still goes through the Playwright path until the Notes endpoints are
-reverse-engineered. The return envelope is identical to the Playwright scraper's,
-so everything downstream (``save_results`` → ``data_processor`` →
+``fetch_profile`` (follower count) and ``fetch_posts`` (note engagement) are both
+implemented natively. The return envelopes are identical to the Playwright
+scraper's, so everything downstream (``save_results`` → ``data_processor`` →
 ``profile_aggregator`` → ``notion_update``) is unchanged.
+
+This module deliberately does **not** import
+``reporting.scrape_client.substack`` — that module pulls in Playwright via
+``substack_session``, which would defeat the whole point of the browser-free
+path. The constants and record shape it shares with the Playwright scraper are
+therefore restated here; see :data:`MAX_POSTS`.
 """
 
 from __future__ import annotations
 
 import logging
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -24,10 +30,15 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 from planning.substack.api_client import (  # noqa: E402
     SessionExpiredError,
     fetch_follower_count,
+    fetch_own_notes,
 )
 from reporting.scrape_client.base import ScrapeError, normalize_target_date  # noqa: E402
 
 logger = logging.getLogger("substack_native")
+
+# Mirrors ``reporting.scrape_client.substack.MAX_POSTS`` — restated rather than
+# imported so this module stays Playwright-free (see the module docstring).
+MAX_POSTS = 10
 
 
 def fetch_profile(target_date: Optional[str] = None) -> Optional[dict]:
@@ -46,3 +57,112 @@ def fetch_profile(target_date: Optional[str] = None) -> Optional[dict]:
         raise ScrapeError(f"Substack native follower fetch failed: {err}") from err
     logger.info("✅ Substack followers (native): %d", count)
     return {"num_followers": count}
+
+
+def note_posted_date(iso_ts: Optional[str]) -> Optional[str]:
+    """Convert a note's UTC ``date`` to a **local** ``YYYY-MM-DD``.
+
+    The API returns UTC (``2026-07-26T04:03:14.591Z``) but the Playwright path
+    read the timestamp Substack rendered in the *browser's local* timezone, and
+    the posts consolidator matches on local days (``posted_at = date - 1 day``).
+    Slicing the first ten characters of the UTC string would therefore shift any
+    note posted after local midnight-minus-offset onto the wrong day. Convert
+    first, then take the date.
+    """
+    if not iso_ts:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(iso_ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone().strftime("%Y-%m-%d")
+
+
+def note_is_teaser(attachments: list[dict]) -> bool:
+    """True when a note embeds a newsletter post preview (issue #84's teaser).
+
+    The Playwright equivalent looked for an ``<a href*='/p/'>`` card inside the
+    note container. Natively the same signal is an attachment: either a ``post``
+    attachment, or a ``link`` attachment whose ``linkMetadata.url`` is a ``/p/``
+    permalink. Plain outbound links (a personal site, say) are *not* teasers, so
+    the URL test matters — ordinary daily notes do carry link attachments.
+    """
+    for att in attachments or []:
+        if att.get("type") == "post":
+            return True
+        url = (att.get("linkMetadata") or {}).get("url") or ""
+        if "/p/" in url:
+            return True
+    return False
+
+
+def note_record(comment: dict, handle: str) -> dict:
+    """Map one raw Note payload to the reporting record shape.
+
+    Field-for-field equivalent to the Playwright scraper's
+    ``_scrape_note_permalink`` return value, including the transient
+    ``is_teaser`` key that :func:`fetch_posts` pops. The three engagement
+    numbers are the same values Substack's own feed renders in the note
+    toolbar (``reaction_count`` / ``children_count`` / ``restacks``).
+
+    Pure — no session, no network — so it is unit-testable on fixtures.
+    """
+    attachments = comment.get("attachments") or []
+    types = {att.get("type") for att in attachments}
+    return {
+        "post_id": f"https://substack.com/@{handle}/note/c-{comment.get('id')}",
+        "posted_at": note_posted_date(comment.get("date")),
+        "is_video": 1 if "video" in types else 0,
+        "num_likes": int(comment.get("reaction_count") or 0),
+        "num_comments": int(comment.get("children_count") or 0),
+        "num_reshares": int(comment.get("restacks") or 0),
+        "is_teaser": note_is_teaser(attachments),
+    }
+
+
+def fetch_posts(target_date: Optional[str] = None) -> Optional[dict]:
+    """Return ``{"posts": [...]}`` — note engagement via the native API.
+
+    Mirrors ``reporting.scrape_client.substack.fetch_posts`` exactly so the two
+    sources are drop-in interchangeable via the ``source`` config flag, but
+    replaces the feed scroll + one page load per note with a couple of GETs.
+    """
+    target_date = normalize_target_date(target_date)
+    logger.info("🚀 Substack native fetch_posts — date=%s", target_date)
+    try:
+        # Over-fetch like the Playwright path does, so dropping teasers still
+        # leaves a full MAX_POSTS window of real daily notes.
+        handle, comments = fetch_own_notes(limit=MAX_POSTS + 2)
+    except SessionExpiredError as err:
+        raise ScrapeError(f"Substack native session expired: {err}") from err
+    except Exception as err:  # noqa: BLE001
+        raise ScrapeError(f"Substack native note fetch failed: {err}") from err
+
+    if not comments:
+        raise ScrapeError("Substack native: no notes returned by the profile feed.")
+    logger.info("ℹ️ Substack notes fetched (native): %d", len(comments))
+
+    posts: list[dict] = []
+    for comment in comments:
+        if len(posts) >= MAX_POSTS:
+            break
+        rec = note_record(comment, handle)
+        if rec.pop("is_teaser", False):
+            logger.info(
+                "⏭️ Substack native: skipping newsletter-teaser note %s.",
+                comment.get("id"),
+            )
+            continue
+        posts.append(rec)
+        logger.debug(
+            "📌 Substack native %s — likes=%d comments=%d reshares=%d posted_at=%s video=%d",
+            comment.get("id"), rec["num_likes"], rec["num_comments"],
+            rec["num_reshares"], rec["posted_at"], rec["is_video"],
+        )
+
+    if not posts:
+        raise ScrapeError("Substack native: every note was filtered out as a teaser.")
+    logger.info("✅ Substack notes (native): %d", len(posts))
+    return {"posts": posts}

--- a/tests/test_substack_native_notes.py
+++ b/tests/test_substack_native_notes.py
@@ -1,0 +1,180 @@
+"""Native note-engagement records must match the Playwright scraper's shape (issue #185).
+
+``reporting/scrape_client/substack_native.py`` reads note engagement over the
+private HTTP API instead of screen-scraping the rendered feed. It is selected by
+a ``source`` flag and writes into the same Postgres/Notion columns as the
+Playwright path, so a field that silently changes meaning corrupts history
+rather than failing loudly.
+
+Pinned here, all pure (no Substack, no network) against captured payload shapes:
+
+* the record is field-for-field what ``_scrape_note_permalink`` returned —
+  ``post_id`` is the same ``/@handle/note/c-<id>`` permalink the DB already keys on;
+* engagement maps to ``reaction_count`` / ``children_count`` / ``restacks``, the
+  same three values Substack's own feed code renders in the note toolbar;
+* ``posted_at`` is converted UTC -> **local** before the date is taken. Slicing
+  the UTC string instead would shift late-evening notes onto the wrong day and
+  silently break the consolidator's ``posted_at = date - 1 day`` match;
+* teaser detection keys on a ``/p/`` attachment, so an ordinary note carrying an
+  outbound link is *not* dropped.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from reporting.scrape_client.substack_native import (
+    note_is_teaser,
+    note_posted_date,
+    note_record,
+)
+
+HANDLE = "someone"
+
+# Shapes copied from live payloads during the issue #185 spike (ids/urls scrubbed).
+IMAGE_ATT = {
+    "id": "aaaaaaaa-0000-0000-0000-000000000000",
+    "type": "image",
+    "imageUrl": "https://example.invalid/img_3240x3240.png",
+    "imageWidth": 3240,
+    "imageHeight": 3240,
+}
+VIDEO_ATT = {
+    "id": "bbbbbbbb-0000-0000-0000-000000000000",
+    "type": "video",
+    "media_upload_id": "cccccccc-0000-0000-0000-000000000000",
+    "mediaUpload": {"media_type": "video", "state": "transcoded", "duration": 72.2},
+}
+OUTBOUND_LINK_ATT = {
+    "id": "dddddddd-0000-0000-0000-000000000000",
+    "type": "link",
+    "linkMetadata": {
+        "url": "https://example.invalid/inspiring-conversations/guest",
+        "host": "example.invalid",
+        "title": "A conversation",
+    },
+}
+TEASER_LINK_ATT = {
+    "id": "eeeeeeee-0000-0000-0000-000000000000",
+    "type": "link",
+    "linkMetadata": {
+        "url": "https://example.substack.com/p/the-weekly-edition",
+        "host": "example.substack.com",
+        "title": "The weekly edition",
+    },
+}
+
+
+def _comment(**overrides) -> dict:
+    base = {
+        "id": 301901974,
+        "type": "feed",
+        "date": "2026-07-26T10:03:14.591Z",
+        "body": "A daily note.",
+        "reaction_count": 18,
+        "children_count": 2,
+        "restacks": 5,
+        "attachments": [IMAGE_ATT],
+    }
+    base.update(overrides)
+    return base
+
+
+class NoteRecordTests(unittest.TestCase):
+    def test_record_has_exactly_the_scraper_keys(self):
+        rec = note_record(_comment(), HANDLE)
+        self.assertEqual(
+            set(rec),
+            {"post_id", "posted_at", "is_video", "num_likes",
+             "num_comments", "num_reshares", "is_teaser"},
+        )
+
+    def test_post_id_is_the_permalink_the_db_keys_on(self):
+        rec = note_record(_comment(), HANDLE)
+        self.assertEqual(
+            rec["post_id"], f"https://substack.com/@{HANDLE}/note/c-301901974"
+        )
+
+    def test_engagement_maps_to_the_fields_the_feed_ui_renders(self):
+        rec = note_record(_comment(), HANDLE)
+        self.assertEqual(rec["num_likes"], 18)       # reaction_count
+        self.assertEqual(rec["num_comments"], 2)     # children_count
+        self.assertEqual(rec["num_reshares"], 5)     # restacks
+
+    def test_missing_engagement_counts_become_zero_not_none(self):
+        rec = note_record(
+            _comment(reaction_count=None, children_count=None, restacks=None), HANDLE
+        )
+        self.assertEqual(
+            (rec["num_likes"], rec["num_comments"], rec["num_reshares"]), (0, 0, 0)
+        )
+
+    def test_video_attachment_sets_is_video(self):
+        self.assertEqual(note_record(_comment(attachments=[VIDEO_ATT]), HANDLE)["is_video"], 1)
+        self.assertEqual(note_record(_comment(), HANDLE)["is_video"], 0)
+
+    def test_is_video_is_an_int_not_a_bool(self):
+        # The column is numeric; the Playwright path wrote 1/0.
+        self.assertIsInstance(note_record(_comment(attachments=[VIDEO_ATT]), HANDLE)["is_video"], int)
+
+    def test_note_with_no_attachments_is_handled(self):
+        rec = note_record(_comment(attachments=[]), HANDLE)
+        self.assertEqual(rec["is_video"], 0)
+        self.assertFalse(rec["is_teaser"])
+
+
+class PostedDateTests(unittest.TestCase):
+    def test_utc_is_converted_to_local_before_taking_the_date(self):
+        # 23:30 UTC is already the *next* day anywhere east of UTC. Whatever the
+        # runner's zone, the answer must equal the locally-converted date --
+        # never a naive slice of the UTC string.
+        ts = "2026-07-26T23:30:00.000Z"
+        expected = (
+            datetime(2026, 7, 26, 23, 30, tzinfo=timezone.utc)
+            .astimezone()
+            .strftime("%Y-%m-%d")
+        )
+        self.assertEqual(note_posted_date(ts), expected)
+
+    def test_typical_daily_note_timestamp(self):
+        ts = "2026-07-26T10:03:14.591Z"
+        expected = (
+            datetime(2026, 7, 26, 10, 3, 14, tzinfo=timezone.utc)
+            .astimezone()
+            .strftime("%Y-%m-%d")
+        )
+        self.assertEqual(note_posted_date(ts), expected)
+
+    def test_returns_none_rather_than_raising_on_junk(self):
+        self.assertIsNone(note_posted_date(None))
+        self.assertIsNone(note_posted_date(""))
+        self.assertIsNone(note_posted_date("not a date"))
+
+
+class TeaserTests(unittest.TestCase):
+    def test_p_link_attachment_is_a_teaser(self):
+        self.assertTrue(note_is_teaser([TEASER_LINK_ATT]))
+
+    def test_plain_outbound_link_is_not_a_teaser(self):
+        # Regression guard: keying on "has a link attachment" instead of on the
+        # /p/ URL would silently drop ordinary daily notes.
+        self.assertFalse(note_is_teaser([OUTBOUND_LINK_ATT]))
+        self.assertFalse(note_record(_comment(attachments=[OUTBOUND_LINK_ATT]), HANDLE)["is_teaser"])
+
+    def test_post_attachment_is_a_teaser(self):
+        self.assertTrue(note_is_teaser([{"type": "post"}]))
+
+    def test_image_and_video_notes_are_not_teasers(self):
+        self.assertFalse(note_is_teaser([IMAGE_ATT]))
+        self.assertFalse(note_is_teaser([VIDEO_ATT]))
+
+    def test_empty_and_none_attachments(self):
+        self.assertFalse(note_is_teaser([]))
+        self.assertFalse(note_is_teaser(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_substack_note_body.py
+++ b/tests/test_substack_note_body.py
@@ -1,0 +1,99 @@
+"""A Note's ProseMirror body must match what Substack's composer sends (issue #185).
+
+``planning/substack/api_client.py::publish_note`` posts a Note over the HTTP API
+instead of driving the composer. The body is ProseMirror JSON and the endpoint
+accepts a malformed-but-parseable doc happily, so a wrong shape publishes a
+mangled Note **to the whole follower list** — irreversibly, since a Note has no
+draft state. That makes this shape worth pinning hard.
+
+Pinned here, all pure (no Substack, no network):
+
+* the ``doc`` wrapper carries ``schemaVersion: v1`` and a null title, and blank
+  lines split into separate ``paragraph`` nodes — both verified against the
+  stored ``body_json`` of already-published notes;
+* body text is inserted **literally**, never markdown-parsed (it comes from a
+  Notion column and legitimately contains ``*``, ``[`` and backticks);
+* an empty body raises rather than publishing a blank Note.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from planning.substack.api_client import build_note_body_json, note_permalink
+
+
+class NoteBodyJsonTests(unittest.TestCase):
+    def test_doc_wrapper_matches_substacks_own_shape(self):
+        doc = build_note_body_json("Hello.")
+        self.assertEqual(doc["type"], "doc")
+        self.assertEqual(doc["attrs"], {"schemaVersion": "v1", "title": None})
+
+    def test_single_line_is_one_paragraph(self):
+        doc = build_note_body_json("Shaming others is never acceptable.")
+        self.assertEqual(
+            doc["content"],
+            [{
+                "type": "paragraph",
+                "content": [{"type": "text",
+                             "text": "Shaming others is never acceptable."}],
+            }],
+        )
+
+    def test_blank_line_splits_into_separate_paragraphs(self):
+        doc = build_note_body_json("First para.\n\nSecond para.")
+        self.assertEqual(len(doc["content"]), 2)
+        self.assertEqual([p["type"] for p in doc["content"]], ["paragraph", "paragraph"])
+        self.assertEqual(doc["content"][1]["content"][0]["text"], "Second para.")
+
+    def test_multiple_blank_lines_do_not_create_empty_paragraphs(self):
+        doc = build_note_body_json("A.\n\n\n\nB.\n\n   \n\nC.")
+        self.assertEqual(len(doc["content"]), 3)
+        for para in doc["content"]:
+            self.assertTrue(para["content"][0]["text"].strip())
+
+    def test_body_text_is_literal_not_markdown(self):
+        # A real editorial body can contain any of these; markdown-parsing it
+        # would silently drop or restyle characters the author intended.
+        raw = "Why *args and [brackets] break `parsers` -- 100% of the time"
+        doc = build_note_body_json(raw)
+        self.assertEqual(doc["content"][0]["content"][0]["text"], raw)
+        self.assertEqual(doc["content"][0]["content"][0], {"type": "text", "text": raw})
+
+    def test_no_link_marks_are_invented(self):
+        doc = build_note_body_json("See https://example.invalid for more.")
+        node = doc["content"][0]["content"][0]
+        self.assertNotIn("marks", node)
+
+    def test_surrounding_whitespace_is_trimmed(self):
+        doc = build_note_body_json("\n\n  Padded.  \n\n")
+        self.assertEqual(len(doc["content"]), 1)
+        self.assertEqual(doc["content"][0]["content"][0]["text"], "Padded.")
+
+    def test_empty_body_raises_instead_of_publishing_blank(self):
+        for empty in ("", "   ", "\n\n", None):
+            with self.subTest(empty=empty):
+                with self.assertRaises(ValueError):
+                    build_note_body_json(empty)
+
+
+class NotePermalinkTests(unittest.TestCase):
+    def test_permalink_matches_the_reporting_post_id_format(self):
+        # Must equal what substack_native.note_record builds, or the editorial
+        # post_url and the posts table would key on different strings.
+        self.assertEqual(
+            note_permalink("someone", 123456789),
+            "https://substack.com/@someone/note/c-123456789",
+        )
+
+    def test_accepts_string_ids(self):
+        self.assertEqual(
+            note_permalink("someone", "123456789"),
+            "https://substack.com/@someone/note/c-123456789",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The daily Substack Note was the last thing in this repo still driving a headed browser on every single run — DOM selectors, a single-instance Chrome profile lock, and a real-Chrome launch to read three numbers and post one note. Both directions now have a browser-free path over Substack's private HTTP API, each behind its own flag with Playwright kept as a one-key rollback.

**Reading engagement** (`substack_posts.source: "native"`). A Note is not its own entity — it is a `comment` with `type: "feed"`, and `GET /reader/feed/profile/{user_id}?types[]=note` returns our own notes *with the engagement counts already in the payload*. So a feed scroll plus one page load per note collapses to two GETs. Substack's own feed bundle renders the note toolbar from `reaction_count` / `children_count` / `restacks` — the exact three fields mapped here, so this reads the numbers the DOM scrape was reading *off*, not a parallel statistic that could drift.

**Publishing** (`substack.note_source: "native"`). Three calls — `POST /image` → `POST /comment/attachment` → `POST /comment/feed`. Everything either side of the publish step (the Notion read, the idempotence guard, the empty-body refusal, the image resolution, the `post_url` write-back) is shared between backends, so they differ only in how the Note reaches Substack.

Two correctness wins beyond removing the browser:

- **The permalink is now exact.** The Playwright path published, then re-loaded the profile and took the topmost `/note/` anchor — a race against anything else posting. The native path uses the id the create call returns.
- **`posted_at` is converted UTC → local before the date is taken.** The API returns UTC where the scrape read a browser-local rendering, and the posts consolidator matches on local days. Slicing the first ten characters of the UTC string would have silently shifted late-evening notes onto the wrong day — the kind of bug that corrupts history rather than failing.

Note bodies and article text are inserted as **literal** text nodes, never markdown-parsed: the body is a Notion column that legitimately contains `*`, `[` and backticks.

## Validation

- **Live A/B, both engagement paths, same account, same moment: 10/10 records identical on every field**, no set difference either way, **0.9 s (native) vs 37.0 s (Playwright)**.
- **Live publish round-trip through the new code**: published in 1.7 s, read the stored note back (body matched, image attachment present, ProseMirror structure correct), then deleted and confirmed gone from the feed.
- Every live probe reused the text and image of an already-published note rather than posting new content, stayed live for seconds, and was deleted in a `finally:` block with the deletion verified. The account was re-checked afterwards: no test notes remain.
- Full wiring exercised through the real dispatcher (`get_api_data("substack_posts", …)`) and through `post_note()`'s dry-run, which returns 0 without publishing; an unknown `note_source` returns 2 rather than falling through to a backend.
- `py_compile` clean; `config_example.json` still parses; `docs/architecture.mmd` still renders.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests` — **85 tests, all green** (25 new, all pure/offline: no Notion, no Substack, no network).

## Known gaps, stated plainly

- **Video Notes are not migrated.** They upload through a separate mux pipeline (`media_upload_id`, `mux_asset_id`, `state: "transcoded"`) that was not reverse-engineered, so `post_substack_video_note.py` stays on Playwright. #185's scope named this, so it is filed as #189 rather than quietly dropped.
- **Teaser detection is implemented from payload shape, not from a specimen.** No newsletter-teaser note existed in the 144 most recent, so that one branch is the only part of the mapping without direct live evidence. Documented as such.
- Substack rewrites posted bodies server-side (URL-shaped text comes back split into nodes carrying `link` marks). The browser composer behaves identically, so this is parity — but stored `body_json` is not byte-identical to what was sent.

## Test plan

- [x] Engagement A/B against the live account — 10/10 records identical, both directions
- [x] Publish round-trip through the new code, read back and deleted, account verified clean
- [x] Dispatcher resolves `substack_posts` + `native` end-to-end
- [x] `post_note()` dry-run publishes nothing; unknown `note_source` refuses
- [x] UTC→local date conversion pinned by test, not just by eye
- [x] Full suite green (85 tests, 25 new)
- [x] `docs/architecture.mmd` updated in the same PR, per the repo's anti-staleness contract
- [x] No handle, user id, note id or publication URL introduced into the tree

Closes #185
