### PR TITLE
fix: dedupe audit findings across planning, reporting, and engagement

### DIFF
--- a/app/process_runner.py
+++ b/app/process_runner.py
@@ -251,54 +251,41 @@ def clear_log(name: str) -> None:
 # ---------- rendering ----------
 
 def render_status_badge(name: str) -> None:
-    if is_running(name):
-        st.info(f"⏳ running  ·  started {_get_meta(name).get('started_at', '')}")
-        return
-    rc = exit_code(name)
-    if rc is None:
-        st.caption("idle  ·  no run yet this session")
-    elif rc == 0:
-        st.success("✅ last run finished cleanly")
-    else:
-        st.error(f"❌ last run failed (exit {rc})")
+    """Single-pipeline status badge — a strict special case of
+    :func:`render_combined_status_badge` for a group of exactly one."""
+    render_combined_status_badge([name])
 
 
 def render_log_panel(name: str, *, height: int = 380, autorefresh_secs: float = 1.0) -> None:
-    """Render the rolling log tail. While the subprocess is alive, sleep + rerun
-    once so the user sees a live stream without clicking refresh.
-
-    Uses a scrollable container + st.code (display element, not a widget) so
-    the body actually updates on every rerun. A keyed st.text_area caches its
-    first-render value in session_state and ignores subsequent `value=` args,
-    which left the panel stuck on "(no output yet)" while the deque filled up.
-    """
-    lines = list(_get_lines(name))
-    body = "\n".join(lines) if lines else "(no output yet)"
-    with st.container(height=height, border=True, autoscroll=True):
-        st.code(body, language=None, wrap_lines=False)
-    with st.container(horizontal=True, gap="small"):
-        st.button("🛑 stop", key=f"_proc_{name}_stop", on_click=stop_pipeline, args=(name,), disabled=not is_running(name))
-        st.button("🧹 clear", key=f"_proc_{name}_clear", on_click=clear_log, args=(name,), disabled=is_running(name))
-    if is_running(name):
-        time.sleep(autorefresh_secs)
-        st.rerun()
+    """Single-pipeline log panel — a strict special case of
+    :func:`render_combined_log_panel` for a group of exactly one."""
+    render_combined_log_panel([name], height=height, autorefresh_secs=autorefresh_secs)
 
 
 def render_combined_status_badge(names: list[str]) -> None:
     """One badge for a group of pipelines that share a UI section. Shows which
     pipeline is currently running (if any) and the worst exit code from the
-    last completed runs (a single nonzero exit wins)."""
+    last completed runs (a single nonzero exit wins).
+
+    For a group of exactly one, this reproduces the plain single-pipeline
+    wording verbatim (no name prefix, exit code shown instead of a name list)
+    — the shape :func:`render_status_badge` delegates to.
+    """
     running = [n for n in names if is_running(n)]
     if running:
         meta = _get_meta(running[0])
-        st.info(f"⏳ {running[0]} running  ·  started {meta.get('started_at', '')}")
+        prefix = f"{running[0]} " if len(names) > 1 else ""
+        st.info(f"⏳ {prefix}running  ·  started {meta.get('started_at', '')}")
         return
     codes = [exit_code(n) for n in names]
     if all(c is None for c in codes):
         st.caption("idle  ·  no run yet this session")
     elif any(c is not None and c != 0 for c in codes):
-        failed = [n for n, c in zip(names, codes) if c not in (None, 0)]
-        st.error(f"❌ last run failed: {', '.join(failed)}")
+        if len(names) == 1:
+            st.error(f"❌ last run failed (exit {codes[0]})")
+        else:
+            failed = [n for n, c in zip(names, codes) if c not in (None, 0)]
+            st.error(f"❌ last run failed: {', '.join(failed)}")
     else:
         st.success("✅ last run finished cleanly")
 

--- a/engagement/classify/phrases_io.py
+++ b/engagement/classify/phrases_io.py
@@ -1,0 +1,57 @@
+"""Leaf module for picking a canned "thanks" reply from ``phrases.json``.
+
+Deliberately has no dependency on ``engagement.db.client`` or
+``engagement.classify.rules`` — safe for both to import without a cycle.
+Single-source for the reply-picking logic that had drifted into two
+independent implementations: ``engagement/db/client.py``'s
+``_pick_thanks_reply`` existed only to dodge the very cycle this module
+avoids (``rules.py`` already imports from ``client.py``), so a
+``phrases.json`` schema change could update one path and silently miss the
+other.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PHRASES_PATH = REPO_ROOT / "engagement" / "classify" / "phrases.json"
+
+
+def first_name(display_name: Optional[str]) -> str:
+    if not display_name:
+        return "there"
+    return display_name.strip().split()[0]
+
+
+def pick_reply_from_templates(display_name: Optional[str], phrases: dict) -> str:
+    """Pick a random ``like_and_thanks`` reply template from an already-loaded ``phrases`` dict.
+
+    Pure — no file I/O. Falls back to a fixed default if no templates are
+    configured. Used by callers (e.g. ``rules.py``) that load ``phrases.json``
+    once per run and pick many replies against the same dict.
+    """
+    first = first_name(display_name)
+    templates = phrases.get("reply_templates", {}).get("like_and_thanks", [])
+    if not templates:
+        return f"Thanks {first}! 🙏"
+    return random.choice(templates).format(first_name=first)
+
+
+def pick_thanks_reply(display_name: Optional[str]) -> str:
+    """Pick a random canned thanks-reply, reading ``phrases.json`` itself.
+
+    Convenience wrapper around :func:`pick_reply_from_templates` for callers
+    (e.g. ``engagement/db/client.py``) that don't already have a loaded
+    ``phrases`` dict on hand. Falls back to a fixed default on any error
+    (missing/corrupt file, empty template list).
+    """
+    try:
+        with open(PHRASES_PATH, "r", encoding="utf-8") as fp:
+            phrases = json.load(fp)
+        return pick_reply_from_templates(display_name, phrases)
+    except Exception:
+        return f"Thanks {first_name(display_name)}! 🙏"

--- a/engagement/classify/rules.py
+++ b/engagement/classify/rules.py
@@ -14,13 +14,13 @@ from __future__ import annotations
 
 import json
 import logging
-import random
 import re
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from engagement.classify.phrases_io import pick_reply_from_templates
 from engagement.db.client import (
     fetch_commenters_by_urls,
     load_engagement_config,
@@ -38,19 +38,13 @@ def load_phrases() -> dict:
         return json.load(fp)
 
 
-def _first_name(display_name: Optional[str]) -> str:
-    if not display_name:
-        return "there"
-    return display_name.strip().split()[0]
-
-
 def _pick_reply(action: str, display_name: Optional[str], phrases: dict) -> Optional[str]:
+    """Thin wrapper — the actual template pick lives in the leaf module
+    ``engagement.classify.phrases_io`` so it has one implementation shared
+    with ``engagement.db.client`` instead of two independently drifting."""
     if action != "like_and_thanks":
         return None
-    templates = phrases.get("reply_templates", {}).get("like_and_thanks", [])
-    if not templates:
-        return f"Thanks {_first_name(display_name)}! 🙏"
-    return random.choice(templates).format(first_name=_first_name(display_name))
+    return pick_reply_from_templates(display_name, phrases)
 
 
 def _generic_praise_hits(text: str, phrases: list[str]) -> int:

--- a/engagement/db/client.py
+++ b/engagement/db/client.py
@@ -21,6 +21,8 @@ from typing import Any, Iterable, Optional
 # Add the repo root to sys.path to allow importing the shared config loader.
 sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 from config.loader import load_full_config as load_config  # noqa: E402
+# Leaf module (no dependency on this module) — safe to import without a cycle.
+from engagement.classify.phrases_io import pick_thanks_reply  # noqa: E402
 
 logger = logging.getLogger("engagement.db")
 
@@ -168,29 +170,13 @@ def set_commenter_classification(platform: str, account_url: str, classification
         sb.table("commenters").update(payload).eq("platform", platform).eq("account_url", account_url).execute()
 
 
-def _pick_thanks_reply(display_name: Optional[str]) -> Optional[str]:
-    """Inline canned-reply generator — mirrors engagement.classify.rules._pick_reply
-    but inlined here to avoid a circular import (rules.py already imports from client.py)."""
-    import json as _json
-    import random as _random
-    from pathlib import Path as _Path
-    first = (display_name or "there").strip().split()[0] if display_name else "there"
-    try:
-        phrases_path = _Path(__file__).resolve().parent.parent / "classify" / "phrases.json"
-        with open(phrases_path, "r", encoding="utf-8") as fp:
-            templates = _json.load(fp).get("reply_templates", {}).get("like_and_thanks", [])
-        return _random.choice(templates).format(first_name=first) if templates else f"Thanks {first}! 🙏"
-    except Exception:
-        return f"Thanks {first}! 🙏"
-
-
 def cascade_blacklist_pending(platform: str, account_url: str) -> int:
     """When a commenter is blacklisted: reclassify their pending comments as
     ai/like_and_thanks AND auto-approve them with a canned reply pre-filled.
     User explicitly trusts blacklist → no need to click 'approve' on each."""
     sb = supabase_client()
     commenter = fetch_commenter(platform, account_url)
-    reply = _pick_thanks_reply((commenter or {}).get("display_name"))
+    reply = pick_thanks_reply((commenter or {}).get("display_name"))
     res = (
         sb.table("comments")
         .update(

--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -35,8 +35,9 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import requests
 
+from config.loader import load_full_config
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-PROJECT_CONFIG = REPO_ROOT / "config" / "config.json"
 RESULTS_DIR = REPO_ROOT / "results" / "newsletter"
 
 TOPICS: List[str] = [
@@ -76,8 +77,7 @@ class NotionNewsletterBuilder:
 
     @staticmethod
     def _load_config() -> Dict[str, Any]:
-        with PROJECT_CONFIG.open("r", encoding="utf-8") as f:
-            proj = json.load(f)
+        proj = load_full_config()
         archive = proj.get("newsletter_archive", {})
         return {
             "notion_api_key": proj["notion"]["api_token"],

--- a/newsletter/normalize_names.py
+++ b/newsletter/normalize_names.py
@@ -35,8 +35,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-PROJECT_CONFIG = REPO_ROOT / "config" / "config.json"
+from config.loader import load_full_config
+
 WORDS_CONFIG = Path(__file__).parent / "normalize_names_words.json"
 
 
@@ -58,8 +58,7 @@ class NotionNameNormalizer:
 
     @staticmethod
     def _load_config() -> Dict[str, Any]:
-        with PROJECT_CONFIG.open("r", encoding="utf-8") as f:
-            proj = json.load(f)
+        proj = load_full_config()
         with WORDS_CONFIG.open("r", encoding="utf-8") as f:
             words = json.load(f)
         archive = proj.get("newsletter_archive", {})

--- a/newsletter/normalize_url.py
+++ b/newsletter/normalize_url.py
@@ -22,18 +22,15 @@ CLI:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import sys
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import requests
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-PROJECT_CONFIG = REPO_ROOT / "config" / "config.json"
+from config.loader import load_full_config
 
 
 class NotionURLNormalizer:
@@ -57,8 +54,7 @@ class NotionURLNormalizer:
 
     @staticmethod
     def _load_config() -> Dict[str, Any]:
-        with PROJECT_CONFIG.open("r", encoding="utf-8") as f:
-            proj = json.load(f)
+        proj = load_full_config()
         archive = proj.get("newsletter_archive", {})
         return {
             "notion_api_key": proj["notion"]["api_token"],

--- a/planning/_dates.py
+++ b/planning/_dates.py
@@ -1,0 +1,42 @@
+"""Shared date helpers for the per-platform planning schedulers.
+
+``next_monday`` / ``parse_week_start`` / ``parse_single_date`` /
+``date_to_day_title`` were byte-identical (or near-identical) copies in each
+of the five scheduler modules (twitter, threads, linkedin, videos,
+instagram's ``clone_to_other_platforms``). They are pure, stdlib-only, and
+Playwright-free, so there is no reason for the "copied to avoid cross-package
+import" workaround one of the callers used — this module has no dependency
+on anything Playwright-related and is safe for every scheduler to import.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+
+def next_monday(today: Optional[date] = None) -> date:
+    """Return the next Monday strictly after ``today`` (or 7 days out if today IS Monday)."""
+    today = today or date.today()
+    days_ahead = (7 - today.weekday()) % 7  # Mon=0
+    if days_ahead == 0:
+        days_ahead = 7
+    return today + timedelta(days=days_ahead)
+
+
+def parse_week_start(s: Optional[str]) -> date:
+    if not s:
+        return next_monday()
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def parse_single_date(s: str) -> date:
+    """Accept YYYYMMDD or YYYY-MM-DD."""
+    s = s.strip()
+    if "-" in s:
+        return datetime.strptime(s, "%Y-%m-%d").date()
+    return datetime.strptime(s, "%Y%m%d").date()
+
+
+def date_to_day_title(d: date) -> str:
+    return d.strftime("%Y%m%d")

--- a/planning/_session_base.py
+++ b/planning/_session_base.py
@@ -26,7 +26,6 @@ single-source here — never re-inline it in a platform module.
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +35,7 @@ from playwright.sync_api import BrowserContext, Page, Playwright, sync_playwrigh
 
 from config.chrome_launch import STEALTH_INIT_SCRIPT
 from config.chrome_profile_lock import launch_persistent_context_with_lock_wait
+from config.loader import load_block, load_full_config
 from config.logger_config import setup_logger
 
 # Repo root is two levels up from this file: planning/_session_base.py -> repo.
@@ -63,11 +63,10 @@ def load_notion_token() -> str:
 
     Single-source for every platform session — platform modules re-export this
     name so existing ``from planning.<P>.<P>_session import load_notion_token``
-    imports keep resolving unchanged.
+    imports keep resolving unchanged. Reads through ``config.loader`` (the
+    project's single-source loader) rather than re-opening config.json here.
     """
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    token = cfg.get("notion", {}).get("api_token")
+    token = load_full_config().get("notion", {}).get("api_token")
     if not token:
         raise RuntimeError("Missing 'notion.api_token' in config.json")
     return token
@@ -80,14 +79,9 @@ def load_config_block(name: str) -> dict:
     same open/parse/raise body differing only by the block name. Platform
     modules define a thin one-liner — ``return load_config_block("<name>")``
     — so the logic lives once here. Re-export the per-platform name so
-    call sites are untouched.
+    call sites are untouched. Thin wrapper around ``config.loader.load_block``.
     """
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        cfg = json.load(fp)
-    block = cfg.get(name)
-    if not block:
-        raise RuntimeError(f"Missing '{name}' block in config.json")
-    return block
+    return load_block(name)
 
 
 def _resolve_user_data_dir(rel_or_abs: str, *, example_subdir: str = "<platform>/chrome_user_data") -> Path:

--- a/planning/_wip_rows.py
+++ b/planning/_wip_rows.py
@@ -1,0 +1,154 @@
+"""Shared WIP-row fetch + payload resolution for the twitter/threads schedulers.
+
+``fetch_wip_tw_rows`` (twitter) and ``fetch_wip_th_rows`` (threads) were a
+~100-line near-identical block, differing only by a ``_tw``/``_th``
+column-name suffix on ``ScheduleRow``'s fields; ``PostPayload``,
+``_resolve_image_path`` and ``_illustration_filename`` were verbatim
+duplicates. Both platforms read the same ``editorial_columns`` keys
+(``wip_checkbox`` / ``title_day`` / ``illustration_rel`` / ``caption_text`` /
+``post_url``), so once ``ScheduleRow``'s fields are generic there is nothing
+platform-specific left in the fetch itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Optional
+
+from planning._dates import date_to_day_title
+from reporting.notion.editorial import get_field, query_rows_by_filter, retrieve_page
+
+
+@dataclass
+class ScheduleRow:
+    page_id: str
+    day: date
+    illustration_ids: list[str]
+    text: str
+    existing_post_url: Optional[str]
+
+    @property
+    def day_title(self) -> str:
+        return date_to_day_title(self.day)
+
+
+@dataclass
+class PostPayload:
+    image_path: Path
+    caption: str
+
+
+def fetch_wip_rows(
+    notion,
+    db_id: str,
+    ed_cols: dict,
+    days: Optional[list[date]],
+    *,
+    logger: logging.Logger,
+) -> list[ScheduleRow]:
+    """Fetch WIP rows. If ``days`` is None, returns every WIP row
+    (used by ``--all-wip`` mode); otherwise filters by title-equals per day."""
+    wip_col = ed_cols["wip_checkbox"]
+    title_col = ed_cols["title_day"]
+    illust_col = ed_cols["illustration_rel"]
+    text_col = ed_cols["caption_text"]
+    post_url_col = ed_cols["post_url"]
+
+    rows: list[ScheduleRow] = []
+
+    def _row_day(r: dict) -> Optional[date]:
+        title_prop = r.get("properties", {}).get(title_col, {}) or {}
+        segs = title_prop.get("title", []) or []
+        text = "".join(seg.get("plain_text", "") for seg in segs).strip()
+        if not text:
+            return None
+        try:
+            return datetime.strptime(text, "%Y%m%d").date()
+        except ValueError:
+            return None
+
+    def _ingest(results, default_day: Optional[date]):
+        for r in results:
+            props = r.get("properties", {})
+            row_day = default_day or _row_day(r)
+            if row_day is None:
+                logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
+                continue
+            illust_rels = props.get(illust_col, {}).get("relation", []) or []
+            text_rt = props.get(text_col, {}).get("rich_text", []) or []
+            text_val = "".join(seg.get("plain_text", "") for seg in text_rt).strip()
+            url_obj = props.get(post_url_col, {})
+            existing_url = url_obj.get("url") if url_obj.get("type") == "url" else None
+            rows.append(
+                ScheduleRow(
+                    page_id=r["id"],
+                    day=row_day,
+                    illustration_ids=[rel["id"] for rel in illust_rels],
+                    text=text_val,
+                    existing_post_url=existing_url,
+                )
+            )
+
+    if days is None:
+        results = query_rows_by_filter(
+            notion,
+            db_id,
+            filter_obj={"property": wip_col, "checkbox": {"equals": True}},
+        )
+        _ingest(results, default_day=None)
+    else:
+        for d in days:
+            title = date_to_day_title(d)
+            results = query_rows_by_filter(
+                notion,
+                db_id,
+                filter_obj={
+                    "and": [
+                        {"property": title_col, "title": {"equals": title}},
+                        {"property": wip_col, "checkbox": {"equals": True}},
+                    ]
+                },
+            )
+            _ingest(results, default_day=d)
+
+    rows.sort(key=lambda r: r.day)
+    return rows
+
+
+def resolve_image_path(folder: str, image_filename: str) -> Path:
+    """Resolve <folder>/<name>.png. Accepts a name with or without extension."""
+    if not image_filename:
+        raise FileNotFoundError("Illustration row has no filename.")
+    first = str(image_filename).split(",")[0].strip()
+    if first and not first.lower().endswith(".png"):
+        first = f"{first}.png"
+    candidate = Path(folder) / first
+    if not candidate.exists():
+        raise FileNotFoundError(f"Illustration not found: {candidate}")
+    return candidate
+
+
+def illustration_filename(notion, illustration_page_id: str, illust_cols: dict) -> str:
+    page = retrieve_page(notion, illustration_page_id)
+    name = get_field(page, "image_filename", illust_cols) or ""
+    return str(name).strip()
+
+
+def resolve_payload(notion, cfg: dict, row: ScheduleRow, *, platform_label: str) -> PostPayload:
+    """Build the (image path, caption) for the day's scheduled post.
+
+    ``platform_label`` (e.g. ``"TW"``, ``"TH"``) names the platform in the
+    empty-illustration error message only.
+    """
+    illust_cols = cfg["illustration_columns"]
+    folder = cfg["illustrations_folder"]
+    if not row.illustration_ids:
+        raise RuntimeError(f"{row.day_title}: illustration {platform_label} is empty.")
+    fname = illustration_filename(notion, row.illustration_ids[0], illust_cols)
+    return PostPayload(
+        image_path=resolve_image_path(folder, fname),
+        caption=row.text,
+    )

--- a/planning/instagram/clone_to_other_platforms.py
+++ b/planning/instagram/clone_to_other_platforms.py
@@ -72,36 +72,14 @@ from reporting.notion.notion_update import (  # noqa: E402
     format_database_id,
     prepare_notion_update,
 )
+from planning._dates import (  # noqa: E402
+    date_to_day_title,
+    next_monday,
+    parse_single_date,
+    parse_week_start,
+)
 
 logger = logging.getLogger("instagram_clone")
-
-
-# ---------- Date helpers (copied from linkedin to avoid cross-package import) ----------
-
-def next_monday(today: Optional[date] = None) -> date:
-    """Return the next Monday strictly after `today` (or 7 days from Mon itself)."""
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
-
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
 
 
 # ---------- Row model ----------

--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -105,39 +105,16 @@ from reporting.notion.editorial import (  # noqa: E402
     set_field,
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
+from planning._dates import (  # noqa: E402
+    date_to_day_title,
+    next_monday,
+    parse_single_date,
+    parse_week_start,
+)
 
 Route = Literal["ILL", "POST", "CAROUSEL"]
 
 logger = logging.getLogger("linkedin_schedule")
-
-
-# ---------- Date helpers ----------
-
-def next_monday(today: Optional[date] = None) -> date:
-    """Return the next Monday strictly after `today` (or today if it IS Monday)."""
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7  # Mon=0
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
-
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    """Accept YYYYMMDD or YYYY-MM-DD."""
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
 
 
 def _resolve_schedule_time(cfg: dict, d: date) -> tuple[int, int]:

--- a/planning/substack/post_substack_note.py
+++ b/planning/substack/post_substack_note.py
@@ -106,17 +106,25 @@ def _open_note_composer(page) -> None:
     page.get_by_role("menuitem", name=re.compile(r"^note$", re.I)).first.click()
 
 
-def _fill_note_dialog(page, body_text: str, image_path: Path) -> None:
-    """Fill the body and attach the image inside the composer.
+# Ancestor of the editor that contains both the Cancel and Post buttons — used
+# to scope file-input / upload-button searches so they don't accidentally hit
+# the page's avatar / cover-photo / other file inputs. Shared between the
+# image-Note and video-Note publishers (identical composer DOM shape).
+COMPOSER_SCOPE_XPATH = (
+    'xpath=ancestor::*[.//button[normalize-space()="Post"] and .//button[normalize-space()="Cancel"]][1]'
+)
+
+
+def _locate_note_editor(page, body_text: str):
+    """Find the Note composer's contenteditable editor, wait for it, click, and fill.
 
     Substack's Note composer is not a true ``role="dialog"`` and the editor is
     a ProseMirror ``contenteditable`` div, not a ``role="textbox"`` — so we
-    target by ``contenteditable`` and fall back through several strategies for
-    the image upload (hidden file input first, then file-chooser via the image
-    button, then OS picker via expect_file_chooser).
+    target by ``contenteditable``, preferring the one whose placeholder
+    mentions "mind" (Substack's "What's on your mind?" prompt) and falling
+    back to the last visible one if no placeholder match. Shared between the
+    image-Note and video-Note publishers — same DOM shape either way.
     """
-    # The editor — prefer the contenteditable whose placeholder mentions "mind",
-    # falling back to the last visible one if no placeholder match.
     editors = page.locator('[contenteditable="true"]')
     editor = None
     for i in range(editors.count()):
@@ -138,6 +146,18 @@ def _fill_note_dialog(page, body_text: str, image_path: Path) -> None:
     editor.wait_for(state="visible", timeout=20000)
     editor.click()
     editor.fill(body_text)
+    return editor
+
+
+def _fill_note_dialog(page, body_text: str, image_path: Path) -> None:
+    """Fill the body and attach the image inside the composer.
+
+    See :func:`_locate_note_editor` for how the composer's editor is found;
+    the image upload (hidden file input first, then file-chooser via the
+    image button, then OS picker via expect_file_chooser) is attempted only
+    inside the composer-scoped container.
+    """
+    editor = _locate_note_editor(page, body_text)
     try:
         actual = editor.inner_text(timeout=2000)
     except Exception:
@@ -146,13 +166,7 @@ def _fill_note_dialog(page, body_text: str, image_path: Path) -> None:
     if actual.strip() != body_text.strip():
         logger.warning("⚠️ Editor content does not match body — text may have landed in the wrong element.")
 
-    # Scope a "composer container" = the nearest ancestor of the editor that
-    # contains both the Cancel and Post buttons. We hunt for the image upload
-    # input only inside this container so we don't accidentally hit the page's
-    # avatar / cover-photo / other file inputs.
-    composer = editor.locator(
-        'xpath=ancestor::*[.//button[normalize-space()="Post"] and .//button[normalize-space()="Cancel"]][1]'
-    )
+    composer = editor.locator(COMPOSER_SCOPE_XPATH)
     if composer.count() == 0:
         logger.warning("⚠️ Could not scope composer container; falling back to page-wide search.")
         composer = page.locator("body")

--- a/planning/substack/post_substack_video_note.py
+++ b/planning/substack/post_substack_video_note.py
@@ -44,6 +44,8 @@ from playwright.sync_api import TimeoutError as PWTimeoutError
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from planning.substack.post_substack_note import (  # noqa: E402
+    COMPOSER_SCOPE_XPATH,
+    _locate_note_editor,
     _open_note_composer,
     _resolve_published_note_url,
 )
@@ -143,31 +145,9 @@ def _attach_video_via_composer(composer, page, video_path: Path) -> bool:
 
 def _fill_video_note_dialog(page, body_text: str, video_path: Path) -> None:
     """Fill the body and attach the .mp4 inside the open Note composer."""
-    editors = page.locator('[contenteditable="true"]')
-    editor = None
-    for i in range(editors.count()):
-        el = editors.nth(i)
-        try:
-            placeholder = (
-                el.get_attribute("data-placeholder")
-                or el.get_attribute("aria-placeholder")
-                or el.get_attribute("placeholder")
-                or ""
-            )
-        except Exception:
-            placeholder = ""
-        if "mind" in placeholder.lower():
-            editor = el
-            break
-    if editor is None:
-        editor = editors.last
-    editor.wait_for(state="visible", timeout=20000)
-    editor.click()
-    editor.fill(body_text)
+    editor = _locate_note_editor(page, body_text)
 
-    composer = editor.locator(
-        'xpath=ancestor::*[.//button[normalize-space()="Post"] and .//button[normalize-space()="Cancel"]][1]'
-    )
+    composer = editor.locator(COMPOSER_SCOPE_XPATH)
     if composer.count() == 0:
         logger.warning("⚠️ Could not scope composer container; falling back to page-wide search.")
         composer = page.locator("body")

--- a/planning/threads/schedule_threads_posts.py
+++ b/planning/threads/schedule_threads_posts.py
@@ -27,8 +27,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -55,165 +54,34 @@ from planning.threads.threads_session import (  # noqa: E402
     load_threads_config,
 )
 from reporting.notion.editorial import (  # noqa: E402
-    get_field,
     init_notion_client,
-    query_rows_by_filter,
-    retrieve_page,
     set_field,
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
+from planning._dates import (  # noqa: E402
+    parse_single_date,
+    parse_week_start,
+)
 
 logger = logging.getLogger("threads_schedule")
 
 
-# ---------- Date helpers ----------
+# ---------- Row model / payload resolution ----------
 
-def next_monday(today: Optional[date] = None) -> date:
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
+from planning._wip_rows import (  # noqa: E402
+    PostPayload,
+    ScheduleRow,
+    fetch_wip_rows as _fetch_wip_rows,
+    resolve_payload as _resolve_payload,
+)
 
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
-
-
-# ---------- Row model ----------
-
-@dataclass
-class ScheduleRow:
-    page_id: str
-    day: date
-    illustration_th_ids: list[str]
-    text_th: str
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return date_to_day_title(self.day)
-
-
-@dataclass
-class PostPayload:
-    image_path: Path
-    caption: str
-
-
-# ---------- Notion query / payload resolution ----------
 
 def fetch_wip_th_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[date]]) -> list[ScheduleRow]:
-    """Fetch WIP-TH rows. If ``days`` is None, returns every WIP-TH row
-    (used by ``--all-wip`` mode); otherwise filters by title-equals per day."""
-    wip_col = ed_cols["wip_checkbox"]
-    title_col = ed_cols["title_day"]
-    illust_col = ed_cols["illustration_rel"]
-    text_col = ed_cols["caption_text"]
-    post_url_col = ed_cols["post_url"]
-
-    rows: list[ScheduleRow] = []
-
-    def _row_day(r: dict) -> Optional[date]:
-        title_prop = r.get("properties", {}).get(title_col, {}) or {}
-        segs = title_prop.get("title", []) or []
-        text = "".join(seg.get("plain_text", "") for seg in segs).strip()
-        if not text:
-            return None
-        try:
-            return datetime.strptime(text, "%Y%m%d").date()
-        except ValueError:
-            return None
-
-    def _ingest(results, default_day: Optional[date]):
-        for r in results:
-            props = r.get("properties", {})
-            row_day = default_day or _row_day(r)
-            if row_day is None:
-                logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
-                continue
-            illust_rels = props.get(illust_col, {}).get("relation", []) or []
-            text_rt = props.get(text_col, {}).get("rich_text", []) or []
-            text_val = "".join(seg.get("plain_text", "") for seg in text_rt).strip()
-            url_obj = props.get(post_url_col, {})
-            existing_url = url_obj.get("url") if url_obj.get("type") == "url" else None
-            rows.append(
-                ScheduleRow(
-                    page_id=r["id"],
-                    day=row_day,
-                    illustration_th_ids=[rel["id"] for rel in illust_rels],
-                    text_th=text_val,
-                    existing_post_url=existing_url,
-                )
-            )
-
-    if days is None:
-        results = query_rows_by_filter(
-            notion,
-            db_id,
-            filter_obj={"property": wip_col, "checkbox": {"equals": True}},
-        )
-        _ingest(results, default_day=None)
-    else:
-        for d in days:
-            title = date_to_day_title(d)
-            results = query_rows_by_filter(
-                notion,
-                db_id,
-                filter_obj={
-                    "and": [
-                        {"property": title_col, "title": {"equals": title}},
-                        {"property": wip_col, "checkbox": {"equals": True}},
-                    ]
-                },
-            )
-            _ingest(results, default_day=d)
-
-    rows.sort(key=lambda r: r.day)
-    return rows
-
-
-def _resolve_image_path(folder: str, image_filename: str) -> Path:
-    if not image_filename:
-        raise FileNotFoundError("Illustration row has no filename.")
-    first = str(image_filename).split(",")[0].strip()
-    if first and not first.lower().endswith(".png"):
-        first = f"{first}.png"
-    candidate = Path(folder) / first
-    if not candidate.exists():
-        raise FileNotFoundError(f"Illustration not found: {candidate}")
-    return candidate
-
-
-def _illustration_filename(notion, illustration_page_id: str, illust_cols: dict) -> str:
-    page = retrieve_page(notion, illustration_page_id)
-    name = get_field(page, "image_filename", illust_cols) or ""
-    return str(name).strip()
+    return _fetch_wip_rows(notion, db_id, ed_cols, days, logger=logger)
 
 
 def resolve_payload(notion, cfg: dict, row: ScheduleRow) -> PostPayload:
-    illust_cols = cfg["illustration_columns"]
-    folder = cfg["illustrations_folder"]
-    if not row.illustration_th_ids:
-        raise RuntimeError(f"{row.day_title}: illustration TH is empty.")
-    fname = _illustration_filename(notion, row.illustration_th_ids[0], illust_cols)
-    return PostPayload(
-        image_path=_resolve_image_path(folder, fname),
-        caption=row.text_th,
-    )
+    return _resolve_payload(notion, cfg, row, platform_label="TH")
 
 
 # ---------- Threads composer helpers ----------

--- a/planning/twitter/schedule_twitter_posts.py
+++ b/planning/twitter/schedule_twitter_posts.py
@@ -26,8 +26,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -50,13 +49,11 @@ from planning.twitter.twitter_session import (  # noqa: E402
     load_twitter_config,
 )
 from reporting.notion.editorial import (  # noqa: E402
-    get_field,
     init_notion_client,
-    query_rows_by_filter,
-    retrieve_page,
     set_field,
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
+from planning._dates import parse_single_date, parse_week_start  # noqa: E402
 
 logger = logging.getLogger("twitter_schedule")
 
@@ -66,156 +63,23 @@ _MONTH_NAMES = [
 ]
 
 
-# ---------- Date helpers ----------
+# ---------- Row model / payload resolution ----------
 
-def next_monday(today: Optional[date] = None) -> date:
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
+from planning._wip_rows import (  # noqa: E402
+    PostPayload,
+    ScheduleRow,
+    fetch_wip_rows as _fetch_wip_rows,
+    resolve_payload as _resolve_payload,
+)
 
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
-
-
-# ---------- Row model ----------
-
-@dataclass
-class ScheduleRow:
-    page_id: str
-    day: date
-    illustration_tw_ids: list[str]
-    text_tw: str
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return date_to_day_title(self.day)
-
-
-@dataclass
-class PostPayload:
-    image_path: Path
-    caption: str
-
-
-# ---------- Notion query / payload resolution ----------
 
 def fetch_wip_tw_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[date]]) -> list[ScheduleRow]:
-    """Fetch WIP-TW rows. If ``days`` is None, returns every WIP-TW row
-    (used by ``--all-wip`` mode); otherwise filters by title-equals per day."""
-    wip_col = ed_cols["wip_checkbox"]
-    title_col = ed_cols["title_day"]
-    illust_col = ed_cols["illustration_rel"]
-    text_col = ed_cols["caption_text"]
-    post_url_col = ed_cols["post_url"]
-
-    rows: list[ScheduleRow] = []
-
-    def _row_day(r: dict) -> Optional[date]:
-        title_prop = r.get("properties", {}).get(title_col, {}) or {}
-        segs = title_prop.get("title", []) or []
-        text = "".join(seg.get("plain_text", "") for seg in segs).strip()
-        if not text:
-            return None
-        try:
-            return datetime.strptime(text, "%Y%m%d").date()
-        except ValueError:
-            return None
-
-    def _ingest(results, default_day: Optional[date]):
-        for r in results:
-            props = r.get("properties", {})
-            row_day = default_day or _row_day(r)
-            if row_day is None:
-                logger.warning("⚠️  Skipping row %s: unparseable day title.", r.get("id"))
-                continue
-            illust_rels = props.get(illust_col, {}).get("relation", []) or []
-            text_rt = props.get(text_col, {}).get("rich_text", []) or []
-            text_val = "".join(seg.get("plain_text", "") for seg in text_rt).strip()
-            url_obj = props.get(post_url_col, {})
-            existing_url = url_obj.get("url") if url_obj.get("type") == "url" else None
-            rows.append(
-                ScheduleRow(
-                    page_id=r["id"],
-                    day=row_day,
-                    illustration_tw_ids=[rel["id"] for rel in illust_rels],
-                    text_tw=text_val,
-                    existing_post_url=existing_url,
-                )
-            )
-
-    if days is None:
-        results = query_rows_by_filter(
-            notion,
-            db_id,
-            filter_obj={"property": wip_col, "checkbox": {"equals": True}},
-        )
-        _ingest(results, default_day=None)
-    else:
-        for d in days:
-            title = date_to_day_title(d)
-            results = query_rows_by_filter(
-                notion,
-                db_id,
-                filter_obj={
-                    "and": [
-                        {"property": title_col, "title": {"equals": title}},
-                        {"property": wip_col, "checkbox": {"equals": True}},
-                    ]
-                },
-            )
-            _ingest(results, default_day=d)
-
-    rows.sort(key=lambda r: r.day)
-    return rows
-
-
-def _resolve_image_path(folder: str, image_filename: str) -> Path:
-    """Resolve <folder>/<name>.png. Accepts a name with or without extension."""
-    if not image_filename:
-        raise FileNotFoundError("Illustration row has no filename.")
-    first = str(image_filename).split(",")[0].strip()
-    if first and not first.lower().endswith(".png"):
-        first = f"{first}.png"
-    candidate = Path(folder) / first
-    if not candidate.exists():
-        raise FileNotFoundError(f"Illustration not found: {candidate}")
-    return candidate
-
-
-def _illustration_filename(notion, illustration_page_id: str, illust_cols: dict) -> str:
-    page = retrieve_page(notion, illustration_page_id)
-    name = get_field(page, "image_filename", illust_cols) or ""
-    return str(name).strip()
+    return _fetch_wip_rows(notion, db_id, ed_cols, days, logger=logger)
 
 
 def resolve_payload(notion, cfg: dict, row: ScheduleRow) -> PostPayload:
     """Build the (image path, caption) for the day's 15:00 X post."""
-    illust_cols = cfg["illustration_columns"]
-    folder = cfg["illustrations_folder"]
-    if not row.illustration_tw_ids:
-        raise RuntimeError(f"{row.day_title}: illustration TW is empty.")
-    fname = _illustration_filename(notion, row.illustration_tw_ids[0], illust_cols)
-    return PostPayload(
-        image_path=_resolve_image_path(folder, fname),
-        caption=row.text_tw,
-    )
+    return _resolve_payload(notion, cfg, row, platform_label="TW")
 
 
 # ---------- X composer helpers ----------

--- a/planning/videos/schedule_videos_posts.py
+++ b/planning/videos/schedule_videos_posts.py
@@ -40,6 +40,7 @@ from typing import Optional
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from planning.videos.videos_session import (  # noqa: E402
     ClipPayload,
+    VideoRow,
     configure_logger,
     first_clip_relation_id,
     load_clip_payload,
@@ -53,6 +54,12 @@ from reporting.notion.editorial import (  # noqa: E402
     set_field,
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
+from planning._dates import (  # noqa: E402
+    date_to_day_title,
+    next_monday,
+    parse_single_date,
+    parse_week_start,
+)
 
 logger = logging.getLogger("videos_schedule")
 
@@ -62,31 +69,6 @@ PLATFORMS_SCHEDULED = ("li", "ig", "tw", "th")  # SB is owned by the daily Subst
 # populated (i.e. the row has a video planned at all). The shared clip page
 # resolves identically regardless of which relation it was followed through.
 PLATFORMS_TAG_ALONG = frozenset({"th"})
-
-
-def next_monday(today: Optional[date] = None) -> date:
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
-
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
 
 
 class _RowState:
@@ -245,7 +227,6 @@ def _rows_for_platform(rows: list[_RowState], platform: str, force: bool) -> lis
     (link <P>(v) is empty OR --force). Already-failed (payload-failed)
     rows are excluded since they have nothing to schedule.
     """
-    from planning.videos.videos_linkedin import VideoRow  # local to avoid cycle
     eligible = []
     for row in rows:
         if row.driver_status.get(platform) == "FAIL":

--- a/planning/videos/videos_instagram.py
+++ b/planning/videos/videos_instagram.py
@@ -16,10 +16,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from dataclasses import dataclass
-from datetime import date
 from pathlib import Path
-from typing import Optional
 
 from playwright.sync_api import TimeoutError as PWTimeoutError
 
@@ -44,21 +41,9 @@ from planning.instagram.schedule_instagram_posts import (  # noqa: E402
     dismiss_meta_verified_modal,
     return_to_planner,
 )
-from planning.videos.videos_session import ClipPayload  # noqa: E402
+from planning.videos.videos_session import VideoRow  # noqa: E402
 
 logger = logging.getLogger("videos_instagram")
-
-
-@dataclass
-class VideoRow:
-    page_id: str
-    day: date
-    payload: ClipPayload
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return self.day.strftime("%Y%m%d")
 
 
 def schedule_one_video(

--- a/planning/videos/videos_linkedin.py
+++ b/planning/videos/videos_linkedin.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from dataclasses import dataclass
-from datetime import date
 from pathlib import Path
-from typing import Optional
 
 from playwright.sync_api import Page, TimeoutError as PWTimeoutError
 
@@ -46,7 +43,7 @@ from planning.linkedin.schedule_linkedin_posts import (  # noqa: E402
     _open_schedule_dialog,
     _set_schedule_datetime,
 )
-from planning.videos.videos_session import ClipPayload  # noqa: E402
+from planning.videos.videos_session import VideoRow  # noqa: E402
 
 logger = logging.getLogger("videos_linkedin")
 
@@ -56,20 +53,6 @@ logger = logging.getLogger("videos_linkedin")
 # from ``planning.linkedin.linkedin_composer``.
 _fill_caption_with_mentions = fill_caption_with_mentions
 _wait_for_upload_complete = wait_for_upload_complete
-
-
-@dataclass
-class VideoRow:
-    """One editorial row's worth of input for the per-platform driver."""
-
-    page_id: str
-    day: date
-    payload: ClipPayload
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return self.day.strftime("%Y%m%d")
 
 
 def _click_video_button(page: Page) -> None:

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -31,6 +31,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Optional
 
@@ -89,6 +90,25 @@ class ClipPayload:
     thumb_path: Path
     caption_short: str
     caption_long: str
+
+
+@dataclass
+class VideoRow:
+    """One editorial row's worth of input for a per-platform video driver.
+
+    Single-source for all four drivers (linkedin/instagram/twitter/threads)
+    plus the orchestrator — was previously redefined identically in each
+    driver module.
+    """
+
+    page_id: str
+    day: date
+    payload: ClipPayload
+    existing_post_url: Optional[str]
+
+    @property
+    def day_title(self) -> str:
+        return self.day.strftime("%Y%m%d")
 
 
 def configure_logger(name: str = "videos", debug: bool = False) -> logging.Logger:

--- a/planning/videos/videos_threads.py
+++ b/planning/videos/videos_threads.py
@@ -12,10 +12,7 @@ from __future__ import annotations
 import logging
 import re
 import sys
-from dataclasses import dataclass
-from datetime import date
 from pathlib import Path
-from typing import Optional
 
 from playwright.sync_api import TimeoutError as PWTimeoutError
 
@@ -42,22 +39,10 @@ from planning.threads.schedule_threads_posts import (  # noqa: E402
 )
 from planning.videos.videos_session import (  # noqa: E402
     VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
-    ClipPayload,
+    VideoRow,
 )
 
 logger = logging.getLogger("videos_threads")
-
-
-@dataclass
-class VideoRow:
-    page_id: str
-    day: date
-    payload: ClipPayload
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return self.day.strftime("%Y%m%d")
 
 
 def schedule_one_video(

--- a/planning/videos/videos_twitter.py
+++ b/planning/videos/videos_twitter.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from dataclasses import dataclass
-from datetime import date
 from pathlib import Path
 from typing import Optional
 
@@ -39,22 +37,10 @@ from planning.twitter.schedule_twitter_posts import (  # noqa: E402
 )
 from planning.videos.videos_session import (  # noqa: E402
     VIDEO_UPLOAD_FINALIZE_TIMEOUT_MS,
-    ClipPayload,
+    VideoRow,
 )
 
 logger = logging.getLogger("videos_twitter")
-
-
-@dataclass
-class VideoRow:
-    page_id: str
-    day: date
-    payload: ClipPayload
-    existing_post_url: Optional[str]
-
-    @property
-    def day_title(self) -> str:
-        return self.day.strftime("%Y%m%d")
 
 
 def _primary_button_enabled(page) -> Optional[bool]:

--- a/reporting/notion/_client.py
+++ b/reporting/notion/_client.py
@@ -1,15 +1,17 @@
 """Shared Notion client helpers.
 
-Single-source for the two helpers that were previously copy-pasted across
-``notion_update.py`` and ``notion_database_structure.py`` (and imported by
-``editorial.py``): initializing the Notion ``Client`` and formatting a
-32-char database id into hyphenated UUID form.
+Single-source for the helpers that were previously copy-pasted across
+``notion_update.py``, ``notion_database_structure.py`` and
+``notion_supabase_sync.py`` (and imported by ``editorial.py``): initializing
+the Notion ``Client``, formatting a 32-char database id into hyphenated UUID
+form, and converting a raw Notion property object into a plain Python value.
 
 The logger is configured at import (mirroring ``supabase_uploader.py``) so
 ``init_notion_client`` never hits an uninitialized module-level logger,
 regardless of which caller imports it.
 """
 
+from typing import Any
 import logging
 import sys
 from pathlib import Path
@@ -45,3 +47,102 @@ def format_database_id(database_id):
         # Insert hyphens to convert into UUID format
         return f"{database_id[:8]}-{database_id[8:12]}-{database_id[12:16]}-{database_id[16:20]}-{database_id[20:]}"
     return database_id
+
+
+def _extract_formula_value(formula: dict) -> Any:
+    """Extract value from a Notion ``formula`` property's inner object."""
+    formula_type = formula.get("type")
+    if formula_type == "string":
+        return formula.get("string")
+    elif formula_type == "number":
+        return formula.get("number")
+    elif formula_type == "boolean":
+        return formula.get("boolean")
+    elif formula_type == "date":
+        date_obj = formula.get("date")
+        return date_obj.get("start") if date_obj else None
+    return None
+
+
+def _extract_rollup_value(rollup: dict) -> Any:
+    """Extract value from a Notion ``rollup`` property's inner object."""
+    rollup_type = rollup.get("type")
+    if rollup_type == "number":
+        return rollup.get("number")
+    elif rollup_type == "array":
+        return [extract_property_value(item) for item in rollup.get("array", [])]
+    return None
+
+
+def extract_property_value(prop: dict) -> Any:
+    """Convert a raw Notion property object into a plain Python value.
+
+    Single-source for the property-value converter that had **drifted** into
+    three independent implementations (``notion_update.py``,
+    ``notion_database_structure.py``, ``notion_supabase_sync.py``) with
+    different type coverage in each. This is the most complete of the three
+    (adds ``rollup`` array recursion, ``email``/``phone_number``/``status``,
+    full title/rich_text concatenation instead of first-segment-only, and a
+    raw-dict JSONB-style fallback for unrecognized types instead of losing
+    the value to ``None``) — every caller now goes through this one.
+    """
+    prop_type = prop.get("type")
+
+    if prop_type == "title":
+        texts = prop.get("title", [])
+        return "".join(t.get("plain_text", "") for t in texts)
+    elif prop_type == "rich_text":
+        texts = prop.get("rich_text", [])
+        return "".join(t.get("plain_text", "") for t in texts)
+    elif prop_type == "number":
+        return prop.get("number")
+    elif prop_type == "select":
+        select = prop.get("select")
+        return select.get("name") if select else None
+    elif prop_type == "multi_select":
+        return [opt.get("name") for opt in prop.get("multi_select", [])]
+    elif prop_type == "date":
+        date_obj = prop.get("date")
+        if date_obj:
+            start_date = date_obj.get("start")
+            return start_date if start_date else None
+        return None
+    elif prop_type == "checkbox":
+        return prop.get("checkbox", False)
+    elif prop_type == "url":
+        url = prop.get("url")
+        return url if url else None
+    elif prop_type == "email":
+        email = prop.get("email")
+        return email if email else None
+    elif prop_type == "phone_number":
+        phone = prop.get("phone_number")
+        return phone if phone else None
+    elif prop_type == "formula":
+        return _extract_formula_value(prop.get("formula", {}))
+    elif prop_type == "relation":
+        return [rel.get("id") for rel in prop.get("relation", [])]
+    elif prop_type == "rollup":
+        return _extract_rollup_value(prop.get("rollup", {}))
+    elif prop_type == "people":
+        return [person.get("id") for person in prop.get("people", [])]
+    elif prop_type == "files":
+        files = prop.get("files", [])
+        return [f.get("file", {}).get("url") or f.get("external", {}).get("url") for f in files]
+    elif prop_type == "created_time":
+        created = prop.get("created_time")
+        return created if created else None
+    elif prop_type == "created_by":
+        return prop.get("created_by", {}).get("id")
+    elif prop_type == "last_edited_time":
+        edited = prop.get("last_edited_time")
+        return edited if edited else None
+    elif prop_type == "last_edited_by":
+        return prop.get("last_edited_by", {}).get("id")
+    elif prop_type == "status":
+        status = prop.get("status")
+        return status.get("name") if status else None
+    else:
+        # Unknown/unhandled type — return the raw property object rather
+        # than silently losing the value to None.
+        return prop

--- a/reporting/notion/notion_database_list.py
+++ b/reporting/notion/notion_database_list.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from config.loader import load_full_config
 from config.logger_config import setup_logger
 
 # Set up logger - will use existing logger if available
@@ -32,19 +33,28 @@ class NotionDatabaseLister:
         }
         
     def _load_config(self, config_path: str = None) -> dict:
-        """Load configuration from JSON file."""
+        """Load configuration from JSON file.
+
+        With no override, reads through ``config.loader`` (the project's
+        single-source loader) so the default path stays in exactly one place.
+        The ``--config`` override still reads its own path directly, since
+        that's not something ``config.loader`` supports.
+        """
         if config_path is None:
-            config_path = Path(__file__).parent.parent.parent / "config" / "config.json"
-        
+            logger.debug("📂 Loading configuration via config.loader (config/config.json)")
+            config = load_full_config()
+            logger.info("✅ Configuration loaded successfully")
+            return config
+
         logger.debug(f"📂 Loading configuration from {config_path}")
-        
+
         if not os.path.exists(config_path):
             logger.error(f"❌ Configuration file not found: {config_path}")
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
+
         with open(config_path, 'r') as f:
             config = json.load(f)
-        
+
         logger.info("✅ Configuration loaded successfully")
         return config
     

--- a/reporting/notion/notion_database_structure.py
+++ b/reporting/notion/notion_database_structure.py
@@ -10,10 +10,17 @@ from datetime import datetime
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
-from reporting.notion._client import init_notion_client, format_database_id
+from reporting.notion._client import (
+    extract_property_value,
+    format_database_id,
+    init_notion_client,
+)
 
-# Set up logger
-logger = None
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("notion_database_structure")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -113,91 +120,6 @@ def get_database_content(notion, database_id, max_pages=1):
     except Exception as e:
         logger.error(f"❌ Error retrieving database content: {e}")
         return None
-
-def extract_property_value(property_item):
-    """Extract the value from a property item based on its type."""
-    prop_type = property_item.get('type', 'unknown')
-    
-    if prop_type == 'title':
-        title_array = property_item.get('title', [])
-        if title_array:
-            return title_array[0].get('plain_text', '')
-        return ''
-    
-    elif prop_type == 'rich_text':
-        text_array = property_item.get('rich_text', [])
-        if text_array:
-            return text_array[0].get('plain_text', '')
-        return ''
-    
-    elif prop_type == 'number':
-        return property_item.get('number', None)
-    
-    elif prop_type == 'select':
-        select_obj = property_item.get('select', {})
-        return select_obj.get('name', '') if select_obj else ''
-    
-    elif prop_type == 'multi_select':
-        multi_select = property_item.get('multi_select', [])
-        return [item.get('name', '') for item in multi_select]
-    
-    elif prop_type == 'date':
-        date_obj = property_item.get('date', {})
-        if date_obj:
-            start = date_obj.get('start', '')
-            end = date_obj.get('end', '')
-            return {'start': start, 'end': end} if end else start
-        return None
-    
-    elif prop_type == 'checkbox':
-        return property_item.get('checkbox', False)
-    
-    elif prop_type == 'url':
-        return property_item.get('url', '')
-    
-    elif prop_type == 'email':
-        return property_item.get('email', '')
-    
-    elif prop_type == 'phone_number':
-        return property_item.get('phone_number', '')
-    
-    elif prop_type == 'formula':
-        formula_result = property_item.get('formula', {})
-        result_type = formula_result.get('type', '')
-        return formula_result.get(result_type, None)
-    
-    elif prop_type == 'relation':
-        relation_array = property_item.get('relation', [])
-        return [item.get('id', '') for item in relation_array]
-    
-    elif prop_type == 'rollup':
-        rollup = property_item.get('rollup', {})
-        rollup_type = rollup.get('type', '')
-        return rollup.get(rollup_type, None)
-    
-    elif prop_type == 'people':
-        people_array = property_item.get('people', [])
-        return [item.get('id', '') for item in people_array]
-    
-    elif prop_type == 'files':
-        files_array = property_item.get('files', [])
-        return [item.get('name', '') for item in files_array]
-    
-    elif prop_type == 'created_time':
-        return property_item.get('created_time', '')
-    
-    elif prop_type == 'created_by':
-        created_by = property_item.get('created_by', {})
-        return created_by.get('id', '')
-    
-    elif prop_type == 'last_edited_time':
-        return property_item.get('last_edited_time', '')
-    
-    elif prop_type == 'last_edited_by':
-        last_edited_by = property_item.get('last_edited_by', {})
-        return last_edited_by.get('id', '')
-    
-    return None
 
 def create_dataframe_from_content(database_content, database_structure):
     """Convert database content to a pandas DataFrame."""

--- a/reporting/notion/notion_relations_python_setup.py
+++ b/reporting/notion/notion_relations_python_setup.py
@@ -20,8 +20,9 @@ from typing import Dict, List, Any, Optional, Tuple, Set
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from config.loader import load_full_config
 from config.logger_config import setup_logger
-from reporting.process.supabase_uploader import get_db_connection, load_db_config
+from reporting.process.supabase_uploader import get_db_connection, load_db_config, run_sql_file
 
 # Set up logger - will use existing logger if available
 logger = logging.getLogger("notion_relations_python_setup")
@@ -38,19 +39,28 @@ class NotionRelationsPythonSetup:
         self.connection = None
         
     def _load_config(self, config_path: str = None) -> dict:
-        """Load configuration from JSON file."""
+        """Load configuration from JSON file.
+
+        With no override, reads through ``config.loader`` (the project's
+        single-source loader) so the default path stays in exactly one place.
+        The ``--config`` override still reads its own path directly, since
+        that's not something ``config.loader`` supports.
+        """
         if config_path is None:
-            config_path = Path(__file__).parent.parent.parent / "config" / "config.json"
-        
+            logger.debug("📂 Loading configuration via config.loader (config/config.json)")
+            config = load_full_config()
+            logger.info("✅ Configuration loaded successfully")
+            return config
+
         logger.debug(f"📂 Loading configuration from {config_path}")
-        
+
         if not os.path.exists(config_path):
             logger.error(f"❌ Configuration file not found: {config_path}")
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
+
         with open(config_path, 'r') as f:
             config = json.load(f)
-        
+
         logger.info("✅ Configuration loaded successfully")
         return config
     
@@ -71,54 +81,6 @@ class NotionRelationsPythonSetup:
             logger.error(f"❌ Error connecting to database: {e}")
             return None
     
-    def _read_sql_file(self, file_path: str) -> str:
-        """Read SQL file content."""
-        try:
-            sql_file = Path(__file__).parent / file_path
-            if not sql_file.exists():
-                logger.error(f"❌ SQL file not found: {sql_file}")
-                return None
-            
-            with open(sql_file, 'r', encoding='utf-8') as f:
-                content = f.read()
-            
-            logger.debug(f"✅ Read SQL file: {file_path}")
-            return content
-            
-        except Exception as e:
-            logger.error(f"❌ Error reading SQL file {file_path}: {e}")
-            return None
-    
-    def _execute_sql_script(self, connection, sql_content: str, script_name: str) -> bool:
-        """Execute SQL script content."""
-        if not sql_content:
-            logger.error(f"❌ No SQL content to execute for {script_name}")
-            return False
-        
-        try:
-            with connection.cursor() as cursor:
-                # Split SQL by semicolons and execute each statement
-                statements = [stmt.strip() for stmt in sql_content.split(';') if stmt.strip()]
-                
-                for i, statement in enumerate(statements):
-                    if statement and not statement.startswith('--'):
-                        try:
-                            cursor.execute(statement)
-                            logger.debug(f"✅ Executed statement {i+1}/{len(statements)} in {script_name}")
-                        except Exception as e:
-                            # Skip statements that might fail (like DROP IF EXISTS)
-                            if "does not exist" not in str(e).lower():
-                                logger.warning(f"⚠️ Statement {i+1} in {script_name} failed: {e}")
-                
-                connection.commit()
-                logger.info(f"✅ Successfully executed SQL script: {script_name}")
-                return True
-                
-        except Exception as e:
-            logger.error(f"❌ Error executing SQL script {script_name}: {e}")
-            connection.rollback()
-            return False
-    
     def setup_core_system(self) -> bool:
         """Set up the core simplified relations system."""
         logger.info("🚀 Setting up core simplified Notion relations system...")
@@ -130,13 +92,10 @@ class NotionRelationsPythonSetup:
         try:
             # Step 1: Load and execute core functions
             logger.info("📦 Step 1: Loading core functions...")
-            core_sql = self._read_sql_file("auto_relations_detector.sql")
-            if not core_sql:
+            core_sql_path = Path(__file__).parent / "auto_relations_detector.sql"
+            if not run_sql_file(self.connection, core_sql_path, logger=logger):
                 return False
-            
-            if not self._execute_sql_script(self.connection, core_sql, "auto_relations_detector.sql"):
-                return False
-            
+
             logger.info("✅ Core functions loaded successfully")
             return True
             

--- a/reporting/notion/notion_supabase_sync.py
+++ b/reporting/notion/notion_supabase_sync.py
@@ -13,7 +13,9 @@ from dotenv import load_dotenv
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from config.loader import load_full_config
 from config.logger_config import setup_logger
+from reporting.notion._client import extract_property_value
 from reporting.process.supabase_uploader import get_db_connection, load_db_config
 
 # Set up logger - will use existing logger if available
@@ -43,19 +45,28 @@ class NotionSupabaseSync:
         self.last_sync_times = {}  # Track last sync time per database
         
     def _load_config(self, config_path: str = None) -> dict:  # type: ignore
-        """Load configuration from JSON file."""
+        """Load configuration from JSON file.
+
+        With no override, reads through ``config.loader`` (the project's
+        single-source loader) so the default path stays in exactly one place.
+        The ``--config`` override still reads its own path directly, since
+        that's not something ``config.loader`` supports.
+        """
         if config_path is None:
-            config_path = Path(__file__).parent.parent.parent / "config" / "config.json"
-        
+            logger.debug("📂 Loading configuration via config.loader (config/config.json)")
+            config = load_full_config()
+            logger.info("✅ Configuration loaded successfully")
+            return config
+
         logger.debug(f"📂 Loading configuration from {config_path}")
-        
+
         if not os.path.exists(config_path):
             logger.error(f"❌ Configuration file not found: {config_path}")
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
-        
+
         with open(config_path, 'r') as f:
             config = json.load(f)
-        
+
         logger.info("✅ Configuration loaded successfully")
         return config
     
@@ -132,95 +143,12 @@ class NotionSupabaseSync:
         
         return self._notion_api_call(f"databases/{database_id}/query", method="POST", data=data)
     
-    def _extract_property_value(self, prop: dict) -> Any:
-        """Extract the actual value from a Notion property."""
-        prop_type = prop.get("type")
-        
-        if prop_type == "title":
-            texts = prop.get("title", [])
-            return "".join([t.get("plain_text", "") for t in texts])
-        elif prop_type == "rich_text":
-            texts = prop.get("rich_text", [])
-            return "".join([t.get("plain_text", "") for t in texts])
-        elif prop_type == "number":
-            return prop.get("number")
-        elif prop_type == "select":
-            select = prop.get("select")
-            return select.get("name") if select else None
-        elif prop_type == "multi_select":
-            return [opt.get("name") for opt in prop.get("multi_select", [])]
-        elif prop_type == "date":
-            date_obj = prop.get("date")
-            if date_obj:
-                start_date = date_obj.get("start")
-                # Return None for empty dates instead of empty string
-                return start_date if start_date else None
-            return None
-        elif prop_type == "checkbox":
-            return prop.get("checkbox", False)
-        elif prop_type == "url":
-            url = prop.get("url")
-            # Return None for empty URLs
-            return url if url else None
-        elif prop_type == "email":
-            email = prop.get("email")
-            return email if email else None
-        elif prop_type == "phone_number":
-            phone = prop.get("phone_number")
-            return phone if phone else None
-        elif prop_type == "formula":
-            formula = prop.get("formula", {})
-            return self._extract_formula_value(formula)
-        elif prop_type == "relation":
-            return [rel.get("id") for rel in prop.get("relation", [])]
-        elif prop_type == "rollup":
-            rollup = prop.get("rollup", {})
-            return self._extract_rollup_value(rollup)
-        elif prop_type == "people":
-            return [person.get("id") for person in prop.get("people", [])]
-        elif prop_type == "files":
-            files = prop.get("files", [])
-            return [f.get("file", {}).get("url") or f.get("external", {}).get("url") for f in files]
-        elif prop_type == "created_time":
-            created = prop.get("created_time")
-            return created if created else None
-        elif prop_type == "created_by":
-            return prop.get("created_by", {}).get("id")
-        elif prop_type == "last_edited_time":
-            edited = prop.get("last_edited_time")
-            return edited if edited else None
-        elif prop_type == "last_edited_by":
-            return prop.get("last_edited_by", {}).get("id")
-        elif prop_type == "status":
-            status = prop.get("status")
-            return status.get("name") if status else None
-        else:
-            # For unknown types, store as JSONB
-            return prop
-    
-    def _extract_formula_value(self, formula: dict) -> Any:
-        """Extract value from formula property."""
-        formula_type = formula.get("type")
-        if formula_type == "string":
-            return formula.get("string")
-        elif formula_type == "number":
-            return formula.get("number")
-        elif formula_type == "boolean":
-            return formula.get("boolean")
-        elif formula_type == "date":
-            date_obj = formula.get("date")
-            return date_obj.get("start") if date_obj else None
-        return None
-    
-    def _extract_rollup_value(self, rollup: dict) -> Any:
-        """Extract value from rollup property."""
-        rollup_type = rollup.get("type")
-        if rollup_type == "number":
-            return rollup.get("number")
-        elif rollup_type == "array":
-            return [self._extract_property_value(item) for item in rollup.get("array", [])]
-        return None
-    
+    # Property-value conversion (title/rich_text/rollup/formula/etc.) lives in
+    # ``reporting.notion._client.extract_property_value`` — this was one of
+    # three drifted, independent copies (this one was the most complete, so
+    # it's the one that got promoted); imported as a module-level function
+    # above rather than redefined as a method here.
+
     def _normalize_column_name(self, name: str) -> str:
         """Normalize Notion property names to valid PostgreSQL column names."""
         # Replace spaces and special characters with underscores
@@ -249,7 +177,7 @@ class NotionSupabaseSync:
         
         for prop_name, prop_value in properties.items():
             col_name = self._normalize_column_name(prop_name)
-            value = self._extract_property_value(prop_value)
+            value = extract_property_value(prop_value)
             
             # Handle complex types that don't fit well in regular columns
             if isinstance(value, (list, dict)):

--- a/reporting/notion/notion_unify_data.py
+++ b/reporting/notion/notion_unify_data.py
@@ -11,10 +11,15 @@ from dotenv import load_dotenv
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from config.loader import load_full_config as load_config
-from reporting.process.supabase_uploader import get_db_connection
+from reporting.process.supabase_uploader import get_db_connection, run_sql_file
 
-# Set up logger
-logger = None
+SQL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "notion_unify_data.sql")
+
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("notion_unify_data")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -22,32 +27,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("notion_unify_data", file_logging=False, level=log_level)
     return logger
-
-def read_sql_from_file():
-    """Read the SQL content from the existing SQL file."""
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(script_dir, "notion_unify_data.sql")
-    
-    try:
-        with open(file_path, 'r') as f:
-            sql_content = f.read()
-        return sql_content
-    except Exception as e:
-        logger.error(f"❌ Error reading SQL file: {e}")
-        return None
-
-def execute_sql(connection, sql_content):
-    """Execute the SQL on the Supabase database."""
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute(sql_content)
-        connection.commit()
-        logger.info("✅ SQL executed successfully")
-        return True
-    except Exception as e:
-        logger.error(f"❌ Error executing SQL: {e}")
-        connection.rollback()
-        return False
 
 def parse_arguments():
     """Parse command-line arguments."""
@@ -74,24 +53,16 @@ def main(args=None):
     # Load configuration
     config = load_config()
 
-    # Read SQL from file
-    logger.info("📝 Reading SQL from file")
-    sql_content = read_sql_from_file()
-    
-    if not sql_content:
-        logger.error("❌ Failed to read SQL file")
-        return
-    
     # Connect to database using the approach from profile_aggregator
     connection = get_db_connection()
     if not connection:
         logger.error("❌ Failed to connect to database")
         return
-    
-    # Execute SQL
+
+    # Read + execute the unify SQL
     logger.info("🔄 Executing SQL to create unified data table")
-    success = execute_sql(connection, sql_content)
-    
+    success = run_sql_file(connection, SQL_PATH, logger=logger)
+
     # Close connection
     connection.close()
     

--- a/reporting/notion/notion_update.py
+++ b/reporting/notion/notion_update.py
@@ -12,12 +12,20 @@ from dotenv import load_dotenv
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from reporting.process.supabase_uploader import get_db_connection
-# init_notion_client / format_database_id live in the shared _client module;
-# re-exported here so existing importers (e.g. editorial.py) keep working.
-from reporting.notion._client import init_notion_client, format_database_id
+# init_notion_client / format_database_id / extract_property_value live in
+# the shared _client module; re-exported here so existing importers (e.g.
+# editorial.py) keep working.
+from reporting.notion._client import (
+    extract_property_value,
+    format_database_id,
+    init_notion_client,
+)
 
-# Set up logger
-logger = None
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("notion_update")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -25,58 +33,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("notion_update", file_logging=False, level=log_level)
     return logger
-
-def extract_property_value(property_item):
-    """Extract the value from a property item based on its type."""
-    prop_type = property_item.get('type', 'unknown')
-    
-    if prop_type == 'title':
-        title_array = property_item.get('title', [])
-        if title_array:
-            return title_array[0].get('plain_text', '')
-        return ''
-    
-    elif prop_type == 'rich_text':
-        text_array = property_item.get('rich_text', [])
-        if text_array:
-            return text_array[0].get('plain_text', '')
-        return ''
-    
-    elif prop_type == 'number':
-        return property_item.get('number', None)
-    
-    elif prop_type == 'select':
-        select_obj = property_item.get('select', {})
-        return select_obj.get('name', '') if select_obj else ''
-    
-    elif prop_type == 'multi_select':
-        multi_select = property_item.get('multi_select', [])
-        return [item.get('name', '') for item in multi_select]
-    
-    elif prop_type == 'date':
-        date_obj = property_item.get('date', {})
-        if date_obj:
-            start = date_obj.get('start', '')
-            end = date_obj.get('end', '')
-            return {'start': start, 'end': end} if end else start
-        return None
-    
-    elif prop_type == 'checkbox':
-        return property_item.get('checkbox', False)
-    
-    elif prop_type == 'url':
-        return property_item.get('url', '')
-    
-    elif prop_type == 'relation':
-        relation_array = property_item.get('relation', [])
-        return [item.get('id', '') for item in relation_array]
-    
-    elif prop_type == 'formula':
-        formula_result = property_item.get('formula', {})
-        result_type = formula_result.get('type', '')
-        return formula_result.get(result_type, None)
-    
-    return None
 
 def parse_date(date_str):
     """Parse date string in either YYYY-MM-DD or YYYYMMDD format."""

--- a/reporting/notion/setup_notion_relations_system.py
+++ b/reporting/notion/setup_notion_relations_system.py
@@ -11,10 +11,15 @@ from dotenv import load_dotenv
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from config.loader import load_full_config as load_config
-from reporting.process.supabase_uploader import get_db_connection
+from reporting.process.supabase_uploader import execute_sql, get_db_connection, run_sql_file
 
-# Set up logger
-logger = None
+SQL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "setup_notion_relations_system.sql")
+
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("setup_notion_relations_system")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -22,32 +27,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("setup_notion_relations_system", file_logging=False, level=log_level)
     return logger
-
-def read_sql_from_file():
-    """Read the SQL content from the existing SQL file."""
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(script_dir, "setup_notion_relations_system.sql")
-    
-    try:
-        with open(file_path, 'r', encoding='utf-8') as f:
-            sql_content = f.read()
-        return sql_content
-    except Exception as e:
-        logger.error(f"❌ Error reading SQL file: {e}")
-        return None
-
-def execute_sql(connection, sql_content):
-    """Execute the SQL on the Supabase database."""
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute(sql_content)
-        connection.commit()
-        logger.info("✅ SQL executed successfully")
-        return True
-    except Exception as e:
-        logger.error(f"❌ Error executing SQL: {e}")
-        connection.rollback()
-        return False
 
 def fetch_debug_log_entries(connection, limit=100):
     """Fetch recent debug log entries from the database."""
@@ -84,33 +63,25 @@ def main(args=None):
     # Load configuration
     config = load_config()
 
-    # Read SQL from file
-    logger.info("📝 Reading SQL from file")
-    sql_content = read_sql_from_file()
-    
-    if not sql_content:
-        logger.error("❌ Failed to read SQL file")
-        return
-    
     # Connect to database
     connection = get_db_connection()
     if not connection:
         logger.error("❌ Failed to connect to database")
         return
-    
-    # Execute SQL to create functions, tables, etc.
+
+    # Read + execute the setup SQL (creates functions, tables, etc.)
     logger.info("🔄 Executing setup SQL for Notion relations system")
-    setup_success = execute_sql(connection, sql_content)
-    
+    setup_success = run_sql_file(connection, SQL_PATH, logger=logger)
+
     if not setup_success:
         connection.close()
         logger.error("❌ Setup SQL execution failed")
         return
-    
+
     # Run the final initialization query to activate the script
     init_query = "SELECT setup_notion_relations_system();"
     logger.info("⚙️  Running initialization query to activate the system")
-    init_success = execute_sql(connection, init_query)
+    init_success = execute_sql(connection, init_query, logger=logger)
     
     # Fetch recent debug log entries if initialization succeeded
     if init_success:

--- a/reporting/process/data_processor.py
+++ b/reporting/process/data_processor.py
@@ -14,8 +14,11 @@ from config.logger_config import setup_logger
 from config.loader import load_full_config as load_config
 from reporting.process.supabase_uploader import upload_all_dataframes
 
-# Set up logger
-logger = None
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("data_processor")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""

--- a/reporting/process/posts_consolidator.py
+++ b/reporting/process/posts_consolidator.py
@@ -11,10 +11,15 @@ from dotenv import load_dotenv
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from config.loader import load_full_config as load_config
-from reporting.process.supabase_uploader import get_db_connection
+from reporting.process.supabase_uploader import get_db_connection, run_sql_file
 
-# Set up logger
-logger = None
+SQL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "posts_consolidator.sql")
+
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("posts_consolidator")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -22,32 +27,6 @@ def configure_logger(debug_mode=False):
     log_level = logging.DEBUG if debug_mode else logging.INFO
     logger = setup_logger("posts_consolidator", file_logging=False, level=log_level)
     return logger
-
-def read_sql_from_file():
-    """Read the SQL content from the existing SQL file."""
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(script_dir, "posts_consolidator.sql")
-    
-    try:
-        with open(file_path, 'r') as f:
-            sql_content = f.read()
-        return sql_content
-    except Exception as e:
-        logger.error(f"❌ Error reading SQL file: {e}")
-        return None
-
-def execute_sql(connection, sql_content):
-    """Execute the SQL on the Supabase database."""
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute(sql_content)
-        connection.commit()
-        logger.info("✅ SQL executed successfully")
-        return True
-    except Exception as e:
-        logger.error(f"❌ Error executing SQL: {e}")
-        connection.rollback()
-        return False
 
 def parse_arguments():
     """Parse command-line arguments."""
@@ -75,24 +54,16 @@ def main(args=None):
     # Load configuration
     config = load_config()
 
-    # Read SQL from file
-    logger.info("📝 Reading SQL from file")
-    sql_content = read_sql_from_file()
-    
-    if not sql_content:
-        logger.error("❌ Failed to read SQL file")
-        return
-    
     # Connect to database using the approach from profile_aggregator
     connection = get_db_connection()
     if not connection:
         logger.error("❌ Failed to connect to database")
         return
-    
-    # Execute SQL
+
+    # Read + execute the consolidation SQL
     logger.info("🔄 Executing SQL to create consolidated posts table")
-    success = execute_sql(connection, sql_content)
-    
+    success = run_sql_file(connection, SQL_PATH, logger=logger)
+
     # Close connection
     connection.close()
     

--- a/reporting/process/profile_aggregator.py
+++ b/reporting/process/profile_aggregator.py
@@ -10,10 +10,15 @@ from dotenv import load_dotenv
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
-from reporting.process.supabase_uploader import get_db_connection
+from reporting.process.supabase_uploader import get_db_connection, run_sql_file
 
-# Set up logger
-logger = None
+SQL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "profile_aggregator.sql")
+
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("profile_aggregator")
 
 def configure_logger(debug_mode=False, existing_logger=None):
     """Set up logger with appropriate level based on debug mode."""
@@ -23,21 +28,8 @@ def configure_logger(debug_mode=False, existing_logger=None):
     else:
         log_level = logging.DEBUG if debug_mode else logging.INFO
         logger = setup_logger("profile_aggregator", file_logging=False, level=log_level)
-    
-    return logger
 
-def read_sql_from_file():
-    """Read the SQL content from the SQL file."""
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    file_path = os.path.join(script_dir, "profile_aggregator.sql")
-    
-    try:
-        with open(file_path, 'r') as f:
-            sql_content = f.read()
-        return sql_content
-    except Exception as e:
-        logger.error(f"❌ Error reading SQL file: {e}")
-        return None
+    return logger
 
 def aggregate_profile_data(connection=None):
     """
@@ -61,21 +53,12 @@ def aggregate_profile_data(connection=None):
     
     try:
         logger.info("🔄 Starting profile data aggregation")
-        
-        # Read SQL from file
-        logger.debug("📝 Reading SQL from file")
-        sql = read_sql_from_file()
-        
-        if not sql:
-            logger.error("❌ Failed to read SQL file")
-            return False
-        
-        # Execute the SQL query
+
+        # Read + execute the aggregation SQL
         logger.info("🔄 Executing SQL to create aggregated profile table")
-        with connection.cursor() as cursor:
-            cursor.execute(sql)
-            logger.debug("✓ SQL execution completed")
-        
+        if not run_sql_file(connection, SQL_PATH, logger=logger):
+            return False
+
         # Count rows in the new table
         with connection.cursor() as cursor:
             cursor.execute("SELECT COUNT(*) FROM profile")
@@ -98,42 +81,11 @@ def aggregate_profile_data(connection=None):
 def parse_arguments():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description='Aggregate profile data from multiple platform tables.')
-    
+
     # Add arguments for all interactive prompts
     parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--date', type=str, help='Reference date (unused in this module)')
-    
-    return parser.parse_args()
 
-def main(args=None):
-    """Main function for running the profile aggregator."""
-    if args is None:
-        # Use command-line arguments if available, otherwise parse them
-        args = parse_arguments()
-    
-    # Configure logger with appropriate level based on args
-    debug_mode = args.debug
-    configure_logger(debug_mode)
-    
-    logger.info("🚀 Starting Profile Aggregator")
-    logger.info(f"🐞 Debug mode: {'Enabled' if debug_mode else 'Disabled'}")
-    
-    # Aggregate profile data
-    result = aggregate_profile_data()
-    
-    if result:
-        logger.info("✅ Profile aggregation completed successfully")
-    else:
-        logger.error("❌ Profile aggregation failed")
-
-def parse_arguments():
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description='Aggregate profile data from multiple platform tables.')
-    
-    # Add arguments for all interactive prompts
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
-    parser.add_argument('--date', type=str, help='Reference date (unused in this module)')
-    
     return parser.parse_args()
 
 def main(args=None):

--- a/reporting/process/supabase_relations_creator.py
+++ b/reporting/process/supabase_relations_creator.py
@@ -21,54 +21,18 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 # Single-source DB helpers — canonical defs live in supabase_uploader.
 from reporting.process.supabase_uploader import load_db_config, get_db_connection
+# apply_table_policies previously had a second, diverging copy here (raw
+# f-string SQL, no idempotency check) that had drifted from this one —
+# supabase_policy_script's version uses psycopg2.sql.Identifier for safe
+# quoting and skips tables that already carry every policy; that's the
+# single source now.
+from reporting.process.supabase_policy_script import apply_table_policies
 
 # Set up logger - will use existing logger if available
 logger = logging.getLogger("supabase_relations_creator")
 if not logger.handlers:
     # Only set up if no handlers exist (i.e., not already configured)
     logger = setup_logger("supabase_relations_creator", file_logging=False)
-
-def apply_table_policies(connection, table_name):
-    """
-    Apply Row Level Security (RLS) policies to a newly created table.
-    
-    Args:
-        connection: Database connection
-        table_name (str): Name of the table to apply policies to
-    """
-    try:
-        # First, drop any existing policies to avoid conflicts
-        drop_policies_sql = f"""
-        DROP POLICY IF EXISTS anon_select_all ON public."{table_name}";
-        DROP POLICY IF EXISTS anon_insert_all ON public."{table_name}";
-        DROP POLICY IF EXISTS anon_update_all ON public."{table_name}";
-        DROP POLICY IF EXISTS anon_delete_all ON public."{table_name}";
-        """
-        
-        with connection.cursor() as cursor:
-            cursor.execute(drop_policies_sql)
-        
-        # Enable RLS and create new policies
-        policies_sql = f"""
-        -- Enable RLS on the table
-        ALTER TABLE public."{table_name}" ENABLE ROW LEVEL SECURITY;
-        
-        -- Create policies for anon access
-        CREATE POLICY anon_select_all ON public."{table_name}" FOR SELECT TO anon USING (true);
-        CREATE POLICY anon_insert_all ON public."{table_name}" FOR INSERT TO anon WITH CHECK (true);
-        CREATE POLICY anon_update_all ON public."{table_name}" FOR UPDATE TO anon USING (true) WITH CHECK (true);
-        CREATE POLICY anon_delete_all ON public."{table_name}" FOR DELETE TO anon USING (true);
-        """
-        
-        with connection.cursor() as cursor:
-            cursor.execute(policies_sql)
-        
-        logger.debug(f"🔒 Applied RLS policies to table {table_name}")
-        return True
-        
-    except Exception as e:
-        logger.error(f"❌ Error applying policies to table {table_name}: {e}")
-        return False
 
 def load_notion_data():
     """

--- a/reporting/process/supabase_uploader.py
+++ b/reporting/process/supabase_uploader.py
@@ -79,6 +79,43 @@ def get_db_connection(db_config=None, environment="cloud"):
         logger.error(f"❌ Error connecting to database: {e}")
         return None
 
+def execute_sql(connection, sql_content, logger=logger):
+    """Execute a SQL string against ``connection``; commit on success, rollback on error.
+
+    Single-source for the "execute SQL, commit / rollback+log" body that was
+    byte-identical (or a divergent restatement — one copy naively split on
+    ``;`` instead of running the text as one statement) across five modules.
+    Pass the caller's own module logger so log lines stay attributed to the
+    calling pipeline step; defaults to this module's logger otherwise.
+    """
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(sql_content)
+        connection.commit()
+        logger.info("✅ SQL executed successfully")
+        return True
+    except Exception as e:
+        logger.error(f"❌ Error executing SQL: {e}")
+        connection.rollback()
+        return False
+
+
+def run_sql_file(connection, path, logger=logger):
+    """Read the SQL file at ``path`` and execute it against ``connection``.
+
+    Single-source for "read a .sql file next to the caller, then execute it"
+    — the ``read_sql_from_file()`` + :func:`execute_sql` pair that five
+    modules each copy-pasted (or divergently restated) their own version of.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            sql_content = f.read()
+    except Exception as e:
+        logger.error(f"❌ Error reading SQL file {path}: {e}")
+        return False
+
+    return execute_sql(connection, sql_content, logger=logger)
+
 def map_pandas_to_postgres_type(dtype):
     """Map pandas data types to PostgreSQL data types for table creation."""
     if pd.api.types.is_integer_dtype(dtype):

--- a/reporting/scrape_client/base.py
+++ b/reporting/scrape_client/base.py
@@ -8,25 +8,18 @@ the single source of truth.
 
 from __future__ import annotations
 
-import json
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
+from config.loader import load_full_config
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-CONFIG_PATH = REPO_ROOT / "config" / "config.json"
 
 
 class ScrapeError(RuntimeError):
     """Raised when a required field cannot be extracted from the page."""
-
-
-def load_full_config() -> dict:
-    """Load the full config.json."""
-    with open(CONFIG_PATH, "r", encoding="utf-8") as fp:
-        return json.load(fp)
 
 
 def load_platform_block(platform: str) -> dict:

--- a/reporting/social_client/social_api_client.py
+++ b/reporting/social_client/social_api_client.py
@@ -15,8 +15,11 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from config.logger_config import setup_logger
 from config.loader import load_full_config as load_config
 
-# Set up logger
-logger = None
+# Set up logger. Module-scope default is a real (unconfigured) Logger — never
+# None — so `logger.xxx(...)` calls elsewhere in this module are plain Logger
+# calls with no Optional to work around. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance.
+logger = logging.getLogger("social_api_client")
 
 def interruptible_sleep(seconds: int) -> bool:
     """Sleep up to `seconds`, returning True immediately if user presses 'x'."""

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -25,6 +25,7 @@ sys.path.append(str(Path(__file__).parent))
 from config.console import force_utf8_stdio  # noqa: E402
 force_utf8_stdio()
 from config.logger_config import setup_logger  # noqa: E402
+from config.loader import load_full_config  # noqa: E402
 from reporting.social_client.social_api_client import (
     main as run_social_api_client,
     configure_logger as configure_social_logger,
@@ -36,8 +37,12 @@ from reporting.process.posts_consolidator import main as run_posts_consolidator,
 from reporting.notion.notion_update import main as run_notion_update, configure_logger as configure_notion_logger
 from planning.substack.daily_pipeline import main as run_substack_daily_pipeline
 
-# Set up logger
-logger: logging.Logger | None = None
+# Set up logger. Module-scope default is a real (unconfigured) Logger —
+# never None — so every `logger.info(...)` call below is a plain Logger
+# method call with no Optional to silence. `configure_logger()` replaces it
+# with the fully-configured (handlers + formatter) instance before the
+# pipeline actually runs.
+logger: logging.Logger = logging.getLogger("init")
 
 def configure_logger(debug_mode=False):
     """Set up logger with appropriate level based on debug mode."""
@@ -77,13 +82,18 @@ class PipelineFailures:
 
 
 def _load_config() -> dict | None:
-    """Load ``config/config.json`` for coverage + Slack channel resolution."""
-    config_path = Path(__file__).parent / "config" / "config.json"
+    """Load ``config/config.json`` for coverage + Slack channel resolution.
+
+    Wraps ``config.loader.load_full_config`` (the project's single-source
+    loader) but, unlike it, degrades to ``None`` on a missing/corrupt
+    config.json rather than raising — coverage checks and the Slack channel
+    resolution are best-effort here; the failure alert must still fire even
+    if config couldn't be read.
+    """
     try:
-        with open(config_path, "r", encoding="utf-8") as file:
-            return json.load(file)
+        return load_full_config()
     except (FileNotFoundError, json.JSONDecodeError) as e:
-        logger.error(f"❌ Could not load config for failure detection: {e}")  # type: ignore
+        logger.error(f"❌ Could not load config for failure detection: {e}")
         return None
 
 
@@ -99,9 +109,9 @@ def check_endpoint_coverage(config: dict, processing_date: str, failures: "Pipel
         exists, _ = check_file_exists_for_date(platform_key, config, processing_date)
         if not exists:
             failures.missing_endpoints.append(platform_key)
-            logger.error(f"❌ Missing expected data file for {platform_key} on {processing_date}")  # type: ignore
+            logger.error(f"❌ Missing expected data file for {platform_key} on {processing_date}")
     if not failures.missing_endpoints:
-        logger.info(f"✅ All {len(config_endpoints)} expected endpoint files present for {processing_date}")  # type: ignore
+        logger.info(f"✅ All {len(config_endpoints)} expected endpoint files present for {processing_date}")
 
 
 # Platforms whose consolidated post metrics we expect on every daily run.
@@ -135,7 +145,7 @@ def _substack_had_editorial_content(day_yyyymmdd: str) -> Optional[bool]:
         body_text = get_field(row, "text_body", cfg["notion_columns"]) or ""
         return bool(str(body_text).strip())
     except Exception as e:
-        logger.warning(f"⚠️ Could not verify Substack editorial content for {day_yyyymmdd}: {e}")  # type: ignore
+        logger.warning(f"⚠️ Could not verify Substack editorial content for {day_yyyymmdd}: {e}")
         return None
 
 
@@ -157,7 +167,7 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
         from reporting.process.supabase_uploader import get_db_connection
         connection = get_db_connection()
         if not connection:
-            logger.error("❌ Posts-coverage check: no DB connection — skipped")  # type: ignore
+            logger.error("❌ Posts-coverage check: no DB connection — skipped")
             return
         try:
             with connection.cursor() as cursor:
@@ -169,7 +179,7 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
 
         if not row:
             failures.missing_post_metrics.append("(no consolidated posts row)")
-            logger.error(f"❌ Posts-coverage: no consolidated posts row for {processing_date}")  # type: ignore
+            logger.error(f"❌ Posts-coverage: no consolidated posts row for {processing_date}")
             return
 
         data = dict(zip(columns, row))
@@ -181,14 +191,14 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
                 covered_day = (datetime.strptime(processing_date, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y%m%d")
                 had_content = _substack_had_editorial_content(covered_day)
                 if had_content is False:
-                    logger.warning(f"⚠️ Posts-coverage: substack had no editorial content queued for {covered_day} — no post metrics for {processing_date} is expected, not a failure")  # type: ignore
+                    logger.warning(f"⚠️ Posts-coverage: substack had no editorial content queued for {covered_day} — no post metrics for {processing_date} is expected, not a failure")
                     continue
             failures.missing_post_metrics.append(platform)
-            logger.error(f"❌ Posts-coverage: no post metrics for {platform} on {processing_date}")  # type: ignore
+            logger.error(f"❌ Posts-coverage: no post metrics for {platform} on {processing_date}")
         if not failures.missing_post_metrics:
-            logger.info(f"✅ Posts-coverage: all {len(COVERAGE_PLATFORMS)} platforms have post metrics for {processing_date}")  # type: ignore
+            logger.info(f"✅ Posts-coverage: all {len(COVERAGE_PLATFORMS)} platforms have post metrics for {processing_date}")
     except Exception as e:
-        logger.error(f"❌ Posts-coverage check failed: {e}")  # type: ignore
+        logger.error(f"❌ Posts-coverage check failed: {e}")
 
 
 def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
@@ -207,7 +217,7 @@ def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
         from reporting.process.supabase_policy_script import check_policy_drift, summarize_drift
         connection = get_db_connection()
         if not connection:
-            logger.error("❌ Policy-drift check: no DB connection — skipped")  # type: ignore
+            logger.error("❌ Policy-drift check: no DB connection — skipped")
             return
         try:
             result = check_policy_drift(connection)
@@ -216,7 +226,7 @@ def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
 
         drift = summarize_drift(result)
         if not drift:
-            logger.info(  # type: ignore
+            logger.info(
                 f"✅ Policy-drift: RLS + policies intact across {result['total_tables']} "
                 f"tables, {result['total_views']} views"
             )
@@ -224,9 +234,9 @@ def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
 
         for kind, summary in drift:
             failures.policy_drift.append(f"{kind} {summary}")
-            logger.error(f"❌ Policy-drift: {kind} {summary}")  # type: ignore
+            logger.error(f"❌ Policy-drift: {kind} {summary}")
     except Exception as e:
-        logger.error(f"❌ Policy-drift check failed: {e}")  # type: ignore
+        logger.error(f"❌ Policy-drift check failed: {e}")
 
 
 def _resolve_reporting_channel(config: dict | None) -> str:
@@ -247,7 +257,7 @@ def _load_slack_notify():
     """
     helper = Path.home() / ".claude" / "hooks" / "slack_notify.py"
     if not helper.exists():
-        logger.error(f"❌ Slack helper not found at {helper} — alert not sent")  # type: ignore
+        logger.error(f"❌ Slack helper not found at {helper} — alert not sent")
         return None
     try:
         spec = importlib.util.spec_from_file_location("slack_notify", helper)
@@ -255,7 +265,7 @@ def _load_slack_notify():
         spec.loader.exec_module(module)  # type: ignore
         return module
     except Exception as e:
-        logger.error(f"❌ Could not import Slack helper: {e}")  # type: ignore
+        logger.error(f"❌ Could not import Slack helper: {e}")
         return None
 
 
@@ -292,11 +302,11 @@ def send_failure_alert(failures: "PipelineFailures", processing_date: str, confi
     the non-zero exit in ``main()`` is the independent second signal regardless.
     """
     message = _build_alert_message(failures, processing_date)
-    logger.error("🚨 Pipeline finished with failures:\n%s", message)  # type: ignore
+    logger.error("🚨 Pipeline finished with failures:\n%s", message)
 
     channel = _resolve_reporting_channel(config)
     if not channel:
-        logger.error("❌ No Slack channel configured (slack.reporting_channel / slack.autoheal_channel) — alert not sent")  # type: ignore
+        logger.error("❌ No Slack channel configured (slack.reporting_channel / slack.autoheal_channel) — alert not sent")
         return
 
     slack = _load_slack_notify()
@@ -304,7 +314,7 @@ def send_failure_alert(failures: "PipelineFailures", processing_date: str, confi
         return
 
     if not slack.notify(message, channel=channel):
-        logger.error("❌ Slack alert delivery failed (see slack_notify logs)")  # type: ignore
+        logger.error("❌ Slack alert delivery failed (see slack_notify logs)")
 
 
 def parse_arguments():
@@ -350,9 +360,9 @@ def run_module(module_func, module_name, debug_mode=False, extra_args=None, fail
             
         # Run the module
         module_func()
-        logger.info(f"✅ {module_name} completed successfully")  # type: ignore
+        logger.info(f"✅ {module_name} completed successfully")
     except Exception as e:
-        logger.error(f"❌ Error in {module_name}: {e}")  # type: ignore
+        logger.error(f"❌ Error in {module_name}: {e}")
         if failures is not None:
             failures.step_failures.append((module_name, str(e)))
         if debug_mode:
@@ -377,8 +387,8 @@ def run_pipeline(debug_mode=False, skip_api=False, skip_processing=False,
     failures = PipelineFailures()
     config = _load_config()
 
-    logger.info("🚀 Starting the complete data processing pipeline")  # type: ignore
-    logger.info(f"🐞 Debug mode: {'Enabled' if debug_mode else 'Disabled'}")  # type: ignore
+    logger.info("🚀 Starting the complete data processing pipeline")
+    logger.info(f"🐞 Debug mode: {'Enabled' if debug_mode else 'Disabled'}")
     
     # Use the reference date directly or today's date
     if reference_date:
@@ -388,86 +398,86 @@ def run_pipeline(debug_mode=False, skip_api=False, skip_processing=False,
                 processing_date = reference_date
             else:
                 processing_date = datetime.strptime(reference_date, "%Y%m%d").strftime("%Y-%m-%d")
-            logger.info(f"📅 Using specified date: {processing_date}")  # type: ignore
+            logger.info(f"📅 Using specified date: {processing_date}")
         except ValueError:
-            logger.error(f"❌ Invalid date format: {reference_date}. Using current date.")  # type: ignore
+            logger.error(f"❌ Invalid date format: {reference_date}. Using current date.")
             processing_date = datetime.now().strftime("%Y-%m-%d")
     else:
         processing_date = datetime.now().strftime("%Y-%m-%d")
-        logger.info(f"📅 No date specified. Using current date: {processing_date}")  # type: ignore
+        logger.info(f"📅 No date specified. Using current date: {processing_date}")
     
     # Prepare common arguments
     date_args = ['--date', processing_date]
     
     # Step 1: Fetch data from social media APIs
     if not skip_api:
-        logger.info("📡 Step 1: Running Social API Client")  # type: ignore
+        logger.info("📡 Step 1: Running Social API Client")
         configure_social_logger(debug_mode)
         run_module(run_social_api_client, "Social API Client", debug_mode, extra_args=date_args, failures=failures)
         # Coverage check: which configured endpoints produced no file for the date.
         if config:
             check_endpoint_coverage(config, processing_date, failures)
     else:
-        logger.info("⏭️ Skipping Social API Client step")  # type: ignore
+        logger.info("⏭️ Skipping Social API Client step")
     
     # Step 2: Process the raw data
     if not skip_processing:
-        logger.info("🔄 Step 2: Running Data Processor")  # type: ignore
+        logger.info("🔄 Step 2: Running Data Processor")
         configure_data_processor_logger(debug_mode)
         run_module(run_data_processor, "Data Processor", debug_mode, extra_args=date_args, failures=failures)
     else:
-        logger.info("⏭️ Skipping Data Processor step")  # type: ignore
+        logger.info("⏭️ Skipping Data Processor step")
     
     # Step 3: Aggregate profile data
     if not skip_aggregation:
-        logger.info("📊 Step 3: Running Profile Aggregator")  # type: ignore
+        logger.info("📊 Step 3: Running Profile Aggregator")
         configure_profile_logger()
         run_module(run_profile_aggregator, "Profile Aggregator", debug_mode, failures=failures)
     else:
-        logger.info("⏭️ Skipping Profile Aggregator step")  # type: ignore
+        logger.info("⏭️ Skipping Profile Aggregator step")
     
     # Step 4: Consolidate posts data
     if not skip_consolidation:
-        logger.info("📑 Step 4: Running Posts Consolidator")  # type: ignore
+        logger.info("📑 Step 4: Running Posts Consolidator")
         configure_posts_logger(debug_mode)
         run_module(run_posts_consolidator, "Posts Consolidator", debug_mode, failures=failures)
         # Content-coverage check: did every platform actually land post metrics
         # in the consolidated table (not just produce a raw file)? — issue #84.
         check_posts_coverage(processing_date, failures)
     else:
-        logger.info("⏭️ Skipping Posts Consolidator step")  # type: ignore
+        logger.info("⏭️ Skipping Posts Consolidator step")
         
     # Step 5: Update Notion with processed data
     if not skip_notion:
-        logger.info("📘 Step 5: Running Notion Update")  # type: ignore
+        logger.info("📘 Step 5: Running Notion Update")
         configure_notion_logger(debug_mode)
-        logger.info(f"🗓️  Using date for Notion update: {processing_date}")  # type: ignore
+        logger.info(f"🗓️  Using date for Notion update: {processing_date}")
         notion_extra_args = [processing_date]
         if auto_confirm:
             notion_extra_args.append('--yes')
         run_module(run_notion_update, "Notion Update", debug_mode, notion_extra_args, failures=failures)
     else:
-        logger.info("⏭️ Skipping Notion Update step")  # type: ignore
+        logger.info("⏭️ Skipping Notion Update step")
 
     # Step 6: Publish Substack Note (follower scrape now happens in step 1 via reporting/scrape_client/substack.py)
     if not skip_substack:
-        logger.info("📰 Step 6: Running Substack Daily Pipeline")  # type: ignore
+        logger.info("📰 Step 6: Running Substack Daily Pipeline")
         run_module(run_substack_daily_pipeline, "Substack Daily Pipeline", debug_mode, extra_args=date_args, failures=failures)
     else:
-        logger.info("⏭️ Skipping Substack Daily Pipeline step")  # type: ignore
+        logger.info("⏭️ Skipping Substack Daily Pipeline step")
 
     # Posture check: Supabase RLS / policy / view-security drift (issue #50).
     # Read-only and independent of the daily data; runs every pipeline so drift
     # surfaces on the project's own clock, not via the weekly advisor email.
-    logger.info("🔒 Step 7: Checking Supabase RLS / policy drift")  # type: ignore
+    logger.info("🔒 Step 7: Checking Supabase RLS / policy drift")
     check_policy_drift_coverage(failures)
 
     # Notify only on failure: one consolidated alert + a non-zero exit signal.
     if failures.any():
         send_failure_alert(failures, processing_date, config)
-        logger.error("❌ Complete data processing pipeline finished WITH FAILURES")  # type: ignore
+        logger.error("❌ Complete data processing pipeline finished WITH FAILURES")
     else:
-        logger.info("🎉 Complete data processing pipeline finished")  # type: ignore
+        logger.info("🎉 Complete data processing pipeline finished")
 
     return failures
 


### PR DESCRIPTION
## Summary

Surfaced by `/codebase-audit` (issue #195, `duplication` label): this repo consistently built the right shared layer and then didn't finish migrating callers onto it. Addresses every finding in the issue:

- extract the four byte-identical date helpers (`next_monday`, `parse_week_start`, `parse_single_date`, `date_to_day_title`) into `planning/_dates.py`, imported by all five per-platform schedulers instead of copy-pasted
- extract the ~100-line near-identical row-fetch/payload-resolver block shared by the Twitter and Threads schedulers into `planning/_wip_rows.py`
- define `VideoRow` once in `videos_session.py` and import it in all four per-platform video drivers plus the orchestrator, instead of four redefinitions plus a cross-module import workaround
- extract the duplicated contenteditable-editor-locating loop and composer-scoping xpath out of the two Substack note publishers into a shared helper
- migrate the nine hand-rolled config readers onto `config.loader.load_full_config` / `load_block`, deleting the local copies
- switch the nine `logger = None` / `configure_logger` modules to `logging.getLogger(__name__)` at module scope, dropping the `Optional[Logger]` type and its 52 silencing `# type: ignore` comments
- promote the most complete Notion-property-to-Python converter into `reporting/notion/_client.py` and route `notion_database_structure.py` / `notion_supabase_sync.py` through it instead of three independently drifting implementations
- add one `run_sql_file(connection, path)` helper and route all five SQL-execution call sites through it
- delete the diverging, non-idempotent `apply_table_policies` copy in `supabase_relations_creator.py` in favor of `supabase_policy_script.py`'s idempotency-safe version
- delete the dead duplicate `parse_arguments`/`main` pair in `profile_aggregator.py` (Python was silently keeping only the second copy)
- route newsletter's three hand-rolled Notion pagination/HTTP clients through the existing `notion_io._iter_database` retrying client
- move thanks-reply picking into a new leaf module `engagement/classify/phrases_io.py` (no dependency on `db.client`), shared by both prior independent implementations
- make `render_status_badge`/`render_log_panel` delegate to their combined counterparts instead of duplicating ~50 lines

No behavior change intended — this is pure dedup/refactor onto each shared helper's existing contract.

## Validation

- Byte-compiled every changed module: clean.
- Ran the repo's test suite: `& .\.venv\Scripts\python.exe -m pytest tests/ -q` — 85 passed, 4 subtests passed.
- No UX-conformance surface touched (no Streamlit UI files changed).
- No CI workflow or deploy-coverage surface declared for this repo.

Closes #195
