### PR TITLE
fix: use chromium_sandbox and doc_capture kwargs in browser launches

### DIFF
--- a/config/chrome_launch.py
+++ b/config/chrome_launch.py
@@ -64,6 +64,10 @@ def stealth_launch_kwargs(user_data_dir: str, *, headless: bool = False) -> dict
       a Spanish-language account, the account setting wins and must be
       flipped to English manually once (Settings → Account preferences →
       Language).
+    * ``chromium_sandbox=True`` — enables Playwright's sandbox (the default
+      ``False`` implicitly injects ``--no-sandbox``, which pops Chrome's
+      "unsupported command-line flag" infobar — itself a bot tell of the
+      same class as the automation infobar above).
     """
     return {
         "user_data_dir": user_data_dir,
@@ -80,13 +84,9 @@ def stealth_launch_kwargs(user_data_dir: str, *, headless: bool = False) -> dict
         "ignore_default_args": [
             "--enable-automation",
             "--enable-blink-features=IdleDetection",
-            # Stops the yellow "You are using an unsupported command-line flag:
-            # --no-sandbox. Stability and security will suffer." infobar. The
-            # sandbox is still effectively disabled by Playwright's process
-            # model — this just hides Chrome's protest about that.
-            "--no-sandbox",
         ],
         "viewport": {"width": 1280, "height": 900},
+        "chromium_sandbox": True,
     }
 
 
@@ -119,6 +119,8 @@ def doc_capture_launch_kwargs(*, headless: bool = True) -> dict[str, Any]:
     (``channel="chrome"``) so the rendering matches what the user sees;
     ``--force-color-profile=srgb`` + ``--hide-scrollbars`` remove the two
     remaining sources of pixel drift between machines/runs.
+    ``chromium_sandbox=True`` enables Playwright's sandbox rather than
+    letting it silently inject ``--no-sandbox``.
     """
     return {
         "channel": "chrome",
@@ -131,6 +133,7 @@ def doc_capture_launch_kwargs(*, headless: bool = True) -> dict[str, Any]:
             "--no-first-run",
             "--lang=en-US",
         ],
+        "chromium_sandbox": True,
     }
 
 

--- a/engagement/check_review_app.py
+++ b/engagement/check_review_app.py
@@ -29,7 +29,7 @@ from playwright.sync_api import Page, TimeoutError as PWTimeoutError, sync_playw
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.append(str(REPO_ROOT))
 
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from config.chrome_launch import doc_capture_context_kwargs, doc_capture_launch_kwargs  # noqa: E402
 from config.console import force_utf8_stdio  # noqa: E402
 from engagement.db.client import supabase_client  # noqa: E402
 
@@ -88,13 +88,15 @@ def run() -> int:
 
     fails = 0
     with sync_playwright() as pw:
-        # Fresh context, no persistent profile — local app, no auth needed.
-        kwargs = stealth_launch_kwargs(str(out_dir / "_browser"), headless=True)
-        # Drop persistent_context dir — we just want a clean throwaway context.
-        kwargs.pop("user_data_dir", None)
-        browser = pw.chromium.launch(channel=kwargs.get("channel"), headless=True, args=kwargs.get("args"))
-        context = browser.new_context(viewport={"width": 1400, "height": 1800})
-        context.add_init_script(STEALTH_INIT_SCRIPT)
+        # Fresh context, no persistent profile — drives our own localhost
+        # Streamlit app, so the doc-capture profile applies (determinism and
+        # isolation, not stealth — there's nothing to hide from on localhost).
+        browser = pw.chromium.launch(**doc_capture_launch_kwargs(headless=True))
+        context_kwargs = doc_capture_context_kwargs()
+        # Taller viewport than the doc-capture default — this app's cards
+        # need more vertical room than the control-panel screenshots do.
+        context_kwargs["viewport"] = {"width": 1400, "height": 1800}
+        context = browser.new_context(**context_kwargs)
         page = context.new_page()
 
         print("\n📱 step 1 — open the app")


### PR DESCRIPTION
## Summary

Surfaced by `/codebase-audit` (drift against the global `~/.claude/CLAUDE.md`): `config/chrome_launch.py` set the sandbox rule via the rejected workaround — listing `--no-sandbox` in `ignore_default_args` instead of setting `chromium_sandbox=True` — on both `stealth_launch_kwargs` and `doc_capture_launch_kwargs`. Separately, `engagement/check_review_app.py` reached for `stealth_launch_kwargs` (the persistent-profile variant meant for real logged-in social sessions) and manually cherry-picked only `channel`/`args` out of it, silently dropping `ignore_default_args`, `viewport`, and `locale`, instead of using the purpose-built `doc_capture_launch_kwargs()` / `doc_capture_context_kwargs()` pair that already exists for exactly this case (driving our own localhost app, non-persistent, determinism over stealth).

Fixes both: `chromium_sandbox=True` on both kwargs builders (drops the `--no-sandbox` entry and its justifying comment), and `check_review_app.py` now uses `doc_capture_launch_kwargs()` / `doc_capture_context_kwargs()` directly.

The audit's third finding (missing type hints across `reporting/process/*` etc.) is explicitly scoped out — the issue itself calls it opportunistic, next-touch work, not a mass-edit PR.

## Validation

- Ran the repo's test suite (`tests/`): `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 85/85 passed.
- No UX-conformance surface touched (Playwright launch config, not Streamlit UI).
- No CI workflow or deploy-coverage surface declared for this repo.

Closes #197
