### PR TITLE
feat(substack): migrate the video Note off Playwright to the native API

### DIFF
--- a/docs/substack-native-api.md
+++ b/docs/substack-native-api.md
@@ -75,6 +75,11 @@ to avoid the library's construction-time round-trips.
 | Delete a Note | `DELETE /comment/{id}` | Returns `{}`. |
 | React to ("like") a Note | `POST /comment/{id}/reaction` | Body `{"reaction": "❤"}` — the only reaction type the composer sends. Idempotent (a second POST is a no-op). |
 | Remove a reaction | `DELETE /comment/{id}/reaction` | Same body. Idempotent (a DELETE with no existing reaction is a no-op). |
+| Start a video upload | `POST /video/upload?filetype=&fileSize=&fileName=` | No body. Returns `{mediaUpload: {id, state: "created", ...}, multipartUploadId, multipartUploadUrls: [...]}` — one **ready-to-use, presigned** S3 PUT URL per part. No client-side AWS signing needed. |
+| Upload a part | `PUT <presigned S3 URL>` | Raw bytes as the body. Response `ETag` header must be collected per part. |
+| Complete upload + kick off transcode | `POST /video/upload/{id}/transcode` | Body `{"duration": <seconds>, "multipart_upload_id": ..., "multipart_upload_etags": [...]}`. |
+| Poll transcode status | `GET /video/upload/{id}` | `state` goes `created` → `uploaded` → `transcoded`. |
+| Make a video Note attachment | `POST /comment/attachment` | Body `{"mediaUploadId": <id>, "type": "video"}` (vs. `{"url", "type": "image"}` for images) → `{id}`. |
 
 ## Notes: a Note is a `comment`, and engagement comes free
 
@@ -179,6 +184,61 @@ browser at all, confirming the minimal body `{"reaction": "❤"}` is sufficient
 probe created one throwaway note, reacted/un-reacted, then deleted it —
 nothing was left on the account.
 
+### Video Notes: chunked multipart upload + Mux transcode (issue #189)
+
+**Verdict: go.** The video-Note upload pipeline is reverse-engineered and
+shipped — `substack.note_source = "native"` now covers video Notes too, via
+`post_substack_video_note.py`'s native branch (same flag, same one-key
+rollback to `"playwright"` as the text/image path).
+
+The write routes were captured the same way as #185's — the composer is a
+lazily-imported webpack chunk, invisible to a bundle grep — by driving the
+real video Note composer with a network listener attached, attaching a
+synthetic throwaway clip (2s solid color + silence, zero real content), and
+observing the sequence:
+
+1. `POST /video/upload?filetype=&fileSize=&fileName=` (empty body) — the
+   response hands back a `media_upload_id`, a `multipartUploadId`, and one
+   **already-presigned** S3 PUT URL per part. No AWS credentials or
+   client-side SigV4 signing needed — Substack signs the URLs server-side.
+2. `PUT` the file's bytes directly to each presigned URL (S3 multipart
+   upload), collecting the response `ETag` header per part.
+3. `POST /video/upload/{id}/transcode` with the source duration + the
+   multipart upload id + the collected ETags. This both completes the S3
+   multipart upload and kicks off Mux transcoding.
+4. Poll `GET /video/upload/{id}` until `state == "transcoded"`.
+5. `POST /comment/attachment` with `{"mediaUploadId": <id>, "type": "video"}`
+   (vs. `{"url", "type": "image"}` for images) → an attachment id, then
+   `POST /comment/feed` exactly as for an image Note.
+
+**How many parts, and how are they split?** The server decides: part count
+scales as `ceil(fileSize / 50_000_000)` (empirically confirmed by scanning
+declared `fileSize` values from 5MB to 500MB — file sizes of 50MB, 90MB,
+100MB, 150MB, 200MB and 500MB produced 1, 2, 2, 3, 4 and 10 parts
+respectively). The client only needs to slice the file into **exactly as
+many parts as URLs came back**, in order — S3 multipart upload only requires
+order-preserving parts of at least 5MB (except the last), not that part
+boundaries match the server's own internal chunk-size assumption. An
+equal-`ceil`-division slice was verified live with a real 2-part (~54MB)
+upload: the reconstructed video's duration and resolution matched the
+source exactly, confirming the byte-boundary choice doesn't have to mirror
+the server's internal accounting.
+
+**The duration must be supplied by the caller.** The transcode call needs it
+up front, before Mux has produced anything to derive it from.
+`post_substack_video_note.py`'s native branch gets it via
+`planning.videos.videos_session.probe_duration_seconds` (ffprobe), matching
+the fleet's Windows console-suppression convention.
+
+Verified live, end-to-end, through the actual shipped code (not just the
+discovery probe): `publish_note(text, video_path=..., video_duration_seconds=...)`
+uploads, transcodes, attaches, and publishes a throwaway video Note; the
+published note verifies as `is_video=True` with the correct `mediaUpload`
+state via `fetch_own_notes()`; the note is then deleted and its absence
+confirmed. Every probe used a synthetic clip generated locally with `ffmpeg`
+(solid color + silence, or a `testsrc` test pattern for the larger
+multi-part test) — no real or unreleased content was ever touched.
+
 ### Verified by A/B against the browser path
 
 Both `fetch_posts` implementations were run back-to-back against the live
@@ -245,9 +305,13 @@ Article titles are emitted as **literal text nodes**, never run through
 - Beware: a `GET` on a POST-only route returns **404, not 405** (Express routes
   per method), so "GET says 404" is *not* evidence that a write route is absent.
   An early pass in the spike drew the wrong conclusion from exactly this.
-- Video Notes remain Playwright-only (separate mux upload pipeline).
 - No rate limiting was observed across the spike's calls (including a 12-page
   cursor walk over 144 notes), but it is unmeasured at daily-cron scale.
+- The video-upload part-size scaling (`ceil(fileSize / 50_000_000)`) was
+  observed empirically, not documented anywhere — a future Substack change to
+  that threshold wouldn't break anything (the client always slices into
+  exactly as many parts as URLs the server returns), but is worth knowing if
+  upload timing shifts unexpectedly.
 
 ## Scope today vs. follow-ups
 
@@ -269,5 +333,8 @@ Both keep Playwright as a one-key rollback.
 Also shipped (#186): native **"like" support** — `react_to_note` /
 `unreact_to_note` in `api_client.py`, exposed as the manual `api_like.py` CLI.
 
-Deferred: native **video** Note posting (mux upload pipeline, still Playwright;
-tracked in #189).
+Also shipped (#189): native **video** Note posting — chunked multipart
+upload + Mux transcode, wired into `post_substack_video_note.py` behind the
+same `substack.note_source` flag, Playwright kept as the rollback.
+
+Nothing deferred from the #91/#185/#186/#189 spike chain remains outstanding.

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -91,8 +91,15 @@ taking whatever is topmost.
 
 Because a Note has no draft state, publishing is immediate and public;
 `--dry-run` is enforced before the publish call, so it never reaches Substack.
-**Video** notes (`post_substack_video_note.py`) remain Playwright-only — they
-upload through a separate mux pipeline that isn't reverse-engineered.
+
+**Video** notes (`post_substack_video_note.py`) support the same
+`note_source` flag (issue #189): `"native"` does a chunked multipart upload
++ Mux transcode over the HTTP API — no browser at request time — via the
+same `POST /comment/feed` publish step once the upload transcodes. The
+video's duration is probed with ffprobe
+(`planning.videos.videos_session.probe_duration_seconds`) before the upload,
+since the transcode call needs it up front. `"playwright"` (default) stays
+the one-key rollback.
 
 ### Manual archive + create
 

--- a/planning/substack/api_client.py
+++ b/planning/substack/api_client.py
@@ -39,6 +39,7 @@ import mimetypes
 import os
 import re
 import tempfile
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -62,6 +63,7 @@ logger = logging.getLogger("substack_api")
 
 __all__ = [
     "SessionExpiredError",
+    "VideoTranscodeError",
     "load_session",
     "fetch_follower_count",
     "fetch_own_notes",
@@ -271,17 +273,130 @@ def _create_note_attachment(session: requests.Session, image_url: str) -> str:
     return attachment_id
 
 
+class VideoTranscodeError(RuntimeError):
+    """Raised when Substack's Mux transcode of an uploaded video fails or times out."""
+
+
+# A part every 50MB (server-observed, issue #189 — parts scale as
+# ceil(fileSize / 50_000_000)); S3 multipart only requires order-preserving,
+# >=5MB-except-last parts, so slicing into exactly as many equal parts as the
+# server hands back URLs for is correct regardless of the server's own
+# internal chunk-size convention (verified live with a real 2-part upload).
+VIDEO_PART_UPLOAD_TIMEOUT_S = 180
+VIDEO_TRANSCODE_POLL_INTERVAL_S = 3
+VIDEO_TRANSCODE_TIMEOUT_S = 300
+
+
+def _upload_video(session: requests.Session, video_path: Path, duration_seconds: float) -> str:
+    """Upload a video through Substack's chunked multipart pipeline and kick off
+    the Mux transcode. Returns the ``media_upload_id``.
+
+    Mirrors what the real composer does (issue #189), captured by driving it
+    with a network listener attached (the write routes are lazily-imported
+    webpack chunks, invisible to a bundle grep — same lesson as #185):
+
+    1. ``POST /video/upload?filetype=&fileSize=&fileName=`` — no body; the
+       response hands back a ready-to-use ``media_upload_id`` plus one
+       presigned S3 PUT URL per part (no client-side AWS signing needed).
+    2. ``PUT`` each part directly to its presigned URL, collecting the
+       ``ETag`` response header per part.
+    3. ``POST /video/upload/{id}/transcode`` with the source duration, the
+       multipart upload id, and the collected ETags — this both completes
+       the S3 multipart upload and kicks off Mux transcoding.
+    """
+    size = video_path.stat().st_size
+    mime = mimetypes.guess_type(str(video_path))[0] or "video/mp4"
+    resp = _check(session.post(
+        f"{BASE_URL}/video/upload",
+        params={"filetype": mime, "fileSize": size, "fileName": video_path.name},
+        timeout=60,
+    ))
+    data = resp.json() or {}
+    media_upload_id = (data.get("mediaUpload") or {}).get("id")
+    multipart_upload_id = data.get("multipartUploadId")
+    urls = data.get("multipartUploadUrls") or []
+    if not media_upload_id or not multipart_upload_id or not urls:
+        raise RuntimeError(
+            "Substack /video/upload returned no media upload id / part URLs — "
+            "endpoint may have changed."
+        )
+
+    file_bytes = video_path.read_bytes()
+    n_parts = len(urls)
+    part_size = -(-len(file_bytes) // n_parts)  # ceil division
+    etags = []
+    for i, part_url in enumerate(urls):
+        chunk = file_bytes[i * part_size:(i + 1) * part_size]
+        put_resp = session.put(part_url, data=chunk, timeout=VIDEO_PART_UPLOAD_TIMEOUT_S)
+        put_resp.raise_for_status()
+        etag = put_resp.headers.get("ETag")
+        if not etag:
+            raise RuntimeError(f"S3 part {i + 1}/{n_parts} upload returned no ETag header.")
+        etags.append(etag)
+
+    _check(session.post(
+        f"{BASE_URL}/video/upload/{media_upload_id}/transcode",
+        json={
+            "duration": duration_seconds,
+            "multipart_upload_id": multipart_upload_id,
+            "multipart_upload_etags": etags,
+        },
+        timeout=60,
+    ))
+    return media_upload_id
+
+
+def _wait_for_video_transcode(
+    session: requests.Session,
+    media_upload_id: str,
+    *,
+    timeout_s: int = VIDEO_TRANSCODE_TIMEOUT_S,
+) -> None:
+    """Poll ``GET /video/upload/{id}`` until Mux reports ``state == "transcoded"``."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        data = _check(session.get(f"{BASE_URL}/video/upload/{media_upload_id}", timeout=30)).json()
+        state = data.get("state")
+        if state == "transcoded":
+            return
+        if state in ("errored", "failed"):
+            raise VideoTranscodeError(
+                f"Substack video transcode failed (state={state!r}) for media_upload_id={media_upload_id}."
+            )
+        time.sleep(VIDEO_TRANSCODE_POLL_INTERVAL_S)
+    raise VideoTranscodeError(
+        f"Video {media_upload_id} did not reach 'transcoded' within {timeout_s}s."
+    )
+
+
+def _create_video_attachment(session: requests.Session, media_upload_id: str) -> str:
+    """Turn a transcoded media upload into a Note attachment id."""
+    resp = _check(session.post(
+        f"{BASE_URL}/comment/attachment",
+        json={"mediaUploadId": media_upload_id, "type": "video"},
+        timeout=30,
+    ))
+    attachment_id = (resp.json() or {}).get("id")
+    if not attachment_id:
+        raise RuntimeError(
+            "Substack /comment/attachment (video) returned no 'id' — endpoint may have changed."
+        )
+    return attachment_id
+
+
 def publish_note(
     text: str,
     *,
     image_path: Optional[Path] = None,
+    video_path: Optional[Path] = None,
+    video_duration_seconds: Optional[float] = None,
     session_file: Path = SESSION_FILE,
 ) -> dict:
     """Publish a Substack Note over the native API. Returns the created note dict.
 
     **This is immediately public** — a Note has no draft state, so there is no
-    dry-run at this layer; callers own that gate (``post_substack_note.py``
-    short-circuits before reaching here).
+    dry-run at this layer; callers own that gate (``post_substack_note.py``/
+    ``post_substack_video_note.py`` short-circuit before reaching here).
 
     A Note is a ``comment`` of ``type == "feed"``. With an image it is three
     calls, mirroring exactly what the web composer sends:
@@ -290,14 +405,22 @@ def publish_note(
     2. ``POST /comment/attachment`` — that URL → an attachment id.
     3. ``POST /comment/feed`` — ``bodyJson`` + ``attachmentIds``.
 
+    With a video, the attachment step is a chunked multipart upload + Mux
+    transcode instead (issue #189) — see :func:`_upload_video`. Pass exactly
+    one of ``image_path``/``video_path``; ``video_path`` requires
+    ``video_duration_seconds`` (the transcode call needs it up front, before
+    Mux has produced anything to derive it from — get it via
+    ``planning.videos.videos_session.probe_duration_seconds``).
+
     Unlike the Playwright path this returns the created note's **own** id, so
     the permalink is exact rather than "whatever is topmost on the profile a
     moment later".
-
-    Video notes are **not** supported here — they upload through a separate mux
-    pipeline that is not reverse-engineered; ``post_substack_video_note.py``
-    stays on Playwright.
     """
+    if image_path and video_path:
+        raise ValueError("publish_note: pass image_path or video_path, not both.")
+    if video_path and video_duration_seconds is None:
+        raise ValueError("publish_note: video_path requires video_duration_seconds.")
+
     body_json = build_note_body_json(text)  # validate before any network call
     session, _ = load_session(session_file)
 
@@ -310,6 +433,14 @@ def publish_note(
         payload["attachmentIds"] = [
             _create_note_attachment(session, _upload_note_image(session, image_path))
         ]
+    elif video_path:
+        video_path = Path(video_path)
+        if not video_path.exists():
+            raise FileNotFoundError(f"Note video not found: {video_path}")
+        logger.info("📤 Uploading note video: %s (%.1fs)", video_path.name, video_duration_seconds)
+        media_upload_id = _upload_video(session, video_path, video_duration_seconds)
+        _wait_for_video_transcode(session, media_upload_id)
+        payload["attachmentIds"] = [_create_video_attachment(session, media_upload_id)]
 
     resp = _check(session.post(f"{BASE_URL}/comment/feed", json=payload, timeout=60))
     data = resp.json() or {}

--- a/planning/substack/post_substack_video_note.py
+++ b/planning/substack/post_substack_video_note.py
@@ -2,15 +2,24 @@
 
 Triggered from the daily Substack pipeline on video days (rows where
 ``Work in Progress Video`` is checked AND ``clip SB(v)`` is populated).
-Resolves the shared clip page once, then drives the same Note composer
-used by ``post_substack_note`` — but uses the camera/video toolbar icon
-(screenshot 4) instead of the image icon, and uploads the .mp4 from the
-clip's ``clipPC``/``filePC`` properties. On success, writes
-``link SB(v)`` on the editorial row so the videos orchestrator's next run
-can untick the shared ``Work in Progress Video`` checkbox.
+Resolves the shared clip page once, then either publishes natively or drives
+the same Note composer used by ``post_substack_note`` (the camera/video
+toolbar icon instead of the image icon), uploading the .mp4 from the clip's
+``clipPC``/``filePC`` properties. On success, writes ``link SB(v)`` on the
+editorial row so the videos orchestrator's next run can untick the shared
+``Work in Progress Video`` checkbox.
 
 The video Note's caption is the clip page's ``Text`` property (the same
 short caption that feeds IG/TW/TH).
+
+**Two publish backends**, chosen by ``substack.note_source`` in
+``config.json`` (same flag and one-key rollback as ``post_substack_note.py``):
+
+* ``"playwright"`` (default) — drives the real-Chrome Note composer.
+* ``"native"`` — chunked multipart upload to Substack's HTTP API + Mux
+  transcode, no browser at request time (issue #189). The video's duration
+  is probed via ffprobe (``planning.videos.videos_session.probe_duration_seconds``)
+  before the upload, since the transcode call needs it up front.
 
 CLI (standalone — same flags shape as ``post_substack_note``):
 
@@ -58,6 +67,26 @@ from reporting.notion.editorial import (  # noqa: E402
 )
 
 logger = logging.getLogger("substack_post_video_note")
+
+
+def _publish_native(cfg: dict, body_text: str, video_path: Path) -> str:
+    """Publish the video Note over the HTTP API; return its permalink.
+
+    Same shape as ``post_substack_note.py::_publish_native`` — imported
+    lazily so the Playwright path never pays for it and a missing
+    ``api_session.json`` can't break the default backend.
+    """
+    from planning.substack.api_client import (
+        fetch_self_handle,
+        note_permalink,
+        publish_note,
+    )
+    from planning.videos.videos_session import probe_duration_seconds
+
+    duration = probe_duration_seconds(video_path)
+    note = publish_note(body_text, video_path=video_path, video_duration_seconds=duration)
+    handle = note.get("handle") or cfg.get("handle") or fetch_self_handle()
+    return note_permalink(handle, note["id"])
 
 
 def parse_args() -> argparse.Namespace:
@@ -207,6 +236,36 @@ def _post_video_note_for_row(
     if not payload.caption_short:
         logger.error("❌ Clip page has empty 'Text' caption — refusing to post empty Note.")
         return 5
+
+    note_source = str(cfg.get("note_source", "playwright")).lower()
+    if note_source not in ("playwright", "native"):
+        logger.error(
+            "❌ Unknown substack.note_source %r — expected 'playwright' or 'native'.",
+            note_source,
+        )
+        return 2
+
+    if note_source == "native":
+        if dry_run:
+            logger.info(
+                "✅ DRY-RUN (native): would publish video %s (%d chars caption) — nothing was posted.",
+                payload.video_path.name, len(payload.caption_short),
+            )
+            return 0
+        logger.info("🔌 Publishing the video Note via the native HTTP API (no browser).")
+        try:
+            note_url = _publish_native(cfg, payload.caption_short, payload.video_path)
+        except Exception as err:  # noqa: BLE001
+            logger.error("❌ Native video note publish failed: %s", err)
+            return 9
+        logger.info("🔗 Published video note URL: %s", note_url)
+        try:
+            set_field(notion, page_id, "post_url_sb", note_url, video_cols, "url")
+            sb_col = video_cols.get("post_url_sb", "link SB")
+            logger.info("✅ Wrote %s on editorial row.", sb_col)
+        except Exception as err:
+            logger.warning("⚠️ Posted OK but failed to write SB post URL: %s", err)
+        return 0
 
     try:
         session.goto_with_login_check(cfg["profile_url"])

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -271,8 +271,10 @@ attach helper. See:
 - `__init__.py` — empty package marker.
 - `videos_session.py` — config loader, Notion token loader, `ClipPayload`
   dataclass, `load_clip_payload(notion, editorial_row, video_cols, clip_cols)`,
-  OneDrive hydration (`ensure_local_file`), and platform-safe transcode
-  (`ensure_platform_safe_clip`).
+  OneDrive hydration (`ensure_local_file`), platform-safe transcode
+  (`ensure_platform_safe_clip`), and clip duration probing
+  (`probe_duration_seconds`, via ffprobe — used by the native Substack video
+  Note path, `planning/substack/post_substack_video_note.py`).
 - `schedule_videos_posts.py` — orchestrator entry point. Implements the
   `main() -> tuple[int, list[dict]]` contract consumed by
   `planning_pipeline.py`.

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -353,6 +353,28 @@ def _probe_video(path: Path) -> Optional[dict]:
     }
 
 
+def probe_duration_seconds(path: Path) -> float:
+    """Return a clip's duration in seconds via ffprobe.
+
+    Needed by the native Substack video-Note path (issue #189): the
+    ``/video/upload/{id}/transcode`` call requires the source duration
+    up front, before Mux has transcoded anything to derive it from.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        raise RuntimeError("ffprobe not found on PATH — required to read the clip's duration.")
+    proc = subprocess.run(
+        [ffprobe, "-v", "error", "-show_entries", "format=duration", "-of", "json", str(path)],
+        check=True, capture_output=True, timeout=60,
+        creationflags=_no_window_flags(),
+    )
+    data = json.loads(proc.stdout or b"{}")
+    duration = (data.get("format") or {}).get("duration")
+    if duration is None:
+        raise RuntimeError(f"ffprobe returned no duration for {path}.")
+    return float(duration)
+
+
 def _needs_transcode(probe: dict, tcfg: dict) -> tuple[bool, str]:
     """Decide whether a probed master trips a platform-safety threshold."""
     size_mb = probe["size"] / 1_048_576
@@ -577,4 +599,5 @@ __all__ = [
     "load_clip_payload",
     "load_notion_token",
     "load_videos_config",
+    "probe_duration_seconds",
 ]


### PR DESCRIPTION
## Summary

Follow-up from #185: the daily image/text Note was moved off Playwright to Substack's native HTTP API, but video Notes (`post_substack_video_note.py`, the video-day branch) stayed Playwright-only because the mux upload pipeline wasn't reverse-engineered. This spike reverse-engineers it and ships it.

The write routes weren't discoverable by grepping JS bundles (same lesson as #185 — the composer is a lazily-imported webpack chunk). Captured by driving the real video Note composer with a Playwright network listener attached, using a synthetic throwaway clip (solid color + silence, generated locally with ffmpeg — zero real content):

1. `POST /video/upload?filetype=&fileSize=&fileName=` (empty body) → the response hands back a `media_upload_id`, a `multipartUploadId`, and one **already-presigned** S3 PUT URL per part — no client-side AWS signing needed, Substack signs server-side.
2. `PUT` the file's bytes to each presigned URL (S3 multipart upload), collecting the response `ETag` per part.
3. `POST /video/upload/{id}/transcode` with `{duration, multipart_upload_id, multipart_upload_etags}` — completes the multipart upload and kicks off Mux transcode.
4. Poll `GET /video/upload/{id}` until `state == "transcoded"`.
5. `POST /comment/attachment` with `{"mediaUploadId": <id>, "type": "video"}`, then the existing `POST /comment/feed` publish call.

The server decides part count (`ceil(fileSize / 50_000_000)`, confirmed by scanning declared sizes from 5MB–500MB) — the client just slices into exactly as many equal parts as URLs came back; S3 multipart only requires order-preserving, ≥5MB-except-last parts, not that boundaries match the server's own internal convention. Verified live with a real ~54MB/2-part upload: reconstructed duration/resolution matched the source exactly.

`substack.note_source = "native"` now covers video Notes too (`post_substack_video_note.py`'s native branch), same flag and one-key rollback to `"playwright"` as the text/image path. Duration is probed via ffprobe (new `planning.videos.videos_session.probe_duration_seconds`) since the transcode call needs it up front.

## Validation

- Findings comment posted on #189 with the full spike write-up.
- Verified live three ways: (1) browser-driven discovery capture, canceled before publish — no note created; (2) a full pure-HTTP round trip through the actual shipped code (`publish_note(text, video_path=..., video_duration_seconds=...)`) — upload → transcode → attach → publish → verified `is_video=True` via `fetch_own_notes()` → deleted → confirmed gone; (3) a real ~54MB/2-part multipart upload proving the chunking approach generalizes.
- Every publish probe used a synthetic ffmpeg-generated clip and was deleted immediately after verification — no real or unreleased content was touched, nothing left on the account.
- `py_compile` clean on changed files.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 85/85 passed (no new tests: the new functions are thin network wrappers with no pure logic to unit test, same as the existing `publish_note`/`delete_note`, validated live instead per this module's established pattern).
- `docs/substack-native-api.md`, `planning/substack/README.md`, and `planning/videos/README.md` updated.

## Test plan

- [x] Video upload pipeline reverse-engineered via live browser network capture
- [x] Pure-HTTP round trip through the shipped code: publish → verify → delete
- [x] Multi-part chunking verified with a real ~54MB/2-part upload
- [x] `post_substack_video_note.py`'s native branch (`_publish_native`) exercised end-to-end
- [x] No throwaway test note left on the live account
- [x] Full test suite green (85 tests)
- [x] Docs updated (endpoint map + READMEs)

Closes #189