### PR TITLE
fix: retry Playwright/native-sourced endpoints on transient scrape failures

### DIFF
--- a/reporting/social_client/social_api_client.py
+++ b/reporting/social_client/social_api_client.py
@@ -122,6 +122,31 @@ def _fetch_via_native(platform_key, reference_date):
         return None
 
 
+# Retries for the playwright/native scrape sources, run between attempts. A
+# transient timing hiccup (cold browser profile, slow page load on the 06:00
+# scheduled run) shouldn't permanently drop a day's data — mirrors the
+# resilience the RapidAPI branch below already has, just with a shorter
+# backoff since each attempt re-launches a full browser session.
+SCRAPE_RETRY_BACKOFF = [20, 60]  # seconds between attempts
+
+
+def _fetch_scrape_with_retries(fetch_fn, platform_key, reference_date):
+    """Retry a Playwright/native scrape fetch on failure before giving up."""
+    attempts = len(SCRAPE_RETRY_BACKOFF) + 1
+    for attempt in range(attempts):
+        data = fetch_fn(platform_key, reference_date)
+        if data:
+            return data
+        if attempt < attempts - 1:
+            wait_time = SCRAPE_RETRY_BACKOFF[attempt]
+            logger.info(f"⏳ Retrying {platform_key} in {wait_time} seconds (attempt {attempt+2}/{attempts})...")
+            if interruptible_sleep(wait_time):
+                logger.info(f"⏩ {platform_key} skipped by user")
+                return None
+    logger.error(f"❌ All {attempts} attempts failed for {platform_key}")
+    return None
+
+
 def get_api_data(platform_key, config, reference_date=None):
     """Fetch data for the specified platform with retries and exponential backoff.
 
@@ -130,10 +155,12 @@ def get_api_data(platform_key, config, reference_date=None):
     * ``"playwright"`` → delegates to ``reporting.scrape_client.<platform>.fetch_<data_type>``
       which drives the platform's persistent Chrome profile via the existing
       ``planning/<platform>/<platform>_session.py`` session class (stealth
-      launch comes from ``config/chrome_launch.py``).
+      launch comes from ``config/chrome_launch.py``). Retried per
+      ``SCRAPE_RETRY_BACKOFF``.
     * ``"native"`` → delegates to ``reporting.scrape_client.<platform>_native.fetch_<data_type>``
       which calls the platform's own HTTP API directly with cookie auth (no
-      browser). Used by Substack's follower count.
+      browser). Used by Substack's follower count. Retried per
+      ``SCRAPE_RETRY_BACKOFF``.
     * anything else (including the default when the key is absent) → RapidAPI
       HTTP call as before.
     """
@@ -145,9 +172,9 @@ def get_api_data(platform_key, config, reference_date=None):
 
     source = api_config.get('source', 'rapidapi')
     if source == 'playwright':
-        return _fetch_via_playwright(platform_key, reference_date)
+        return _fetch_scrape_with_retries(_fetch_via_playwright, platform_key, reference_date)
     if source == 'native':
-        return _fetch_via_native(platform_key, reference_date)
+        return _fetch_scrape_with_retries(_fetch_via_native, platform_key, reference_date)
     if source != 'rapidapi':
         logger.error(f"❌ Unknown source '{source}' for {platform_key} — expected 'rapidapi', 'playwright', or 'native'")
         return None

--- a/tests/test_social_api_client_scrape_retry.py
+++ b/tests/test_social_api_client_scrape_retry.py
@@ -1,0 +1,65 @@
+"""Regression test: Playwright/native-sourced endpoints (issue #205) get the
+same resilience RapidAPI endpoints already had -- a single transient failure
+(cold browser profile, slow page load on the scheduled 06:00 run) shouldn't
+permanently drop a day's data. ``_fetch_scrape_with_retries`` retries the
+underlying fetch before ``get_api_data`` gives up on it.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+from reporting.social_client import social_api_client as sac
+
+
+class ScrapeRetryTests(unittest.TestCase):
+    def setUp(self):
+        sac.logger = MagicMock()
+        sac.logger.level = logging.INFO
+
+    def test_retries_until_success(self):
+        fetch_fn = MagicMock(side_effect=[None, {"num_followers": 100}])
+        with patch.object(sac, "interruptible_sleep", return_value=False) as sleep_mock:
+            result = sac._fetch_scrape_with_retries(fetch_fn, "twitter_profile", "2026-08-04")
+        self.assertEqual(result, {"num_followers": 100})
+        self.assertEqual(fetch_fn.call_count, 2)
+        sleep_mock.assert_called_once_with(sac.SCRAPE_RETRY_BACKOFF[0])
+
+    def test_gives_up_after_all_attempts_exhausted(self):
+        fetch_fn = MagicMock(return_value=None)
+        with patch.object(sac, "interruptible_sleep", return_value=False) as sleep_mock:
+            result = sac._fetch_scrape_with_retries(fetch_fn, "twitter_profile", "2026-08-04")
+        self.assertIsNone(result)
+        self.assertEqual(fetch_fn.call_count, len(sac.SCRAPE_RETRY_BACKOFF) + 1)
+        self.assertEqual(sleep_mock.call_count, len(sac.SCRAPE_RETRY_BACKOFF))
+
+    def test_user_skip_stops_retrying_early(self):
+        fetch_fn = MagicMock(return_value=None)
+        with patch.object(sac, "interruptible_sleep", return_value=True):
+            result = sac._fetch_scrape_with_retries(fetch_fn, "twitter_profile", "2026-08-04")
+        self.assertIsNone(result)
+        self.assertEqual(fetch_fn.call_count, 1)
+
+    def test_get_api_data_routes_playwright_source_through_retries(self):
+        config = {"twitter_profile": {"source": "playwright"}}
+        with patch.object(sac, "_fetch_via_playwright", return_value=None) as playwright_mock, \
+             patch.object(sac, "interruptible_sleep", return_value=False):
+            result = sac.get_api_data("twitter_profile", config, reference_date="2026-08-04")
+        self.assertIsNone(result)
+        self.assertEqual(playwright_mock.call_count, len(sac.SCRAPE_RETRY_BACKOFF) + 1)
+
+    def test_get_api_data_routes_native_source_through_retries(self):
+        config = {"substack_profile": {"source": "native"}}
+        with patch.object(sac, "_fetch_via_native", return_value=None) as native_mock, \
+             patch.object(sac, "interruptible_sleep", return_value=False):
+            result = sac.get_api_data("substack_profile", config, reference_date="2026-08-04")
+        self.assertIsNone(result)
+        self.assertEqual(native_mock.call_count, len(sac.SCRAPE_RETRY_BACKOFF) + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Today's "Reporting failed" alert (run=20260804T060001, exit=1) was `check_endpoint_coverage` flagging `twitter_profile` missing for 2026-08-04. `reporting/scrape_client/twitter.py`'s `fetch_profile()` timed out waiting for the followers-count link, raised `ScrapeError`, which `_fetch_via_playwright()` swallowed and returned `None` — no exception surfaces, the endpoint's data file just silently never gets written.
- Confirmed this is **not** UI/selector drift: live X DOM still has exactly the `<a role="link">17.4K Followers</a>` element the primary selector looks for. It's a timing/cold-start flake — the same failure recurred on 2026-05-26 and 2026-06-15 (screenshots in `results/twitter/`), always around the scheduled 06:00 run.
- Root cause: `get_api_data()` retries RapidAPI-sourced endpoints 5x with exponential backoff, but `source: "playwright"` / `source: "native"` endpoints (twitter_profile, twitter_posts, and others depending on config) get exactly one attempt with zero retry.
- Fix: added `_fetch_scrape_with_retries()` — wraps the playwright/native dispatch in `get_api_data()` with 2 extra attempts (20s/60s backoff, shorter than the RapidAPI schedule since each attempt relaunches a full browser session).
- Backfilled `reporting/results/raw/twitter_profile_2026-08-04.json` (real fetch, `num_followers: 17483`) and reran the downstream steps (data processor → profile aggregator → posts consolidator → Notion update) for 2026-08-04 with `--skip-api --skip-substack` so today's Notion follower count is correct (`follow TW: None → 17483`). Supabase writes are `ON CONFLICT` upserts and Notion update is search-then-update by date, so this was safe to rerun.

## Validation

- `py_compile` on both changed files: clean.
- New regression suite `tests/test_social_api_client_scrape_retry.py` (5 tests: retry-then-succeed, exhaustion, user-skip, playwright/native routing) — confirmed to fail with `AttributeError` against pre-fix code, pass against the fix.
- Full suite: `& .\.venv\Scripts\python.exe -m unittest discover tests -v` → 93/93 passing, 0 failures.
- `/e2e`: no e2e suite in this repo yet (`SUITE=absent`, `WEB_SURFACE=yes` — Streamlit control panel exists but this diff doesn't touch it); tier n/a for this diff, backend-only change fully covered by unit tests.
- Independent fresh-agent review: **pass** (initial false-negative on the backfill criterion was the reviewer checking the stale legacy `results/raw/` path instead of the real `reporting/results/raw/`; corrected and re-verified).
- Re-ran the actual reporting pipeline's coverage checks end-to-end for 2026-08-04 after the backfill: `any() == False` — zero failures, matching a clean run.

Closes #205
