### PR TITLE
docs: add llm_fallback block to config_example.json engagement section

### DIFF
--- a/config/config_example.json
+++ b/config/config_example.json
@@ -294,6 +294,13 @@
             "expand_max_clicks": 30,
             "expand_settle_ms": 1200,
             "page_settle_ms": 2500
+        },
+        "llm_fallback": {
+            "enabled": true,
+            "base_url": "http://127.0.0.1:8000",
+            "model": "claude_haiku",
+            "cache_path": "engagement/classify/.llm_cache.json",
+            "timeout_seconds": 20
         }
     },
     "slack": {


### PR DESCRIPTION
## Summary

Surfaced by `/codebase-audit`: `engagement/README.md` documents `engagement.llm_fallback` (`enabled`/`base_url`/`model`/`cache_path`/`timeout_seconds`) as shipped config and marks Phase 3 (LLM fallback) as complete, but `config/config_example.json`'s `engagement` block carried no `llm_fallback` key — a fresh setup copied from the template landed a config that didn't match what the docs (and the pipeline) actually read. Mirrors the block already present in the real `config.json` so the template matches both the docs and the live config.

## Validation

- Confirmed `config/config_example.json` is valid JSON.
- Ran the repo's pytest suite (`tests/`): 85 passed, 4 subtests passed.
- No CI workflow, verification-gate script, or UX/deploy-coverage surface applies to this repo (JSON-template-only doc fix).

Closes #199
