### PR TITLE
chore: ignore launcher-tmp scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ engagement/classify/local_model.json
 
 # LLM fallback verdict cache (per-machine performance cache; truth lives in Supabase).
 engagement/classify/.llm_cache.json
+# Launcher scratch (ephemeral images/logs written by the tray launcher)
+.launcher-tmp/


### PR DESCRIPTION
Backfill .launcher-tmp/ into the .gitignore so the app-launcher session host's ephemeral upload scratch dir doesn't get tracked when a session is rooted here.

Part of ferraroroberto/fleet-config#496