### PR TITLE
feat(substack): add native "like" support for Notes

### DIFF
--- a/docs/substack-native-api.md
+++ b/docs/substack-native-api.md
@@ -73,6 +73,8 @@ to avoid the library's construction-time round-trips.
 | Make a Note attachment | `POST /comment/attachment` | Body `{"url": <cdn url>, "type": "image"}` → `{id}`. |
 | Publish a Note | `POST /comment/feed` | Body `{"bodyJson": …, "attachmentIds": […], "replyMinimumRole": "everyone"}`. **Immediately public** — Notes have no draft state. |
 | Delete a Note | `DELETE /comment/{id}` | Returns `{}`. |
+| React to ("like") a Note | `POST /comment/{id}/reaction` | Body `{"reaction": "❤"}` — the only reaction type the composer sends. Idempotent (a second POST is a no-op). |
+| Remove a reaction | `DELETE /comment/{id}/reaction` | Same body. Idempotent (a DELETE with no existing reaction is a no-op). |
 
 ## Notes: a Note is a `comment`, and engagement comes free
 
@@ -149,6 +151,33 @@ Caveats worth knowing:
 - **Video notes are not supported natively.** They upload through a separate mux
   pipeline (`mux_asset_id` / `mux_playback_id` on the attachment) that was not
   reverse-engineered; `post_substack_video_note.py` stays on Playwright.
+
+### Reacting to ("liking") a Note (issue #186)
+
+`react_to_note(note_id)` / `unreact_to_note(note_id)` in `api_client.py` wrap
+`POST` / `DELETE /comment/{id}/reaction`. There is no existing "like" workflow
+in this repo to slot into, so these are exposed as a small manual CLI,
+`api_like.py`, alongside `api_pull.py`/`api_create.py` — not wired into any
+pipeline.
+
+The write route was **not** discoverable from the JS bundles either (same
+lesson as the Note-publish routes) — found by driving the real composer with
+a `page.on("request")` listener attached while clicking the heart icon on a
+throwaway note. A note permalink page renders a *feed* (the subject note plus
+recommended notes), each with its own Like button, so the click was scoped to
+the subject note's own container the same way
+`reporting/scrape_client/substack.py::_scrape_note_permalink` already scopes
+its engagement read — via the timestamp anchor pointing at `/note/c-<id>`,
+walked up to the smallest ancestor owning a `button[aria-label='Like']`.
+
+Verified live, end-to-end, three separate ways: (1) the browser-driven
+capture itself (click → `POST .../reaction` → `reaction_count` 0→1; click
+again → `DELETE .../reaction` → 0), (2) a pure-HTTP round trip with no
+browser at all, confirming the minimal body `{"reaction": "❤"}` is sufficient
+(no `tabId`/`publication_id` needed, despite the browser sending them), and
+(3) double-POST / double-DELETE idempotency (no error, count unchanged). Every
+probe created one throwaway note, reacted/un-reacted, then deleted it —
+nothing was left on the account.
 
 ### Verified by A/B against the browser path
 
@@ -237,5 +266,8 @@ Also shipped (#185): native **note engagement**
 **Note posting** (`substack.note_source = "native"` → `post_substack_note.py`).
 Both keep Playwright as a one-key rollback.
 
-Deferred: native **video** Note posting (mux upload pipeline, still Playwright);
-"like" support (#186).
+Also shipped (#186): native **"like" support** — `react_to_note` /
+`unreact_to_note` in `api_client.py`, exposed as the manual `api_like.py` CLI.
+
+Deferred: native **video** Note posting (mux upload pipeline, still Playwright;
+tracked in #189).

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -38,10 +38,12 @@ Modules:
 ```
 api_client.py        — session loader + fetch_follower_count() + fetch_own_notes()
                        + publish_note()/delete_note()
+                       + react_to_note()/unreact_to_note()
                        + SubstackAPI (pull/create/publish)
 extract_session.py   — harvest cookies+UA from the Chrome profile → api_session.json (gitignored)
 api_pull.py          — manual CLI: dump a post archive to JSON
 api_create.py        — manual CLI: create a draft edition (publish only with --confirm)
+api_like.py          — manual CLI: react to / remove a reaction from a Note
 ```
 
 The weekly newsletter has its own consumer of this client:
@@ -105,6 +107,16 @@ upload through a separate mux pipeline that isn't reverse-engineered.
 
 `api_create` defaults to draft + pre-publish validation and never publishes
 without `--confirm`; it is never wired into the daily cron.
+
+### Reacting to a Note
+
+```powershell
+& .\.venv\Scripts\python.exe -m planning.substack.api_like --note NOTE_ID_OR_URL
+& .\.venv\Scripts\python.exe -m planning.substack.api_like --note NOTE_ID_OR_URL --unlike
+```
+
+No existing "like" workflow to slot into (issue #186), so this is a standalone
+manual tool, not wired into any pipeline. Both calls are idempotent.
 
 ## Module layout
 

--- a/planning/substack/api_client.py
+++ b/planning/substack/api_client.py
@@ -70,6 +70,8 @@ __all__ = [
     "note_permalink",
     "publish_note",
     "delete_note",
+    "react_to_note",
+    "unreact_to_note",
     "build_section_nodes",
     "SubstackAPI",
     "SESSION_FILE",
@@ -324,6 +326,34 @@ def delete_note(note_id, *, session_file: Path = SESSION_FILE) -> None:
     """Delete a published Note. Used to clean up throwaway verification notes."""
     session, _ = load_session(session_file)
     _check(session.delete(f"{BASE_URL}/comment/{note_id}", timeout=30))
+
+
+# The heart is the only reaction the web composer sends — Notes have no other
+# reaction type (verified live, issue #186).
+NOTE_REACTION_HEART = "❤"
+
+
+def react_to_note(note_id, *, session_file: Path = SESSION_FILE) -> None:
+    """React ("like") to a Note. Idempotent — reacting twice leaves the count
+    unchanged (verified live: two consecutive POSTs both return 200, count
+    stays at 1)."""
+    session, _ = load_session(session_file)
+    _check(session.post(
+        f"{BASE_URL}/comment/{note_id}/reaction",
+        json={"reaction": NOTE_REACTION_HEART},
+        timeout=30,
+    ))
+
+
+def unreact_to_note(note_id, *, session_file: Path = SESSION_FILE) -> None:
+    """Remove a reaction from a Note. Idempotent — un-reacting when not
+    reacted is a no-op (verified live, same as the double-POST case)."""
+    session, _ = load_session(session_file)
+    _check(session.delete(
+        f"{BASE_URL}/comment/{note_id}/reaction",
+        json={"reaction": NOTE_REACTION_HEART},
+        timeout=30,
+    ))
 
 
 def _text_node(text: str, href: Optional[str] = None) -> dict:

--- a/planning/substack/api_like.py
+++ b/planning/substack/api_like.py
@@ -1,0 +1,55 @@
+r"""Manual CLI — react to / remove a reaction from a Substack Note (P2, issue #186).
+
+Uses the native HTTP API (cookie auth). NOT part of the daily cron — this repo
+has no existing "like" workflow to slot into, so this is a small standalone
+tool alongside api_pull.py / api_create.py.
+
+Usage (from the repo root):
+    & .\.venv\Scripts\python.exe -m planning.substack.api_like --note NOTE_ID_OR_URL
+    & .\.venv\Scripts\python.exe -m planning.substack.api_like --note NOTE_ID_OR_URL --unlike
+
+    --note VALUE   a Note id, or its https://substack.com/@handle/note/c-<id> URL
+    --unlike       remove the reaction instead of adding it
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+from planning.substack.api_client import react_to_note, unreact_to_note
+from planning.substack.substack_session import configure_logger
+
+_NOTE_ID_IN_URL = re.compile(r"/note/c-(\d+)")
+
+
+def _resolve_note_id(value: str) -> str:
+    """Accept either a bare note id or its public permalink."""
+    match = _NOTE_ID_IN_URL.search(value)
+    return match.group(1) if match else value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="React to (or remove a reaction from) a Substack Note.")
+    parser.add_argument("--note", required=True, help="Note id, or its .../note/c-<id> URL.")
+    parser.add_argument("--unlike", action="store_true", help="Remove the reaction instead of adding it.")
+    parser.add_argument("--debug", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    logger = configure_logger("substack_api_like", debug=args.debug)
+    note_id = _resolve_note_id(args.note)
+
+    if args.unlike:
+        unreact_to_note(note_id)
+        logger.info("💔 Removed reaction from note %s", note_id)
+    else:
+        react_to_note(note_id)
+        logger.info("❤️ Reacted to note %s", note_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-up from #91/#185's P2 backlog: the reaction ("like") endpoint was never reverse-engineered because P1 (pull/create/publish) and #185 (Note posting/engagement) came first. This spike reverse-engineers it and ships it.

`POST /api/v1/comment/{note_id}/reaction` (body `{"reaction": "❤"}`) reacts to a Note; `DELETE` on the same route removes the reaction. Both are idempotent. The heart is the only reaction the composer sends. No auth beyond the existing session cookie — same `load_session()` every other native call uses.

The write route wasn't discoverable by grepping JS bundles (same lesson as #185's publish routes — the composer is a lazily-imported webpack chunk). It was captured by driving the real Note composer with a Playwright network listener attached, scoping the click to the subject note's own container the same way `reporting/scrape_client/substack.py::_scrape_note_permalink` already scopes its engagement read (a note permalink renders a feed of multiple notes, each with its own Like button).

No existing "like" workflow in this repo to slot into, so this ships as `react_to_note()`/`unreact_to_note()` in `api_client.py`, exposed via a small manual CLI (`api_like.py`) alongside `api_pull.py`/`api_create.py` — not wired into any pipeline.

## Validation

- Findings comment posted on #186 with the full spike write-up.
- Verified live three separate ways: browser-driven capture (click → `reaction_count` 0→1, click again → 0), a pure-HTTP round trip with no browser (confirms the minimal body is sufficient), and double-call idempotency (two POSTs / two DELETEs in a row, no errors, correct final count).
- Every live probe created one throwaway note, reacted/un-reacted, then deleted the note — nothing left on the account.
- `py_compile` clean on changed files.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 85/85 passed (no new tests: `react_to_note`/`unreact_to_note` are thin network wrappers with no pure logic, same as the existing `publish_note`/`delete_note`, which are also unverified by unit test — validated live instead, per the repo's established pattern for this module).
- `docs/substack-native-api.md` + `planning/substack/README.md` updated.

## Test plan

- [x] Reaction endpoint reverse-engineered via live browser network capture
- [x] Pure-HTTP round trip confirms minimal payload works, no browser needed at call time
- [x] Idempotency confirmed (double-react, double-unreact)
- [x] Manual CLI (`api_like.py`) exercised end-to-end, both by note id and by permalink URL
- [x] No throwaway test note left on the live account
- [x] Full test suite green (85 tests)
- [x] Docs updated (endpoint map + README)

Closes #186