### PR TITLE
Newsletter triage: Step 1/3 — history dataset + criteria inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ engagement/classify/local_model.json
 engagement/classify/.llm_cache.json
 # Launcher scratch (ephemeral images/logs written by the tray launcher)
 .launcher-tmp/
+
+# Google OAuth client + tokens (Gmail read-only for newsletter triage) — never commit
+auth/

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -286,6 +286,16 @@
             "x.com"
         ]
     },
+    "newsletter_triage": {
+        "gmail_label": "newsletters",
+        "gmail_credentials_path": "auth/gmail/credentials.json",
+        "gmail_token_path": "auth/gmail/token.json",
+        "history_weeks": 54,
+        "min_anchor_chars": 12,
+        "redirect_workers": 8,
+        "redirect_timeout_s": 10,
+        "redirect_budget_history": 6000
+    },
     "engagement": {
         "default_days": 5,
         "phrases_path": "engagement/classify/phrases.json",

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -73,8 +73,12 @@ flowchart TB
     NNORM["normalize_names + normalize_url"]
     NBUILD["build_newsletter.py"]
     NSBDRAFT["substack_draft.py\n(optional, explicit step)"]
+    NTRIAGE["triage/ — gmail.py + history.py\n(label ingest, link decode, 54-week\nground truth + criteria)"]
   end
   NPIPE --> NBOOT --> NARCHIVE --> NNORM --> NBUILD
+  NTRIAGE -->|"gmail.readonly via vendored\ngmail_readonly/ + google_oauth_common/"| GMAILAPI[("Gmail API\nlabel 'newsletters'")]
+  NTRIAGE -->|"positives: articles + editions"| NOTION
+  NTRIAGE --> RESULTSTRIAGE[["results/newsletter/triage/\nhistory/ + redirects.json"]]
   NARCHIVE -->|"readability-lxml extraction"| NOTION
   NARCHIVE --> LLMHUB[("local LLM hub\n127.0.0.1:8000\ntopic + 3-line summary")]
   NBUILD --> RESULTSNEWS[["results/newsletter/N{NNN}.html"]]

--- a/docs/newsletter-triage-criteria.md
+++ b/docs/newsletter-triage-criteria.md
@@ -1,0 +1,77 @@
+# Newsletter triage — selection criteria (inferred from 54 weeks)
+
+The weekly newsletter picks 8 articles × 3 topics (leadership and management · personal development · innovation), stars one per topic and names one must-read. This document states the criteria that reproduce those picks, **each with the number it was measured on**, so a reader (or the Step-2 ranker, which consumes the machine-readable twin `newsletter/triage/criteria.json`) can tell a rule from a guess.
+
+**Ground truth** (`python -m newsletter.triage.history`, built 2026-08-21): Gmail label `newsletters`, 2025-08-08 → 2026-08-21 — 4,383 emails (median 82/week, min 25 in the opening week, max 102), 57,849 non-noise links; Notion editions N174–N229 (58 rows, 54 complete) with 1,317 picks. 93.9% of picks were traced to the email that offered them (45% exact URL, 27% Substack slug, 8% anchor-title fuzzy, 14% by the sender's domain in the window); the 80 unmatched are mostly Rishad/Mike Fisher posts whose email anchor is an image or a one-word title.
+
+Regenerate: `python -m newsletter.triage.history --no-gmail --reextract --no-resolve` (cached HTML, no network) then `python -m newsletter.triage.criteria`.
+
+## 1. Shape of an edition (hard)
+
+| Rule | Measured |
+|---|---|
+| 8 articles per topic, 24 per edition | 8/8/8 in 51 of 54 complete editions; 25 four times (one article with no topic), 23 once |
+| exactly one ⭐ per topic | 3 stars in 51/54 editions (2 twice, 1 once) |
+| one must-read = first sentence of the edition title | 48 recoverable; topic of the must-read: personal development 29 (60%), leadership 17 (35%), innovation 2 (4%) |
+| the review fills the first future edition with a free slot | at build time N228 already had 12 picks and N229 had 6 — the queue runs 1–2 editions ahead |
+
+## 2. Caps per edition
+
+| Cap | Target | Tolerated | Histogram (56 editions) |
+|---|---:|---:|---|
+| HBR articles | ≤3 | 4 | 3:26 · 2:10 · 4:12 · 1:6 · 0:1 · 5:1 |
+| same author | ≤2 | 3 | 2:32 · 3:14 · 1:5 · 4:3 · 5:2 — the ≥4 tail is org-level "authors" (HBR's `harvardbiz`, McKinsey), not people |
+| same domain | ≤3 | 4 | 3:30 · 4:13 · 2:11 · 5:1 · 1:1 |
+| picks per email | 1 | 2 | one email → one pick is the norm; only the Readwise digest (2.0/email) and HBR daily alerts routinely exceed it |
+
+Owner-stated and confirmed: *no more than two articles from the same person in one edition*, *no more than three from HBR*.
+
+## 3. Sender priors (who gets picked)
+
+Hit-rate = picks per email received. Full ranked table in `criteria.json → sender_priors.ranked`; headline tiers:
+
+- **Near-certain (≥0.9/email):** Readwise weekly digest 2.02 (113 picks / 56 emails — a curated digest of widely-highlighted articles; the single best source), Anne-Laure Le Cunff / Ness Labs 0.96, Tom Geraghty / psychsafety 0.91, Ethan Mollick 0.94, Sheril Mathews 0.92.
+- **Strong (0.5–0.9):** Wes Kao 0.80, Mike Fisher 0.78, Oliver Burkeman 0.77, Rishad Tobaccowala 0.72, Rex Woodbury 0.70, Scott Young 0.65, INSEAD Knowledge 0.65, Jason Cohen 0.60, Kate Sotsenko / TheGoodBusy 0.57, Howard Yu 0.56, Gustavo Razzetti 0.53, Visual IDEAs 0.50.
+- **Volume sources (low per-email, high total):** HBR 0.44 but 151 picks / 345 emails (119 leadership), Sahil Bloom 0.49 (79 picks, the weekly essay), Lenny 0.32 (39 — podcast episodes and product/AI essays), Gorick Ng 0.41, David Epstein 0.47, Cassie Kozyrkov 0.45, IMD 0.33, Superhuman AI-news 0.14 but 51 picks (41 innovation — *one* general-interest item per issue, never the release list), McKinsey 0.16 (27, reports/surveys), Tim Ferriss 0.16, Ben Thompson 0.22, Peter Diamandis 0.16.
+- **Floor (≥20 emails, 0–2 picks in 54 weeks):** Esade Alumni 146, IESE Alumni 84, Designing Your Life 65, Myriam Hadnes 55, James Clear 55 (2), Matthias 45, Khe Hy 33, Explain Ideas Visually 30, Dorie Clark 30, The Generalist 29 (1), Estelle Metayer 24, Magda Teruel 22, Substack system mails. Listed in every report, ranked last, never silently dropped.
+
+Topic mix per sender is stable (e.g. psychsafety → leadership 40/48, Ness Labs → personal development 43/49, Rex Woodbury → innovation 21/21), so the sender is a strong topic prior before reading the article.
+
+## 4. Topic signatures
+
+**Leadership and management** (439 picks) — psychological safety, culture/change, feedback & difficult conversations, trust, meetings/decisions, emotions and humanity at work, power and politics, delegation/accountability. Domains: hbr.org 124, fearlessculture 38, psychsafety 36, mikefisher 27, rishad 17, INSEAD 17, Wes Kao 15, IMD 14. Authors: Razzetti 39, HBR 35+19, Geraghty 33, Fisher 27, Rishad 18, Kao 16.
+
+**Personal development** (442) — attention/focus/busyness, habits & motivation, learning & reading, meaning/optimism/happiness, mental models for oneself, career & identity, writing & thinking. Domains: sahilbloom 77, nesslabs 41, youtube 22 (talks), scotthyoung 22, thegoodbusy 22, rishad 21, hbr 19, davidepstein 16, ryanholiday 8, gorick 10, justinwelsh 7, fs.blog 4. Authors: Bloom 69, Le Cunff 33, Sotsenko 23, Young 22, Rishad 21, Epstein 16, Burkeman 11, Holiday 10.
+
+**Innovation** (432) — AI and the future of work/organisations, agents and what they change, strategy & foresight, founders/product/growth, long-form science interviews, platform economics, charts that capture change. Domains: lennysnewsletter 23, digitalnative 22, mckinsey 19, oneusefulthing 18, mikefisher 17, youtube 17, decision.substack 15, dwarkesh 14, hbr 13, stratechery 13, x.com 12, leanfoundry 12, howardyu 11, metatrends 10. Authors: Woodbury 22, Rachitsky 22, Mollick 20, Fisher 17, McKinsey 16, Kozyrkov 15, Maurya 13, Thompson 12, Patel 11, Yu 11, Diamandis 10, Osmani 10.
+
+Videos/podcasts count (youtube 43, x.com 18 picks); `type` stays `article`.
+
+## 5. News policy (innovation)
+
+Owner rule: *a new model is not relevant; a new capability or a general-interest shift is.* Measured: news-shaped titles (launch/release/announce/model names/funding…) are 3.5% of innovation picks vs 2.3% of all offered links — no over-weighting. The release-shaped picks that exist are essays about the release (Mollick "Sign of the future: GPT-5.5", Thompson "Gemini! At the disco", "Three years from GPT-3 to Gemini 3") or a single primary source per event (Google's Gemini 3 post, Anthropic research posts).
+
+Keep: new capability class explained for a business reader · credible adoption/jobs/economy surveys (McKinsey, Stanford HAI, Gallup, HBS, Microsoft/Glean reports) · first-hand practitioner essays. Drop: funding/valuations/earnings/executive moves · benchmarks, model cards, release notes · vendor product pages · AI-news roundups as a whole (take at most the one general-interest item).
+
+## 6. Exclusions that are not "noise"
+
+Beyond the mechanical noise filter (unsubscribe, share, social, app stores — `newsletter/triage/gmail.py`), these anchors were offered thousands of times and picked zero times: book orders/pre-orders, courses/cohorts/workshops/masterclasses/consultations, sponsor and partner promos, job postings, "continue in the Substack app", RSS/feed links, executive-education programme brochures (IMD programme mails: 0 picks; IMD *insight* articles: 21), alumni bulletins.
+
+## 7. Style and timing
+
+- Titles: evergreen and conceptual — "The X effect", "Why Y", "How to Z", a named paradox/metaphor; avg 6.8 words / 41 chars. Listicles are rare; questions are fine.
+- Email → edition lag: mode 10 / 17 / 20 days (review ~1 week before publication, items land in the first edition with a free slot). Anything dated >21 days before an edition is rare; the backfill pool (`next` checkbox, 28 rows; classics) covers a short topic.
+- Stars concentrate on the strong-tier senders: Fisher 9, Geraghty 8, Bloom 7, Le Cunff 6, Woodbury 6, HBR 5+14 by domain, Yu 5, Mollick 5, Sotsenko 5. Must-reads by author: Geraghty 4, Le Cunff 4, Bloom 3, Burkeman 3, Sotsenko 3.
+
+## 8. What the ranker should therefore do (Step 2)
+
+1. Score = sender prior × topic fit × title/content quality, with the news policy and exclusions as vetoes.
+2. Fill 8 per topic from the candidates, enforcing HBR ≤3 (4 only if the 4th is clearly stronger than the next non-HBR), same person ≤2, same domain ≤3, one pick per email unless Readwise/HBR.
+3. Suggest ⭐ per topic and a must-read from the top of personal development or leadership (innovation only with a reason) — flagged as suggestions.
+4. Report every email and every link with its verdict and reason; floor senders included; unknown states (unfetchable, unscorable) kept distinct from "skipped".
+
+## Known limits of the dataset
+
+- Author caps are measured on Notion's `author or source`, which is sometimes an organisation (`harvardbiz`, McKinsey) or `(not classified)` (64 picks) — the person-level cap is slightly stricter than the histogram suggests.
+- 6% of picks are matched to a sender by domain only (anchor ≠ title); per-sender hit-rates for Rishad, Mike Fisher, Gorick, Susan David, Justin Welsh, Marketoonist are therefore lower bounds by 1–9 picks.
+- The negative set is "offered and not picked in that window"; an article offered twice and picked once counts once.

--- a/docs/newsletter-triage-criteria.md
+++ b/docs/newsletter-triage-criteria.md
@@ -63,7 +63,14 @@ Beyond the mechanical noise filter (unsubscribe, share, social, app stores — `
 - Email → edition lag: mode 10 / 17 / 20 days (review ~1 week before publication, items land in the first edition with a free slot). Anything dated >21 days before an edition is rare; the backfill pool (`next` checkbox, 28 rows; classics) covers a short topic.
 - Stars concentrate on the strong-tier senders: Fisher 9, Geraghty 8, Bloom 7, Le Cunff 6, Woodbury 6, HBR 5+14 by domain, Yu 5, Mollick 5, Sotsenko 5. Must-reads by author: Geraghty 4, Le Cunff 4, Bloom 3, Burkeman 3, Sotsenko 3.
 
-## 8. What the ranker should therefore do (Step 2)
+## 8. Owner rules added at review (2026-08-21)
+
+- **No paywalled content, ever.** A paywalled pick is promotion, not content for the reader. Hard walls (Substack "for paid subscribers", subscribe-to-read) are excluded; metered/registration walls like HBR's are accessible and stay in. **Fearless Culture (Gustavo Razzetti) went paywalled in 2026 and is excluded from now on** — its 40 historical picks stay in the dataset as history, the sender is `tier: never` in `newsletter/triage/overrides.json` and its domain was dropped from the leadership signature list. The Step-2 engine detects paywall markers on fetch and reports them as their own state.
+- **One window → one edition.** A run covers the review window (last watermark → now, normally Saturday → Friday) and fills *one* edition (8/8/8) for the next Saturday, keeping the queue one edition ahead. A backlog of N weeks is processed as N windows → N editions, oldest first — never drained into one edition.
+- **Feedback loop.** The report is the review surface: tick = yes, untick = no. Ingesting the reviewed report updates sender tiers/weights in `overrides.json` and logs each decision to `results/newsletter/triage/feedback.jsonl`; the weekly Notion re-sync (`history.py`) refreshes the data priors, so the next run uses classification + criteria.
+- **New senders.** A sender with no history is flagged NEW, scored on content + criteria only, and listed for a manual tier decision (`always|usually|rarely|never|review`) that persists in `overrides.json`.
+
+## 9. What the ranker should therefore do (Step 2)
 
 1. Score = sender prior × topic fit × title/content quality, with the news policy and exclusions as vetoes.
 2. Fill 8 per topic from the candidates, enforcing HBR ≤3 (4 only if the 4th is clearly stronger than the next non-HBR), same person ≤2, same domain ≤3, one pick per email unless Readwise/HBR.

--- a/gmail_readonly/__init__.py
+++ b/gmail_readonly/__init__.py
@@ -1,0 +1,39 @@
+"""Portable, read-only Gmail OAuth and search component."""
+
+from gmail_readonly.core import (
+    GMAIL_READONLY_SCOPE,
+    DiscoveredSender,
+    GmailLabel,
+    GmailMailbox,
+    GmailProfile,
+    GmailReadClient,
+    GmailReadError,
+    GmailSearch,
+    GmailSender,
+    GmailSource,
+    NormalizedEmail,
+    masked_email_address,
+)
+from gmail_readonly.google_client import (
+    GoogleGmailReadClient,
+    build_google_read_client,
+    write_token_atomically,
+)
+
+__all__ = [
+    "GMAIL_READONLY_SCOPE",
+    "DiscoveredSender",
+    "GmailLabel",
+    "GmailMailbox",
+    "GmailProfile",
+    "GmailReadClient",
+    "GmailReadError",
+    "GmailSearch",
+    "GmailSender",
+    "GmailSource",
+    "GoogleGmailReadClient",
+    "NormalizedEmail",
+    "build_google_read_client",
+    "masked_email_address",
+    "write_token_atomically",
+]

--- a/gmail_readonly/core.py
+++ b/gmail_readonly/core.py
@@ -1,0 +1,495 @@
+"""Framework-neutral Gmail whitelist, search, and message normalization."""
+
+from __future__ import annotations
+
+import base64
+import html
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.utils import parseaddr, parsedate_to_datetime
+from html.parser import HTMLParser
+from typing import Any, Protocol
+
+GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
+_SELECTED_HEADERS = (
+    "message-id",
+    "in-reply-to",
+    "references",
+    "from",
+    "to",
+    "subject",
+    "date",
+)
+
+
+@dataclass(frozen=True)
+class GmailSender:
+    """One allowed sender and the name callers show for it."""
+
+    address: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class GmailLabel:
+    """One allowed Gmail label and the name callers show for it."""
+
+    name: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class GmailSearch:
+    """One read-only Gmail search with optional server-side constraints."""
+
+    query: str = ""
+    label_ids: tuple[str, ...] = ()
+    lookback_days: int | None = None
+
+    def api_query(self) -> str:
+        """Return the Gmail query string after validating caller input."""
+        query = self.query.strip()
+        if any(character in query for character in ("\x00", "\r", "\n")):
+            raise ValueError("Gmail query must be a single line without NUL bytes")
+        if self.lookback_days is not None:
+            if self.lookback_days < 1:
+                raise ValueError("lookback_days must be at least 1")
+            query = " ".join(part for part in (query, f"newer_than:{self.lookback_days}d") if part)
+        return query or "in:anywhere"
+
+
+@dataclass(frozen=True)
+class GmailSource:
+    """Resolved whitelist entry with a stable id and precedence-safe search."""
+
+    source_id: str
+    display_name: str
+    search: GmailSearch
+
+
+@dataclass(frozen=True)
+class DiscoveredSender:
+    """A distinct sender seen while scanning a recent time window (#166).
+
+    Produced by :meth:`GmailMailbox.discover_senders` from message metadata only —
+    never full bodies. ``address`` is lowercased for stable identity; ``display_name``
+    is the friendliest ``From`` name seen (falling back to the address).
+    """
+
+    address: str
+    display_name: str
+    last_timestamp: str
+    message_count: int
+
+
+@dataclass(frozen=True)
+class GmailProfile:
+    """Safe mailbox identity and aggregate counts returned by Gmail."""
+
+    email_address: str
+    messages_total: int | None = None
+    threads_total: int | None = None
+
+    @property
+    def masked_email_address(self) -> str:
+        """Return an operator-friendly identity without exposing the full address."""
+        return masked_email_address(self.email_address)
+
+
+@dataclass(frozen=True)
+class NormalizedEmail:
+    """Provider-neutral email record produced from a Gmail API message."""
+
+    message_id: str
+    thread_id: str | None
+    timestamp: str
+    subject: str | None
+    body_text: str | None
+    sender_name: str | None
+    sender_address: str | None
+    headers: dict[str, str] = field(default_factory=dict)
+    label_ids: tuple[str, ...] = ()
+
+    @property
+    def text(self) -> str | None:
+        """Return the subject/body form used by text-classification callers."""
+        parts = (
+            f"Subject: {self.subject}" if self.subject else "",
+            self.body_text or "",
+        )
+        value = "\n\n".join(part for part in parts if part)
+        return value or None
+
+
+class GmailReadError(RuntimeError):
+    """A privacy-safe Gmail failure suitable for logs and status surfaces."""
+
+
+class GmailReadClient(Protocol):
+    """Minimal Gmail read surface; implementations must expose no writes."""
+
+    def get_profile(self) -> dict[str, Any]: ...
+
+    def list_labels(self) -> list[dict[str, Any]]: ...
+
+    def list_message_ids(
+        self,
+        *,
+        query: str,
+        label_ids: list[str] | None = None,
+    ) -> list[str]: ...
+
+    def get_message(
+        self,
+        message_id: str,
+        *,
+        metadata_only: bool = False,
+    ) -> dict[str, Any]: ...
+
+    def close(self) -> None: ...
+
+
+class GmailMailbox:
+    """Reusable whitelist and search facade over a narrow Gmail client."""
+
+    def __init__(self, client: GmailReadClient) -> None:
+        self._client = client
+
+    def profile(self) -> GmailProfile:
+        """Return mailbox identity and aggregate counts."""
+        try:
+            raw = self._client.get_profile()
+            return GmailProfile(
+                email_address=str(raw.get("emailAddress") or ""),
+                messages_total=_optional_int(raw.get("messagesTotal")),
+                threads_total=_optional_int(raw.get("threadsTotal")),
+            )
+        except Exception as exc:
+            raise GmailReadError(_safe_error_detail(exc)) from exc
+
+    def resolve_sources(
+        self,
+        *,
+        senders: tuple[GmailSender, ...] = (),
+        labels: tuple[GmailLabel, ...] = (),
+        lookback_days: int | None = None,
+    ) -> tuple[GmailSource, ...]:
+        """Validate and resolve whitelist entries with deterministic ownership."""
+        sender_addresses = tuple(item.address.strip().lower() for item in senders)
+        label_names = tuple(item.name.strip() for item in labels)
+        if not senders and not labels:
+            raise ValueError("whitelist is empty; configure at least one sender or label")
+        if any(not address for address in sender_addresses):
+            raise ValueError("sender whitelist contains an empty address")
+        if len(set(sender_addresses)) != len(sender_addresses):
+            raise ValueError("duplicate sender whitelist entry")
+        if any(not name for name in label_names):
+            raise ValueError("label whitelist contains an empty name")
+        if len(set(label_names)) != len(label_names):
+            raise ValueError("duplicate label whitelist entry")
+
+        try:
+            available = {
+                str(label.get("name")): str(label.get("id"))
+                for label in self._client.list_labels()
+                if label.get("name") and label.get("id")
+            }
+        except Exception as exc:
+            raise GmailReadError(_safe_error_detail(exc)) from exc
+        missing = [name for name in label_names if name not in available]
+        if missing:
+            raise ValueError(f"{len(missing)} configured Gmail label(s) were not found")
+
+        sources = [
+            GmailSource(
+                source_id=f"sender:{address}",
+                display_name=sender.display_name,
+                search=GmailSearch(
+                    query=f"from:{_escape_query(address)}",
+                    lookback_days=lookback_days,
+                ),
+            )
+            for sender, address in zip(senders, sender_addresses, strict=True)
+        ]
+        for index, label in enumerate(labels):
+            exclusions = [
+                *(f"-from:{_escape_query(address)}" for address in sender_addresses),
+                *(f'-label:"{_escape_query(name)}"' for name in label_names[:index]),
+            ]
+            label_id = available[label_names[index]]
+            sources.append(
+                GmailSource(
+                    source_id=f"label:{label_id}",
+                    display_name=label.display_name,
+                    search=GmailSearch(
+                        query=" ".join(exclusions),
+                        label_ids=(label_id,),
+                        lookback_days=lookback_days,
+                    ),
+                )
+            )
+        return tuple(sources)
+
+    def discover_senders(
+        self, *, days: int, limit: int
+    ) -> tuple[DiscoveredSender, ...]:
+        """Distinct senders active in the last ``days``, from metadata only (#166).
+
+        Scans at most ``limit`` recent messages (the mailbox is huge — this hard cap
+        bounds the metadata reads), groups them by lowercased ``From`` address, and
+        returns one :class:`DiscoveredSender` per address with its friendliest name,
+        latest send time, and how many of the scanned messages it accounts for.
+        Sorted most-recent first. Never downloads message bodies or attachments.
+        """
+        if days < 1:
+            raise ValueError("days must be at least 1")
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        metadata = self.metadata(GmailSearch(lookback_days=days), limit=limit)
+        by_address: dict[str, DiscoveredSender] = {}
+        for email in metadata:
+            address = (email.sender_address or "").strip().lower()
+            if not address:
+                continue
+            name = (email.sender_name or "").strip() or address
+            existing = by_address.get(address)
+            if existing is None:
+                by_address[address] = DiscoveredSender(
+                    address=address,
+                    display_name=name,
+                    last_timestamp=email.timestamp,
+                    message_count=1,
+                )
+            else:
+                # Keep the latest timestamp and a non-address display name if we find one.
+                display_name = (
+                    name if existing.display_name == address and name != address
+                    else existing.display_name
+                )
+                last_timestamp = max(existing.last_timestamp, email.timestamp)
+                by_address[address] = DiscoveredSender(
+                    address=address,
+                    display_name=display_name,
+                    last_timestamp=last_timestamp,
+                    message_count=existing.message_count + 1,
+                )
+        return tuple(
+            sorted(
+                by_address.values(),
+                key=lambda sender: (sender.last_timestamp, sender.address),
+                reverse=True,
+            )
+        )
+
+    def count(self, search: GmailSearch) -> int:
+        """Count matching messages without retrieving metadata or content."""
+        return len(self._message_ids(search))
+
+    def metadata(
+        self, search: GmailSearch, *, limit: int | None = None
+    ) -> list[NormalizedEmail]:
+        """Retrieve only selected headers and identifiers for matching messages."""
+        return self._retrieve(search, metadata_only=True, limit=limit)
+
+    def messages(
+        self, search: GmailSearch, *, limit: int | None = None
+    ) -> list[NormalizedEmail]:
+        """Retrieve and normalize matching messages, sorted oldest first."""
+        return self._retrieve(search, metadata_only=False, limit=limit)
+
+    def search_ids(self, search: GmailSearch) -> list[str]:
+        """Matching message ids only — the cheap first half of an incremental read.
+
+        Callers that already hold some messages can diff these ids against their
+        store and download full content for the genuinely new ones via
+        :meth:`messages_by_ids` (#180), instead of re-fetching every body.
+        """
+        return self._message_ids(search)
+
+    def messages_by_ids(self, message_ids: list[str]) -> list[NormalizedEmail]:
+        """Retrieve and normalize exactly these messages, sorted oldest first."""
+        try:
+            messages = [
+                normalize_message(raw)
+                for raw in self._get_many(list(message_ids), metadata_only=False)
+            ]
+        except GmailReadError:
+            raise
+        except Exception as exc:
+            raise GmailReadError(_safe_error_detail(exc)) from exc
+        messages.sort(key=lambda message: (message.timestamp, message.message_id))
+        return messages
+
+    def close(self) -> None:
+        """Release the underlying HTTP transport."""
+        self._client.close()
+
+    def _message_ids(self, search: GmailSearch) -> list[str]:
+        try:
+            return self._client.list_message_ids(
+                query=search.api_query(),
+                label_ids=list(search.label_ids) or None,
+            )
+        except Exception as exc:
+            raise GmailReadError(_safe_error_detail(exc)) from exc
+
+    def _retrieve(
+        self,
+        search: GmailSearch,
+        *,
+        metadata_only: bool,
+        limit: int | None,
+    ) -> list[NormalizedEmail]:
+        if limit is not None and limit < 1:
+            raise ValueError("limit must be at least 1")
+        try:
+            message_ids = self._message_ids(search)
+            if limit is not None:
+                message_ids = message_ids[:limit]
+            messages = [
+                normalize_message(raw)
+                for raw in self._get_many(message_ids, metadata_only=metadata_only)
+            ]
+        except GmailReadError:
+            raise
+        except Exception as exc:
+            raise GmailReadError(_safe_error_detail(exc)) from exc
+        messages.sort(key=lambda message: (message.timestamp, message.message_id))
+        return messages
+
+    def _get_many(
+        self, message_ids: list[str], *, metadata_only: bool
+    ) -> list[dict[str, Any]]:
+        """Fetch raw messages, batched when the client supports it.
+
+        ``get_messages`` is an optional acceleration, not part of the minimal
+        :class:`GmailReadClient` protocol — portable implementations and test
+        fakes stay one-method simple, while the official adapter collapses a
+        window of sequential GETs into a few batch round-trips (#180).
+        """
+        bulk = getattr(self._client, "get_messages", None)
+        if callable(bulk):
+            result: list[dict[str, Any]] = bulk(message_ids, metadata_only=metadata_only)
+            return result
+        return [
+            self._client.get_message(message_id, metadata_only=metadata_only)
+            for message_id in message_ids
+        ]
+
+
+def normalize_message(raw: dict[str, Any]) -> NormalizedEmail:
+    """Normalize one Gmail API message without downloading attachments."""
+    message_id = str(raw.get("id") or "")
+    if not message_id:
+        raise ValueError("Gmail message has no id")
+    payload = raw.get("payload") or {}
+    headers = {
+        str(item.get("name", "")).lower(): str(item.get("value", ""))
+        for item in payload.get("headers") or []
+        if item.get("name")
+    }
+    sender_name, sender_address = parseaddr(headers.get("from", ""))
+    selected_headers = {key: headers[key] for key in _SELECTED_HEADERS if headers.get(key)}
+    return NormalizedEmail(
+        message_id=message_id,
+        thread_id=str(raw["threadId"]) if raw.get("threadId") else None,
+        timestamp=_message_timestamp(raw, headers),
+        subject=headers.get("subject", "").strip() or None,
+        body_text=_message_body(payload) or None,
+        sender_name=sender_name or None,
+        sender_address=sender_address or None,
+        headers=selected_headers,
+        label_ids=tuple(str(item) for item in raw.get("labelIds") or []),
+    )
+
+
+def masked_email_address(address: str) -> str:
+    """Mask a mailbox address while leaving enough identity for an operator."""
+    local, separator, domain = address.strip().partition("@")
+    if not separator:
+        return "***"
+    visible = local[:1]
+    return f"{visible}***@{domain}" if domain else "***"
+
+
+def _safe_error_detail(exc: Exception) -> str:
+    if isinstance(exc, TimeoutError):
+        # Distinct from a generic failure: the transport-level timeout replaced
+        # what used to be an unbounded hang (#180).
+        return "Gmail API request timed out — network stalled or Google unreachable"
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    if status == 401:
+        return "OAuth token is invalid or expired"
+    if status == 403:
+        return "Gmail API permission or quota denied"
+    if status == 429:
+        return "Gmail API quota exceeded"
+    if isinstance(exc, FileNotFoundError):
+        return str(exc)
+    return f"Gmail API request failed ({type(exc).__name__})"
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
+def _escape_query(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _decode_body(data: str) -> str:
+    if not data:
+        return ""
+    padded = data + "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(padded).decode("utf-8", errors="replace")
+
+
+def _message_body(payload: dict[str, Any]) -> str:
+    plain: list[str] = []
+    rich: list[str] = []
+
+    def walk(part: dict[str, Any]) -> None:
+        if part.get("filename"):
+            return
+        mime_type = str(part.get("mimeType") or "").lower()
+        data = str((part.get("body") or {}).get("data") or "")
+        if mime_type == "text/plain" and data:
+            plain.append(_decode_body(data).strip())
+        elif mime_type == "text/html" and data:
+            rich.append(_html_to_text(_decode_body(data)).strip())
+        for child in part.get("parts") or []:
+            walk(child)
+
+    walk(payload)
+    return "\n\n".join(part for part in (plain or rich) if part).strip()
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:
+        value = data.strip()
+        if value:
+            self.parts.append(value)
+
+
+def _html_to_text(value: str) -> str:
+    parser = _TextExtractor()
+    parser.feed(html.unescape(value))
+    return re.sub(r"\s+([.,;:!?])", r"\1", " ".join(parser.parts))
+
+
+def _message_timestamp(raw: dict[str, Any], headers: dict[str, str]) -> str:
+    internal_date = raw.get("internalDate")
+    if internal_date is not None:
+        return datetime.fromtimestamp(int(internal_date) / 1000, tz=UTC).isoformat()
+    date_header = headers.get("date")
+    if date_header:
+        parsed = parsedate_to_datetime(date_header)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC).isoformat()
+    raise ValueError("Gmail message has no timestamp")

--- a/gmail_readonly/google_client.py
+++ b/gmail_readonly/google_client.py
@@ -1,0 +1,225 @@
+"""Official Google API adapter for the portable read-only Gmail core."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from google_oauth_common.credentials import load_or_refresh_credentials
+from google_oauth_common.token_store import write_token_atomically as write_token_atomically
+
+from gmail_readonly.core import GMAIL_READONLY_SCOPE, GmailReadClient
+
+CredentialLoader = Callable[[str, list[str]], Any]
+RequestFactory = Callable[[], Any]
+ServiceBuilder = Callable[..., Any]
+
+# Gmail's batch endpoint accepts up to 100 calls; Google recommends staying ≤50.
+_BATCH_SIZE = 50
+
+# Gmail's per-user rate budget is ~250 quota units/second and a message GET costs
+# 5 units, so one 50-GET batch consumes a full second of budget. Firing batches
+# back-to-back trips the limiter mid-window (observed live while building #180),
+# hence one pause between batches and bounded backoff for items that still 429.
+_BATCH_PAUSE_S = 1.0
+_RETRY_ATTEMPTS = 3
+_RETRYABLE_STATUSES = frozenset({429, 500, 503})
+
+# httplib2's default is no timeout at all — a dropped connection would block a
+# sync forever (#180). Every request made through this adapter gets this bound.
+DEFAULT_REQUEST_TIMEOUT_S = 60
+
+
+class GoogleGmailReadClient:
+    """Narrow adapter over the official Gmail discovery client."""
+
+    def __init__(self, service: Any) -> None:
+        self._service = service
+
+    def get_profile(self) -> dict[str, Any]:
+        response: dict[str, Any] = self._service.users().getProfile(userId="me").execute()
+        return response
+
+    def list_labels(self) -> list[dict[str, Any]]:
+        response = self._service.users().labels().list(userId="me").execute()
+        return list(response.get("labels") or [])
+
+    def list_message_ids(
+        self,
+        *,
+        query: str,
+        label_ids: list[str] | None = None,
+    ) -> list[str]:
+        message_ids: list[str] = []
+        page_token: str | None = None
+        while True:
+            kwargs: dict[str, Any] = {
+                "userId": "me",
+                "q": query,
+                "maxResults": 500,
+                "includeSpamTrash": False,
+            }
+            if label_ids:
+                kwargs["labelIds"] = label_ids
+            if page_token:
+                kwargs["pageToken"] = page_token
+            response = self._service.users().messages().list(**kwargs).execute()
+            message_ids.extend(
+                str(message["id"])
+                for message in response.get("messages") or []
+                if message.get("id")
+            )
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                return message_ids
+
+    def get_message(
+        self,
+        message_id: str,
+        *,
+        metadata_only: bool = False,
+    ) -> dict[str, Any]:
+        response: dict[str, Any] = self._get_request(message_id, metadata_only).execute()
+        return response
+
+    def get_messages(
+        self,
+        message_ids: list[str],
+        *,
+        metadata_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Fetch many messages via the API batch endpoint (≤50 per round-trip).
+
+        Sequential per-message GETs are latency-dominated — a 30-day window costs
+        hundreds of round-trips (#180); batching collapses that to a handful.
+        Batches are paced against the per-user rate budget and rate-limited items
+        retry with exponential backoff; results come back in ``message_ids``
+        order, and the first non-retryable (or retry-exhausted) failure aborts
+        the whole read so callers never advance on a partial window.
+        """
+        collected: dict[str, dict[str, Any]] = {}
+        for start in range(0, len(message_ids), _BATCH_SIZE):
+            if start:
+                time.sleep(_BATCH_PAUSE_S)
+            self._execute_batch(
+                message_ids[start : start + _BATCH_SIZE], metadata_only, collected
+            )
+        return [collected[mid] for mid in message_ids if mid in collected]
+
+    def _execute_batch(
+        self,
+        chunk: list[str],
+        metadata_only: bool,
+        collected: dict[str, dict[str, Any]],
+    ) -> None:
+        remaining = list(chunk)
+        for attempt in range(_RETRY_ATTEMPTS + 1):
+            failures = self._attempt_batch(remaining, metadata_only, collected)
+            if not failures:
+                return
+            fatal = [exc for _, exc in failures if not _is_retryable(exc)]
+            if fatal or attempt == _RETRY_ATTEMPTS:
+                raise (fatal or [failures[0][1]])[0]
+            remaining = [message_id for message_id, _ in failures]
+            time.sleep(2**attempt)
+
+    def _attempt_batch(
+        self,
+        message_ids: list[str],
+        metadata_only: bool,
+        collected: dict[str, dict[str, Any]],
+    ) -> list[tuple[str, Exception]]:
+        failures: list[tuple[str, Exception]] = []
+
+        def _collect(request_id: str, response: Any, exception: Exception | None) -> None:
+            if exception is not None:
+                failures.append((request_id, exception))
+            elif response is not None:
+                collected[request_id] = response
+
+        batch = self._service.new_batch_http_request(callback=_collect)
+        for message_id in message_ids:
+            batch.add(
+                self._get_request(message_id, metadata_only),
+                request_id=message_id,
+            )
+        batch.execute()
+        return failures
+
+    def _get_request(self, message_id: str, metadata_only: bool) -> Any:
+        kwargs: dict[str, Any] = {
+            "userId": "me",
+            "id": message_id,
+            "format": "metadata" if metadata_only else "full",
+        }
+        if metadata_only:
+            kwargs["metadataHeaders"] = [
+                "Message-ID",
+                "In-Reply-To",
+                "References",
+                "From",
+                "To",
+                "Subject",
+                "Date",
+            ]
+        return self._service.users().messages().get(**kwargs)
+
+    def close(self) -> None:
+        http = getattr(self._service, "_http", None)
+        close = getattr(http, "close", None)
+        if callable(close):
+            close()
+
+
+def build_google_read_client(
+    token_path: Path,
+    *,
+    credential_loader: CredentialLoader | None = None,
+    request_factory: RequestFactory | None = None,
+    service_builder: ServiceBuilder | None = None,
+    request_timeout_s: int = DEFAULT_REQUEST_TIMEOUT_S,
+) -> GmailReadClient:
+    """Load/refresh an OAuth token and build the official read-only client."""
+    credentials = load_or_refresh_credentials(
+        token_path,
+        GMAIL_READONLY_SCOPE,
+        missing_token_message="Gmail OAuth token missing; run the OAuth bootstrap interactively",
+        invalid_token_message="Gmail OAuth token is invalid or has been revoked",
+        token_writer=write_token_atomically,
+        credential_loader=credential_loader,
+        request_factory=request_factory,
+    )
+
+    injected_builder = service_builder is not None
+    if service_builder is None:
+        from googleapiclient.discovery import build
+
+        service_builder = build
+
+    if injected_builder:
+        # Test seam: injected builders receive the legacy credentials kwarg and
+        # own their transport entirely.
+        service = service_builder(
+            "gmail",
+            "v1",
+            credentials=credentials,
+            cache_discovery=False,
+        )
+    else:
+        import httplib2  # type: ignore[import-untyped]
+        from google_auth_httplib2 import AuthorizedHttp  # type: ignore[import-untyped]
+
+        service = service_builder(
+            "gmail",
+            "v1",
+            http=AuthorizedHttp(credentials, http=httplib2.Http(timeout=request_timeout_s)),
+            cache_discovery=False,
+        )
+    return GoogleGmailReadClient(service)
+
+
+def _is_retryable(exc: Exception) -> bool:
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    return status in _RETRYABLE_STATUSES or isinstance(exc, TimeoutError)

--- a/gmail_readonly/oauth.py
+++ b/gmail_readonly/oauth.py
@@ -1,0 +1,53 @@
+"""Standalone installed-app OAuth bootstrap for the read-only Gmail scope."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+from google_oauth_common.bootstrap import FlowLoader, authorize_installed_app, run_bootstrap_cli
+from google_oauth_common.token_store import write_token_atomically
+
+from gmail_readonly.core import GMAIL_READONLY_SCOPE
+
+logger = logging.getLogger(__name__)
+
+
+def authorize(
+    *,
+    credentials_path: Path,
+    token_path: Path,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    open_browser: bool = True,
+    flow_loader: FlowLoader | None = None,
+) -> None:
+    """Run consent using explicit paths and persist the resulting refresh token."""
+    authorize_installed_app(
+        credentials_path=credentials_path,
+        token_path=token_path,
+        scope=GMAIL_READONLY_SCOPE,
+        not_found_label="Gmail",
+        token_writer=write_token_atomically,
+        host=host,
+        port=port,
+        open_browser=open_browser,
+        flow_loader=flow_loader,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the standalone explicit-path OAuth command."""
+    return run_bootstrap_cli(
+        argv,
+        description=__doc__,
+        opening_message="Opening Google consent for read-only Gmail access.",
+        success_label="Gmail read-only",
+        logger=logger,
+        authorize_fn=authorize,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/google_oauth_common/__init__.py
+++ b/google_oauth_common/__init__.py
@@ -1,0 +1,15 @@
+"""Shared installed-app OAuth bootstrap for the fleet's portable Google packages.
+
+``gmail_readonly/``, ``calendar_readonly/``, and ``calendar_write/`` each mint
+their own independent OAuth grant — separate credential/scope boundaries, no
+shared state at runtime — but they run the identical installed-app consent
+flow, explicit-path CLI shape, and token load/refresh/persist routine. This
+package holds that shared shape so it exists once instead of three times.
+
+Like its three siblings it has no imports from ``src``, ``app``, or
+``scripts``, so it is itself portable: a consumer lifting one of the other
+three packages into another repo copies this package alongside it. See
+``docs/gmail-reuse.md`` for the copy list.
+"""
+
+from __future__ import annotations

--- a/google_oauth_common/bootstrap.py
+++ b/google_oauth_common/bootstrap.py
@@ -1,0 +1,85 @@
+"""Shared installed-app OAuth consent flow and CLI skeleton.
+
+Parametrized so each portable package's own ``oauth.py`` stays a thin wrapper
+(scope, error-message labels, and log strings) around one real implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+FlowLoader = Callable[[str, list[str]], Any]
+TokenWriter = Callable[[Path, str], None]
+
+
+def authorize_installed_app(
+    *,
+    credentials_path: Path,
+    token_path: Path,
+    scope: str,
+    not_found_label: str,
+    token_writer: TokenWriter,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    open_browser: bool = True,
+    flow_loader: FlowLoader | None = None,
+) -> None:
+    """Run consent using explicit paths and persist the resulting refresh token."""
+    if not credentials_path.is_file():
+        raise FileNotFoundError(
+            f"{not_found_label} OAuth client file not found: {credentials_path}"
+        )
+    if flow_loader is None:
+        from google_auth_oauthlib.flow import InstalledAppFlow
+
+        flow_loader = InstalledAppFlow.from_client_secrets_file
+    flow = flow_loader(str(credentials_path), [scope])
+    credentials = flow.run_local_server(
+        host=host,
+        port=port,
+        access_type="offline",
+        prompt="consent",
+        open_browser=open_browser,
+    )
+    if not credentials.refresh_token:
+        raise RuntimeError("Google returned no refresh token; revoke the old grant and retry")
+    token_writer(token_path, credentials.to_json())
+
+
+def run_bootstrap_cli(
+    argv: list[str] | None,
+    *,
+    description: str | None,
+    opening_message: str,
+    success_label: str,
+    logger: logging.Logger,
+    authorize_fn: Callable[..., None],
+) -> int:
+    """Shared explicit-path CLI skeleton: parse args, run consent, report the result."""
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--credentials", required=True, type=Path)
+    parser.add_argument("--token", required=True, type=Path)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=0, type=int)
+    parser.add_argument("--no-browser", action="store_true")
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    try:
+        logger.info("ℹ️ %s", opening_message)
+        authorize_fn(
+            credentials_path=args.credentials,
+            token_path=args.token,
+            host=args.host,
+            port=args.port,
+            open_browser=not args.no_browser,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        logger.error("❌ %s", exc)
+        return 1
+    logger.info("✅ %s token stored at %s", success_label, args.token)
+    logger.info("ℹ️ Never copy the token into config, documentation, or logs.")
+    return 0

--- a/google_oauth_common/credentials.py
+++ b/google_oauth_common/credentials.py
@@ -1,0 +1,47 @@
+"""Shared OAuth token load/refresh/validate step for the portable Google packages."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+CredentialLoader = Callable[[str, list[str]], Any]
+RequestFactory = Callable[[], Any]
+TokenWriter = Callable[[Path, str], None]
+
+
+def load_or_refresh_credentials(
+    token_path: Path,
+    scope: str,
+    *,
+    missing_token_message: str,
+    invalid_token_message: str,
+    token_writer: TokenWriter,
+    credential_loader: CredentialLoader | None = None,
+    request_factory: RequestFactory | None = None,
+) -> Any:
+    """Load a persisted OAuth token, refresh it if expired, and validate it.
+
+    Returns the (possibly refreshed) ``google.oauth2.credentials.Credentials``
+    instance. Building the API service from it stays with each caller, since
+    that step differs per package (Gmail injects a bounded-timeout transport;
+    Calendar passes credentials straight through).
+    """
+    if not token_path.is_file():
+        raise FileNotFoundError(missing_token_message)
+
+    if credential_loader is None or request_factory is None:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+
+        credential_loader = credential_loader or Credentials.from_authorized_user_file
+        request_factory = request_factory or Request
+
+    credentials = credential_loader(str(token_path), [scope])
+    if credentials.expired and credentials.refresh_token:
+        credentials.refresh(request_factory())
+        token_writer(token_path, credentials.to_json())
+    if not credentials.valid:
+        raise RuntimeError(invalid_token_message)
+    return credentials

--- a/google_oauth_common/token_store.py
+++ b/google_oauth_common/token_store.py
@@ -1,0 +1,13 @@
+"""Atomic OAuth token persistence shared by the portable Google packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_token_atomically(path: Path, token_json: str) -> None:
+    """Persist an OAuth token atomically without logging its contents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    temporary_path.write_text(token_json, encoding="utf-8")
+    temporary_path.replace(path)

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -227,6 +227,66 @@ byline. The fallback exists so the pipeline never invents people.
 - `normalize_url.py` — URL query-param stripper with preserve list.
 - `build_newsletter.py` — HTML builder + must-read line; writes the `N{NNN}.topics.json` sidecar the app's must-read picker reads.
 - `substack_draft.py` — pushes the same grouped article lists into a private Substack draft edition over the native HTTP API.
+- `triage/gmail.py` — read-only Gmail label ingestion + link extraction / redirect decoding (adapter over the vendored `gmail_readonly/`).
+- `triage/history.py` — 54-week ground-truth dataset (Notion positives ⋈ Gmail offered links) + `stats.md`.
+- `triage/criteria.json` — machine-readable selection criteria (twin of `docs/newsletter-triage-criteria.md`).
+
+## Triage — Gmail history + criteria (issue #210, Step 1/3)
+
+The weekly inbox review (label `newsletters`, ~80 emails/week) is being
+automated in three steps. Step 1 builds the **ground truth** the later ranker
+is scored against, under `newsletter/triage/`:
+
+- `gmail.py` — read-only Gmail adapter over the vendored `gmail_readonly/` +
+  `google_oauth_common/` packages (byte-for-byte from whatsapp-radar — never
+  edit them here; extend in this adapter). Raw MIME walk, `<a href>` extraction,
+  noise filter (unsubscribe / share / social / app-store / …), tracking-redirect
+  decoding: local first (ConvertKit/Kit/HBR base64 path, Substack `redirect/2/`
+  JSON, McKinsey host rewrite, Substack `post_id` dedupe), then a bounded, cached
+  HTTP hop (`results/newsletter/triage/redirects.json`) for opaque redirectors
+  (Substack `redirect/`, beehiiv, SendGrid, Mailchimp, ActiveCampaign, …).
+- `history.py` — pulls the label over N weeks (incremental, HTML cached gzipped
+  under `results/newsletter/triage/history/raw/`), loads the Notion positives
+  (every article with an edition relation: topic, author, star, must-read from
+  the edition title), joins positives → source email (canonical URL → Substack
+  slug → fuzzy anchor-vs-title), and writes `stats.json` + `stats.md` (per-sender
+  hit-rates, per-edition caps observed, topic/star/must-read patterns, lag,
+  unmatched list).
+- `criteria.json` — the machine-readable criteria the Step-2 ranker consumes;
+  the human-readable rationale lives in
+  [`docs/newsletter-triage-criteria.md`](../docs/newsletter-triage-criteria.md).
+
+| Command | What it does |
+|---|---|
+| `python -m newsletter.triage.history` | Full build with `newsletter_triage.history_weeks` (54) and `redirect_budget_history`. |
+| `python -m newsletter.triage.history --no-gmail --reextract --no-resolve` | Re-run extraction + join + stats from the cached HTML after a rule change (no network). |
+| `python -m newsletter.triage.history --limit 150 --budget 100` | Smoke test. |
+
+### Gmail one-time setup
+
+```powershell
+& .\.venv\Scripts\python.exe -m pip install -r requirements.txt   # google-api-python-client, google-auth-*
+```
+
+Copy `credentials.json` + `token.json` from the sibling repo's `auth/gmail/`
+into this repo's gitignored `auth/gmail/` (same OAuth client, own token file
+refreshed independently — the pattern grocery-shopping-automation uses). If the
+token is missing or revoked, re-consent (opens a browser, requests
+`gmail.readonly` only):
+
+```powershell
+& .\.venv\Scripts\python.exe -m gmail_readonly.oauth --credentials auth\gmail\credentials.json --token auth\gmail\token.json
+```
+
+Gotchas: an OAuth app left in *Testing* issues refresh tokens that expire after
+7 days — the client is in production. Refresh tokens also die on grant
+revocation, a Google password change, or 6 months unused; recovery = remove the
+grant at `myaccount.google.com/connections`, delete only `auth/gmail/token.json`,
+re-run the command above. Vendored-package drift check:
+`git diff --no-index -- E:\automation\whatsapp-radar\gmail_readonly gmail_readonly`
+(and the same for `google_oauth_common`) — empty output means byte-identical.
+The portable contract test `tests/test_gmail_readonly.py` is pytest-style
+(`& .\.venv\Scripts\python.exe -m pytest tests\test_gmail_readonly.py`).
 
 ## Substack draft edition
 

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -229,7 +229,8 @@ byline. The fallback exists so the pipeline never invents people.
 - `substack_draft.py` — pushes the same grouped article lists into a private Substack draft edition over the native HTTP API.
 - `triage/gmail.py` — read-only Gmail label ingestion + link extraction / redirect decoding (adapter over the vendored `gmail_readonly/`).
 - `triage/history.py` — 54-week ground-truth dataset (Notion positives ⋈ Gmail offered links) + `stats.md`.
-- `triage/criteria.json` — machine-readable selection criteria (twin of `docs/newsletter-triage-criteria.md`).
+- `triage/criteria.json` — machine-readable selection criteria (twin of `docs/newsletter-triage-criteria.md`), rebuilt by `python -m newsletter.triage.criteria`.
+- `triage/overrides.json` — owner-maintained sender decisions (tier `never|rarely|usually|always|review`, e.g. paywalled publications); applied before the data priors, updated by the feedback loop.
 
 ## Triage — Gmail history + criteria (issue #210, Step 1/3)
 

--- a/newsletter/triage/__init__.py
+++ b/newsletter/triage/__init__.py
@@ -1,0 +1,6 @@
+"""Newsletter triage — Gmail-label ingestion, link extraction, history and criteria.
+
+Adapter layer over the vendored read-only ``gmail_readonly`` component (never
+modify that package — extend here). See ``docs/newsletter-triage-criteria.md``
+and issue #210.
+"""

--- a/newsletter/triage/criteria.json
+++ b/newsletter/triage/criteria.json
@@ -86,7 +86,6 @@
     ],
     "signature_domains": [
      "hbr.org",
-     "think.fearlessculture.design",
      "psychsafety.com",
      "mikefisher.substack.com",
      "rishad.substack.com",
@@ -208,6 +207,36 @@
   "backfill": {
    "next_checkbox_pool": true,
    "classics": true
+  },
+  "paywall": {
+   "rule": "never link paywalled content — a paywalled pick is promotion, not content for the reader",
+   "detect": [
+    "Substack 'This post is for paid subscribers' / paywall block",
+    "hard subscribe-to-read walls",
+    "truncated body with a subscription CTA"
+   ],
+   "metered_is_ok": "HBR-style metered/registration walls are accessible and were picked 151 times — only hard walls are excluded",
+   "known_paywalled_senders": "see overrides.json (tier=never, reason=paywalled) — Fearless Culture since 2026"
+  },
+  "cadence": {
+   "rule": "one run covers one review window (last watermark → now, normally one week) and fills ONE edition (8/8/8); a backlog of N weeks yields N windows and N editions, oldest first — never drain the whole inbox into one edition",
+   "window_anchor": "Saturday edition day: the run on Friday covers last Saturday → today and feeds the next edition, so the queue stays one edition ahead"
+  },
+  "feedback_loop": {
+   "rule": "after the owner reviews a report (tick = yes, untick = no), ingest the decisions: update sender tiers/weights in overrides.json, log every decision to results/newsletter/triage/feedback.jsonl; the weekly Notion re-sync (history.py) refreshes the data priors",
+   "new_senders": "a sender with no history is flagged NEW in the report, scored on content + criteria only, and listed for a manual tier decision (always/usually/rarely/never/review) that persists in overrides.json"
+  }
+ },
+ "sender_overrides": {
+  "gustavorazzetti@substack.com": {
+   "tier": "never",
+   "reason": "paywalled since 2026 — the newsletter never links paywalled content (it would be promotion, not content)",
+   "since": "2026-08-21"
+  },
+  "gustavorazzetti+fearless-culture@substack.com": {
+   "tier": "never",
+   "reason": "paywalled since 2026 — same publication as gustavorazzetti@substack.com",
+   "since": "2026-08-21"
   }
  },
  "sender_priors": {

--- a/newsletter/triage/criteria.json
+++ b/newsletter/triage/criteria.json
@@ -1,0 +1,2239 @@
+{
+ "version": "2026-08-21",
+ "window": {
+  "emails": 4383,
+  "editions": 58,
+  "positives": 1317,
+  "first_email": "2025-08-08",
+  "last_email": "2026-08-21",
+  "match_rate": 0.939
+ },
+ "rules": {
+  "edition": {
+   "per_topic": 8,
+   "stars_per_topic": 1,
+   "must_read": 1,
+   "must_read_topic_prior": {
+    "personal development": 0.6,
+    "leadership and management": 0.35,
+    "innovation": 0.04
+   },
+   "fill_ahead_editions": 2
+  },
+  "caps": {
+   "hbr_per_edition": {
+    "target": 3,
+    "hard": 4,
+    "never_above": 5,
+    "measured_hist": "3:26 · 2:10 · 4:12 · 1:6 · 0:1 · 5:1 (56 editions)"
+   },
+   "same_author_per_edition": {
+    "target": 2,
+    "hard": 3,
+    "measured_hist": "2:32 · 3:14 · 1:5 · 4:3 · 5:2 (org-level authors such as 'harvardbiz'/'McKinsey' inflate the tail)"
+   },
+   "same_domain_per_edition": {
+    "target": 3,
+    "hard": 4,
+    "measured_hist": "3:30 · 4:13 · 2:11 · 5:1 · 1:1"
+   },
+   "same_sender_per_email": {
+    "typical": 1,
+    "note": "one email almost never yields more than 1–2 picks; Readwise/HBR digests are the exception"
+   }
+  },
+  "timing": {
+   "email_to_edition_lag_days_mode": [
+    10,
+    17,
+    20
+   ],
+   "review_window_days": [
+    7,
+    21
+   ],
+   "note": "emails are reviewed ~1 week before an edition and land in the first future edition with a free slot; picks dated >21 days before the edition are rare"
+  },
+  "news_policy": {
+   "rule": "a product/model *release* is not an innovation pick; the pick is the commentary that explains what it changes for work, organisations or society",
+   "measured": "news-like titles are 3.5% of innovation picks vs 2.3% of all offered links — no over-weighting; the few release-shaped picks are essays (Mollick 'Sign of the future: GPT-5.5', Thompson 'Gemini! At the disco') or one primary source per event (Google's Gemini 3 post, Anthropic research posts)",
+   "keep_if": [
+    "new capability class (agents, world models, coding agents) explained for a general business reader",
+    "credible survey / report on AI adoption, jobs, or the economy (McKinsey, Stanford HAI, Gallup, HBS)",
+    "first-hand essay from a practitioner/thinker (Mollick, Kozyrkov, Thompson, Woodbury, Dwarkesh interviews)"
+   ],
+   "drop_if": [
+    "funding rounds, valuations, earnings, executive moves",
+    "benchmark leaderboards, model cards, release notes",
+    "vendor marketing, 'try it now' product pages",
+    "daily AI-news roundups as a whole (pick at most the one general-interest item)"
+   ]
+  },
+  "topics": {
+   "leadership and management": {
+    "themes": [
+     "psychological safety",
+     "culture and change",
+     "feedback and difficult conversations",
+     "trust",
+     "meetings and decision-making",
+     "managers and teams",
+     "emotions at work",
+     "power, politics and influence",
+     "delegation and accountability",
+     "humor and humanity at work",
+     "hiring, performance and careers of others"
+    ],
+    "signature_domains": [
+     "hbr.org",
+     "think.fearlessculture.design",
+     "psychsafety.com",
+     "mikefisher.substack.com",
+     "rishad.substack.com",
+     "knowledge.insead.edu",
+     "newsletter.weskao.com",
+     "imd.org",
+     "library.hbs.edu",
+     "strategy-business.com",
+     "gallup.com",
+     "corporate-rebels.com",
+     "leadingsapiens.com"
+    ],
+    "anti_themes": [
+     "executive-education brochures",
+     "program/course promos",
+     "alumni news"
+    ]
+   },
+   "personal development": {
+    "themes": [
+     "attention, focus and busyness",
+     "habits and motivation",
+     "learning and reading",
+     "meaning, optimism and happiness",
+     "mental models and decision-making for oneself",
+     "career and identity",
+     "energy, sleep, health (when first-hand and practical)",
+     "writing and thinking clearly",
+     "psychology of self (paradoxes, effects, traps)"
+    ],
+    "signature_domains": [
+     "sahilbloom.com",
+     "nesslabs.com",
+     "scotthyoung.com",
+     "thegoodbusy.substack.com",
+     "rishad.substack.com",
+     "davidepstein.substack.com",
+     "ryanholiday.net",
+     "oliverburkeman.com",
+     "gorick.com",
+     "justinwelsh.me",
+     "fs.blog",
+     "vizi.substack.com",
+     "theatlantic.com",
+     "youtube.com"
+    ],
+    "anti_themes": [
+     "supplements, gear and gift guides",
+     "book pre-orders and courses",
+     "generic listicles without an idea"
+    ]
+   },
+   "innovation": {
+    "themes": [
+     "AI and the future of work / organisations",
+     "agents and what they change",
+     "strategy and foresight",
+     "founders, product and growth",
+     "technology essays (what it means, not what shipped)",
+     "science and long-form interviews (Dwarkesh)",
+     "economics of AI and platforms",
+     "charts and reports that capture change"
+    ],
+    "signature_domains": [
+     "lennysnewsletter.com",
+     "digitalnative.tech",
+     "mckinsey.com",
+     "oneusefulthing.org",
+     "mikefisher.substack.com",
+     "decision.substack.com",
+     "dwarkesh.com",
+     "stratechery.com",
+     "hbr.org",
+     "x.com",
+     "leanfoundry.com",
+     "howardyu.substack.com",
+     "metatrends.substack.com",
+     "techcrunch.com",
+     "nfx.com",
+     "longform.asmartbear.com",
+     "thoughtsparks.substack.com",
+     "youtube.com"
+    ],
+    "anti_themes": [
+     "release notes and model cards",
+     "funding/earnings news",
+     "sports/entertainment posts from tech writers",
+     "tool directories and 'product pass' drops"
+    ]
+   }
+  },
+  "content_exclusions": {
+   "anchors": [
+    "order/pre-order/buy the book",
+    "course, cohort, workshop, masterclass, consultation, coaching",
+    "sponsor, partner, promo code, discount",
+    "job posting, hiring",
+    "app download",
+    "podcast player links (apple/spotify/overcast) when the episode page is also linked",
+    "continue in the substack app",
+    "subscribe to rss feed",
+    "view/read online"
+   ],
+   "senders_never_selected_min_emails": 20,
+   "note": "senders with ≥20 emails and 0–1 picks get a near-zero prior; still listed in the report, never silently dropped"
+  },
+  "title_style": {
+   "avg_words": 6.8,
+   "avg_chars": 40.7,
+   "note": "evergreen, conceptual titles — 'The X effect', 'Why Y', 'How to Z', a named paradox or metaphor; sentence case is applied later by normalize_names"
+  },
+  "owner_rules": [
+   "≤2 articles from the same person in one edition (measured mode 2; 3 tolerated, above that only for org-level sources)",
+   "≤3 HBR articles per edition (measured mode 3; 4 in 12 editions, 5 once)",
+   "AI model releases are not innovation picks — new capabilities / general-interest shifts are",
+   "when a topic is short, backfill from the `next` pool or classics not yet published",
+   "one star per topic, the must-read is usually personal development or leadership (innovation 2/48)"
+  ],
+  "backfill": {
+   "next_checkbox_pool": true,
+   "classics": true
+  }
+ },
+ "sender_priors": {
+  "ranked": [
+   {
+    "address": "hello@readwise.io",
+    "name": "Readwise",
+    "emails": 56,
+    "picks": 113,
+    "hit_rate_per_email": 2.02,
+    "hit_rate_per_link": 0.094,
+    "stars": 22,
+    "topics": {
+     "innovation": 54,
+     "personal development": 53,
+     "leadership and management": 6
+    }
+   },
+   {
+    "address": "annelaure@nesslabs.com",
+    "name": "Anne-Laure Le Cunff",
+    "emails": 51,
+    "picks": 49,
+    "hit_rate_per_email": 0.96,
+    "hit_rate_per_link": 0.063,
+    "stars": 8,
+    "topics": {
+     "personal development": 43,
+     "leadership and management": 6
+    }
+   },
+   {
+    "address": "oneusefulthing@substack.com",
+    "name": "Ethan Mollick from One Useful Thing",
+    "emails": 18,
+    "picks": 17,
+    "hit_rate_per_email": 0.94,
+    "hit_rate_per_link": 0.092,
+    "stars": 4,
+    "topics": {
+     "innovation": 16,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "sheril@leadingsapiens.com",
+    "name": "Sheril Mathews",
+    "emails": 12,
+    "picks": 11,
+    "hit_rate_per_email": 0.92,
+    "hit_rate_per_link": 0.087,
+    "stars": 0,
+    "topics": {
+     "leadership and management": 6,
+     "personal development": 5
+    }
+   },
+   {
+    "address": "tom@psychsafety.com",
+    "name": "Tom at psychsafety.com",
+    "emails": 53,
+    "picks": 48,
+    "hit_rate_per_email": 0.91,
+    "hit_rate_per_link": 0.036,
+    "stars": 9,
+    "topics": {
+     "leadership and management": 40,
+     "personal development": 5,
+     "innovation": 3
+    }
+   },
+   {
+    "address": "weskao@substack.com",
+    "name": "Wes Kao's Newsletter",
+    "emails": 25,
+    "picks": 20,
+    "hit_rate_per_email": 0.8,
+    "hit_rate_per_link": 0.068,
+    "stars": 2,
+    "topics": {
+     "leadership and management": 13,
+     "personal development": 7
+    }
+   },
+   {
+    "address": "mikefisher@substack.com",
+    "name": "Fish Food for Thought",
+    "emails": 54,
+    "picks": 42,
+    "hit_rate_per_email": 0.78,
+    "hit_rate_per_link": 0.124,
+    "stars": 8,
+    "topics": {
+     "leadership and management": 24,
+     "innovation": 15,
+     "personal development": 3
+    }
+   },
+   {
+    "address": "oliver@oliverburkeman.com",
+    "name": "Oliver Burkeman",
+    "emails": 13,
+    "picks": 10,
+    "hit_rate_per_email": 0.77,
+    "hit_rate_per_link": 0.208,
+    "stars": 3,
+    "topics": {
+     "personal development": 9,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "rishad@substack.com",
+    "name": "Rishad Tobaccowala from The Future Does Not Fit In The Containers Of The Past",
+    "emails": 54,
+    "picks": 39,
+    "hit_rate_per_email": 0.72,
+    "hit_rate_per_link": 0.135,
+    "stars": 4,
+    "topics": {
+     "leadership and management": 15,
+     "personal development": 14,
+     "innovation": 10
+    }
+   },
+   {
+    "address": "digitalnative@substack.com",
+    "name": "Rex Woodbury",
+    "emails": 30,
+    "picks": 21,
+    "hit_rate_per_email": 0.7,
+    "hit_rate_per_link": 0.045,
+    "stars": 5,
+    "topics": {
+     "innovation": 21
+    }
+   },
+   {
+    "address": "newsletter@scotthyoung.com",
+    "name": "Scott Young",
+    "emails": 49,
+    "picks": 32,
+    "hit_rate_per_email": 0.65,
+    "hit_rate_per_link": 0.066,
+    "stars": 1,
+    "topics": {
+     "personal development": 25,
+     "leadership and management": 4,
+     "innovation": 3
+    }
+   },
+   {
+    "address": "insead.knowledge@insead.edu",
+    "name": "INSEAD Knowledge",
+    "emails": 40,
+    "picks": 26,
+    "hit_rate_per_email": 0.65,
+    "hit_rate_per_link": 0.037,
+    "stars": 0,
+    "topics": {
+     "leadership and management": 18,
+     "innovation": 5,
+     "personal development": 3
+    }
+   },
+   {
+    "address": "jason@asmartbear.com",
+    "name": "Jason Cohen",
+    "emails": 20,
+    "picks": 12,
+    "hit_rate_per_email": 0.6,
+    "hit_rate_per_link": 0.364,
+    "stars": 0,
+    "topics": {
+     "innovation": 8,
+     "personal development": 3,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "thegoodbusy@substack.com",
+    "name": "Kate at TheGoodBusy",
+    "emails": 56,
+    "picks": 32,
+    "hit_rate_per_email": 0.57,
+    "hit_rate_per_link": 0.079,
+    "stars": 4,
+    "topics": {
+     "personal development": 22,
+     "leadership and management": 9,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "howardyu@substack.com",
+    "name": "Howard Yu from One Inch Ahead",
+    "emails": 18,
+    "picks": 10,
+    "hit_rate_per_email": 0.56,
+    "hit_rate_per_link": 0.024,
+    "stars": 4,
+    "topics": {
+     "innovation": 8,
+     "leadership and management": 2
+    }
+   },
+   {
+    "address": "ryan@ryanholiday.net",
+    "name": "Ryan Holiday",
+    "emails": 13,
+    "picks": 7,
+    "hit_rate_per_email": 0.54,
+    "hit_rate_per_link": 0.067,
+    "stars": 1,
+    "topics": {
+     "personal development": 7
+    }
+   },
+   {
+    "address": "gustavorazzetti@substack.com",
+    "name": "Gustavo Razzetti from Fearless Culture",
+    "emails": 55,
+    "picks": 29,
+    "hit_rate_per_email": 0.53,
+    "hit_rate_per_link": 0.037,
+    "stars": 1,
+    "topics": {
+     "leadership and management": 27,
+     "personal development": 2
+    }
+   },
+   {
+    "address": "idea-milanicreative@mail.beehiiv.com",
+    "name": "Visual IDEAs Newsletter",
+    "emails": 20,
+    "picks": 10,
+    "hit_rate_per_email": 0.5,
+    "hit_rate_per_link": 0.03,
+    "stars": 2,
+    "topics": {
+     "leadership and management": 7,
+     "personal development": 3
+    }
+   },
+   {
+    "address": "hosanagar@substack.com",
+    "name": "Kartik Hosanagar from Creative Intelligence | Kartik Hosanagar",
+    "emails": 8,
+    "picks": 4,
+    "hit_rate_per_email": 0.5,
+    "hit_rate_per_link": 0.098,
+    "stars": 1,
+    "topics": {
+     "innovation": 3,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "sahil@sahilbloom.com",
+    "name": "Sahil Bloom's Curiosity Chronicle",
+    "emails": 161,
+    "picks": 79,
+    "hit_rate_per_email": 0.49,
+    "hit_rate_per_link": 0.095,
+    "stars": 7,
+    "topics": {
+     "personal development": 77,
+     "leadership and management": 1,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "davidepstein@substack.com",
+    "name": "David Epstein from Range Widely",
+    "emails": 34,
+    "picks": 16,
+    "hit_rate_per_email": 0.47,
+    "hit_rate_per_link": 0.074,
+    "stars": 4,
+    "topics": {
+     "personal development": 16
+    }
+   },
+   {
+    "address": "susan.david@susandavid.com",
+    "name": "Susan David",
+    "emails": 13,
+    "picks": 6,
+    "hit_rate_per_email": 0.46,
+    "hit_rate_per_link": 0.095,
+    "stars": 0,
+    "topics": {
+     "personal development": 4,
+     "leadership and management": 2
+    }
+   },
+   {
+    "address": "vizi@substack.com",
+    "name": "Vizi Andrei",
+    "emails": 13,
+    "picks": 6,
+    "hit_rate_per_email": 0.46,
+    "hit_rate_per_link": 0.162,
+    "stars": 0,
+    "topics": {
+     "personal development": 6
+    }
+   },
+   {
+    "address": "decision@substack.com",
+    "name": "Cassie Kozyrkov",
+    "emails": 38,
+    "picks": 17,
+    "hit_rate_per_email": 0.45,
+    "hit_rate_per_link": 0.038,
+    "stars": 2,
+    "topics": {
+     "innovation": 14,
+     "leadership and management": 2,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "emailteam@emails.hbr.org",
+    "name": "Harvard Business Review",
+    "emails": 345,
+    "picks": 151,
+    "hit_rate_per_email": 0.44,
+    "hit_rate_per_link": 0.041,
+    "stars": 13,
+    "topics": {
+     "leadership and management": 119,
+     "personal development": 18,
+     "innovation": 13,
+     "?": 1
+    }
+   },
+   {
+    "address": "dwarkesh+blog@substack.com",
+    "name": "Dwarkesh Patel",
+    "emails": 9,
+    "picks": 4,
+    "hit_rate_per_email": 0.44,
+    "hit_rate_per_link": 0.044,
+    "stars": 0,
+    "topics": {
+     "innovation": 3,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "thoughtsparks@substack.com",
+    "name": "Rita McGrath",
+    "emails": 26,
+    "picks": 11,
+    "hit_rate_per_email": 0.42,
+    "hit_rate_per_link": 0.039,
+    "stars": 0,
+    "topics": {
+     "innovation": 8,
+     "leadership and management": 3
+    }
+   },
+   {
+    "address": "hello@gorick.com",
+    "name": "Gorick Ng",
+    "emails": 66,
+    "picks": 27,
+    "hit_rate_per_email": 0.41,
+    "hit_rate_per_link": 0.021,
+    "stars": 1,
+    "topics": {
+     "personal development": 15,
+     "innovation": 6,
+     "leadership and management": 6
+    }
+   },
+   {
+    "address": "dwarkesh@substack.com",
+    "name": "Dwarkesh Patel",
+    "emails": 32,
+    "picks": 12,
+    "hit_rate_per_email": 0.38,
+    "hit_rate_per_link": 0.005,
+    "stars": 1,
+    "topics": {
+     "innovation": 11,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "addyo@substack.com",
+    "name": "Addy Osmani from Elevate",
+    "emails": 16,
+    "picks": 6,
+    "hit_rate_per_email": 0.38,
+    "hit_rate_per_link": 0.036,
+    "stars": 0,
+    "topics": {
+     "innovation": 5,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "enquiries@thinkers50.com",
+    "name": "Thinkers50",
+    "emails": 13,
+    "picks": 5,
+    "hit_rate_per_email": 0.38,
+    "hit_rate_per_link": 0.016,
+    "stars": 0,
+    "topics": {
+     "leadership and management": 4,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "gallup@mail.gallup.com",
+    "name": "Gallup News",
+    "emails": 26,
+    "picks": 9,
+    "hit_rate_per_email": 0.35,
+    "hit_rate_per_link": 0.429,
+    "stars": 1,
+    "topics": {
+     "leadership and management": 7,
+     "innovation": 1,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "stanford-hai@stanford.edu",
+    "name": "Stanford HAI",
+    "emails": 17,
+    "picks": 6,
+    "hit_rate_per_email": 0.35,
+    "hit_rate_per_link": 0.024,
+    "stars": 2,
+    "topics": {
+     "innovation": 6
+    }
+   },
+   {
+    "address": "imd@imd.org",
+    "name": "IMD | Program Updates",
+    "emails": 63,
+    "picks": 21,
+    "hit_rate_per_email": 0.33,
+    "hit_rate_per_link": 0.016,
+    "stars": 1,
+    "topics": {
+     "leadership and management": 14,
+     "personal development": 4,
+     "innovation": 3
+    }
+   },
+   {
+    "address": "lenny@substack.com",
+    "name": "Lenny's Newsletter",
+    "emails": 123,
+    "picks": 39,
+    "hit_rate_per_email": 0.32,
+    "hit_rate_per_link": 0.01,
+    "stars": 5,
+    "topics": {
+     "innovation": 22,
+     "leadership and management": 10,
+     "personal development": 7
+    }
+   },
+   {
+    "address": "adamgrant@substack.com",
+    "name": "Adam Grant, Granted",
+    "emails": 14,
+    "picks": 4,
+    "hit_rate_per_email": 0.29,
+    "hit_rate_per_link": 0.061,
+    "stars": 0,
+    "topics": {
+     "personal development": 4
+    }
+   },
+   {
+    "address": "maried@substack.com",
+    "name": "Marie Dollé from In Bed With Social",
+    "emails": 36,
+    "picks": 9,
+    "hit_rate_per_email": 0.25,
+    "hit_rate_per_link": 0.059,
+    "stars": 0,
+    "topics": {
+     "innovation": 6,
+     "personal development": 2,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "hello@justinwelsh.me",
+    "name": "Justin Welsh",
+    "emails": 29,
+    "picks": 7,
+    "hit_rate_per_email": 0.24,
+    "hit_rate_per_link": 0.043,
+    "stars": 1,
+    "topics": {
+     "personal development": 7
+    }
+   },
+   {
+    "address": "hbswk@ac.hbswk.hbs.edu",
+    "name": "Harvard Business School Working Knowledge",
+    "emails": 53,
+    "picks": 12,
+    "hit_rate_per_email": 0.23,
+    "hit_rate_per_link": 0.012,
+    "stars": 1,
+    "topics": {
+     "leadership and management": 8,
+     "?": 2,
+     "personal development": 1,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "facilitatorscorner@substack.com",
+    "name": "Mehdi En-Naizi from Facilitators' Corner",
+    "emails": 35,
+    "picks": 8,
+    "hit_rate_per_email": 0.23,
+    "hit_rate_per_link": 0.046,
+    "stars": 1,
+    "topics": {
+     "personal development": 4,
+     "leadership and management": 3,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "email@stratechery.com",
+    "name": "Ben Thompson",
+    "emails": 78,
+    "picks": 17,
+    "hit_rate_per_email": 0.22,
+    "hit_rate_per_link": 0.013,
+    "stars": 2,
+    "topics": {
+     "innovation": 15,
+     "personal development": 2
+    }
+   },
+   {
+    "address": "ash@leanstack.com",
+    "name": "ash@leanstack.com",
+    "emails": 60,
+    "picks": 13,
+    "hit_rate_per_email": 0.22,
+    "hit_rate_per_link": 0.13,
+    "stars": 0,
+    "topics": {
+     "innovation": 13
+    }
+   },
+   {
+    "address": "gustavorazzetti+fearless-culture@substack.com",
+    "name": "Gustavo Razzetti from Fearless Culture",
+    "emails": 49,
+    "picks": 11,
+    "hit_rate_per_email": 0.22,
+    "hit_rate_per_link": 0.012,
+    "stars": 2,
+    "topics": {
+     "leadership and management": 11
+    }
+   },
+   {
+    "address": "marketoon@marketoonist.com",
+    "name": "Tom Fishburne",
+    "emails": 44,
+    "picks": 9,
+    "hit_rate_per_email": 0.2,
+    "hit_rate_per_link": 0.017,
+    "stars": 0,
+    "topics": {
+     "innovation": 7,
+     "leadership and management": 1,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "review@firstround.com",
+    "name": "First Round Review",
+    "emails": 44,
+    "picks": 9,
+    "hit_rate_per_email": 0.2,
+    "hit_rate_per_link": 0.045,
+    "stars": 0,
+    "topics": {
+     "innovation": 6,
+     "leadership and management": 2,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "hello@ftsg.com",
+    "name": "Amy Webb",
+    "emails": 15,
+    "picks": 3,
+    "hit_rate_per_email": 0.2,
+    "hit_rate_per_link": 0.032,
+    "stars": 1,
+    "topics": {
+     "innovation": 2,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "nir@nirandfar.com",
+    "name": "Nir Eyal",
+    "emails": 32,
+    "picks": 6,
+    "hit_rate_per_email": 0.19,
+    "hit_rate_per_link": 0.032,
+    "stars": 0,
+    "topics": {
+     "personal development": 5,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "newsletters@techcrunch.com",
+    "name": "TechCrunch Week in Review",
+    "emails": 52,
+    "picks": 9,
+    "hit_rate_per_email": 0.17,
+    "hit_rate_per_link": 0.016,
+    "stars": 0,
+    "topics": {
+     "innovation": 9
+    }
+   },
+   {
+    "address": "dina@dinadsmith.com",
+    "name": "Dina Denham Smith",
+    "emails": 6,
+    "picks": 1,
+    "hit_rate_per_email": 0.17,
+    "hit_rate_per_link": 0.023,
+    "stars": 1,
+    "topics": {
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "publishing@email.mckinsey.com",
+    "name": "McKinsey & Company",
+    "emails": 172,
+    "picks": 27,
+    "hit_rate_per_email": 0.16,
+    "hit_rate_per_link": 0.006,
+    "stars": 4,
+    "topics": {
+     "innovation": 19,
+     "leadership and management": 8
+    }
+   },
+   {
+    "address": "tim@fourhourbody.com",
+    "name": "Tim Ferriss",
+    "emails": 107,
+    "picks": 17,
+    "hit_rate_per_email": 0.16,
+    "hit_rate_per_link": 0.01,
+    "stars": 3,
+    "topics": {
+     "personal development": 9,
+     "innovation": 5,
+     "leadership and management": 3
+    }
+   },
+   {
+    "address": "metatrends@substack.com",
+    "name": "Peter H. Diamandis",
+    "emails": 86,
+    "picks": 14,
+    "hit_rate_per_email": 0.16,
+    "hit_rate_per_link": 0.036,
+    "stars": 2,
+    "topics": {
+     "innovation": 10,
+     "personal development": 3,
+     "?": 1
+    }
+   },
+   {
+    "address": "qed@nfx.com",
+    "name": "NFX",
+    "emails": 37,
+    "picks": 6,
+    "hit_rate_per_email": 0.16,
+    "hit_rate_per_link": 0.025,
+    "stars": 0,
+    "topics": {
+     "innovation": 6
+    }
+   },
+   {
+    "address": "info@corporate-rebels.com",
+    "name": "Corporate Rebels",
+    "emails": 81,
+    "picks": 12,
+    "hit_rate_per_email": 0.15,
+    "hit_rate_per_link": 0.05,
+    "stars": 2,
+    "topics": {
+     "leadership and management": 11,
+     "personal development": 1
+    }
+   },
+   {
+    "address": "superhuman@mail.joinsuperhuman.ai",
+    "name": "Superhuman – Zain Kahn",
+    "emails": 372,
+    "picks": 51,
+    "hit_rate_per_email": 0.14,
+    "hit_rate_per_link": 0.007,
+    "stars": 4,
+    "topics": {
+     "innovation": 41,
+     "personal development": 5,
+     "leadership and management": 5
+    }
+   },
+   {
+    "address": "wondertools@substack.com",
+    "name": "Jeremy Caplan",
+    "emails": 54,
+    "picks": 7,
+    "hit_rate_per_email": 0.13,
+    "hit_rate_per_link": 0.006,
+    "stars": 0,
+    "topics": {
+     "personal development": 4,
+     "innovation": 3
+    }
+   },
+   {
+    "address": "bostonconsultinggroup@bcg.com",
+    "name": "BCG Weekly Recap",
+    "emails": 34,
+    "picks": 4,
+    "hit_rate_per_email": 0.12,
+    "hit_rate_per_link": 0.018,
+    "stars": 2,
+    "topics": {
+     "leadership and management": 3,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "edit@strategy-business.com",
+    "name": "strategy-business editors",
+    "emails": 109,
+    "picks": 11,
+    "hit_rate_per_email": 0.1,
+    "hit_rate_per_link": 0.009,
+    "stars": 0,
+    "topics": {
+     "leadership and management": 7,
+     "innovation": 4
+    }
+   },
+   {
+    "address": "alexandbooks@mail.beehiiv.com",
+    "name": "Alex & Books",
+    "emails": 60,
+    "picks": 5,
+    "hit_rate_per_email": 0.08,
+    "hit_rate_per_link": 0.006,
+    "stars": 2,
+    "topics": {
+     "personal development": 2,
+     "leadership and management": 2,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "newsletter@farnamstreetblog.com",
+    "name": "Shane Parrish (FS)",
+    "emails": 54,
+    "picks": 4,
+    "hit_rate_per_email": 0.07,
+    "hit_rate_per_link": 0.014,
+    "stars": 2,
+    "topics": {
+     "personal development": 4
+    }
+   },
+   {
+    "address": "quanta@simonsfoundation.org",
+    "name": "Quanta Magazine",
+    "emails": 83,
+    "picks": 4,
+    "hit_rate_per_email": 0.05,
+    "hit_rate_per_link": 0.005,
+    "stars": 0,
+    "topics": {
+     "personal development": 3,
+     "innovation": 1
+    }
+   },
+   {
+    "address": "simonw@substack.com",
+    "name": "Simon Willison from Simon Willison’s Newsletter",
+    "emails": 19,
+    "picks": 1,
+    "hit_rate_per_email": 0.05,
+    "hit_rate_per_link": 0.001,
+    "stars": 1,
+    "topics": {
+     "innovation": 1
+    }
+   },
+   {
+    "address": "lenny+how-i-ai@substack.com",
+    "name": "Lenny's Newsletter",
+    "emails": 56,
+    "picks": 2,
+    "hit_rate_per_email": 0.04,
+    "hit_rate_per_link": 0.003,
+    "stars": 0,
+    "topics": {
+     "innovation": 2
+    }
+   },
+   {
+    "address": "james@jamesclear.com",
+    "name": "James Clear",
+    "emails": 55,
+    "picks": 2,
+    "hit_rate_per_email": 0.04,
+    "hit_rate_per_link": 0.004,
+    "stars": 0,
+    "topics": {
+     "innovation": 2
+    }
+   },
+   {
+    "address": "davidalayon@substack.com",
+    "name": "Future Today · David Alayón",
+    "emails": 26,
+    "picks": 1,
+    "hit_rate_per_email": 0.04,
+    "hit_rate_per_link": 0.002,
+    "stars": 0,
+    "topics": {
+     "innovation": 1
+    }
+   },
+   {
+    "address": "thegeneralist@substack.com",
+    "name": "The Generalist",
+    "emails": 29,
+    "picks": 1,
+    "hit_rate_per_email": 0.03,
+    "hit_rate_per_link": 0.002,
+    "stars": 0,
+    "topics": {
+     "personal development": 1
+    }
+   }
+  ],
+  "floor": [
+   {
+    "address": "news@newsalumni.esade.edu",
+    "name": "Esade Alumni",
+    "emails": 146,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "alumnicommunity@global-mail.iese.edu",
+    "name": "IESE Alumni Association",
+    "emails": 84,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "daveandbill@designingyour.life",
+    "name": "Bill Burnett and Dave Evans",
+    "emails": 65,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "myriam@workshops.work",
+    "name": "Myriam Hadnes",
+    "emails": 55,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "hello@matthiasfrank.de",
+    "name": "Matthias",
+    "emails": 45,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "khemaridh@substack.com",
+    "name": "Khe Hy",
+    "emails": 33,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "no-reply@notification.circle.so",
+    "name": "Explain Ideas Visually",
+    "emails": 30,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "dorie@dorieclark.com",
+    "name": "Dorie Clark",
+    "emails": 30,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "competia@substack.com",
+    "name": "Estelle Metayer @competia from Weak signals and other trends",
+    "emails": 24,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "newsletter@magda.es",
+    "name": "Magda Teruel",
+    "emails": 22,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "insight@global-mail.iese.edu",
+    "name": "IESE Insight",
+    "emails": 19,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "thepalindrome@substack.com",
+    "name": "The Palindrome",
+    "emails": 15,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "iese@global-mail.iese.edu",
+    "name": "IESE Business School | Executive Education",
+    "emails": 14,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "on+product@substack.com",
+    "name": "Substack",
+    "emails": 13,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "myriamhadnes@substack.com",
+    "name": "Myriam Hadnes from workshops work Substack",
+    "emails": 10,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "on+stories@substack.com",
+    "name": "Substack",
+    "emails": 9,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "growthbyvisuals@substack.com",
+    "name": "Hidde from Growth by Visuals",
+    "emails": 8,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "on+open-tab@substack.com",
+    "name": "Substack",
+    "emails": 8,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "kacymaxwell@substack.com",
+    "name": "Kacy @ Drawn to Lead",
+    "emails": 8,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "dblthink@substack.com",
+    "name": "Lewis O'Brien",
+    "emails": 7,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "danielpink@substack.com",
+    "name": "Daniel Pink",
+    "emails": 7,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "ineo@iese.edu",
+    "name": "Excelencia en las Operaciones (INEO)",
+    "emails": 6,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "alp.bcn@global-mail.iese.edu",
+    "name": "IESE Alumni Association",
+    "emails": 5,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "on+resources@substack.com",
+    "name": "Substack",
+    "emails": 3,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "marshallgoldsmith@substack.com",
+    "name": "Substack from The Marshall Goldsmith Newsletter",
+    "emails": 3,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "visualgrowth@substack.com",
+    "name": "Ash Lamb",
+    "emails": 3,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "on+news@substack.com",
+    "name": "Substack",
+    "emails": 3,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "creativewisdom@substack.com",
+    "name": "PJ Milani from Creative Wisdom",
+    "emails": 1,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "lifelonglearning@iese.edu",
+    "name": "IESE Lifelong Learning",
+    "emails": 1,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   },
+   {
+    "address": "drfeifei@substack.com",
+    "name": "Fei-Fei Li",
+    "emails": 1,
+    "picks": 0,
+    "hit_rate_per_email": 0.0,
+    "hit_rate_per_link": 0.0,
+    "stars": 0,
+    "topics": {}
+   }
+  ]
+ },
+ "domain_priors": [
+  {
+   "domain": "hbr.org",
+   "picks": 157,
+   "editions": 55,
+   "max_per_edition": 5,
+   "stars": 14,
+   "topics": {
+    "leadership and management": 124,
+    "personal development": 19,
+    "innovation": 13
+   }
+  },
+  {
+   "domain": "sahilbloom.com",
+   "picks": 79,
+   "editions": 52,
+   "max_per_edition": 3,
+   "stars": 7,
+   "topics": {
+    "personal development": 77
+   }
+  },
+  {
+   "domain": "mikefisher.substack.com",
+   "picks": 49,
+   "editions": 41,
+   "max_per_edition": 2,
+   "stars": 9,
+   "topics": {
+    "leadership and management": 27,
+    "personal development": 5,
+    "innovation": 17
+   }
+  },
+  {
+   "domain": "rishad.substack.com",
+   "picks": 48,
+   "editions": 40,
+   "max_per_edition": 2,
+   "stars": 4,
+   "topics": {
+    "leadership and management": 17,
+    "personal development": 21,
+    "innovation": 10
+   }
+  },
+  {
+   "domain": "nesslabs.com",
+   "picks": 42,
+   "editions": 41,
+   "max_per_edition": 2,
+   "stars": 7,
+   "topics": {
+    "personal development": 41
+   }
+  },
+  {
+   "domain": "youtube.com",
+   "picks": 42,
+   "editions": 30,
+   "max_per_edition": 4,
+   "stars": 4,
+   "topics": {
+    "personal development": 22,
+    "innovation": 17
+   }
+  },
+  {
+   "domain": "think.fearlessculture.design",
+   "picks": 40,
+   "editions": 33,
+   "max_per_edition": 2,
+   "stars": 3,
+   "topics": {
+    "leadership and management": 38
+   }
+  },
+  {
+   "domain": "lennysnewsletter.com",
+   "picks": 39,
+   "editions": 26,
+   "max_per_edition": 3,
+   "stars": 4,
+   "topics": {
+    "leadership and management": 9,
+    "personal development": 7,
+    "innovation": 23
+   }
+  },
+  {
+   "domain": "psychsafety.com",
+   "picks": 39,
+   "editions": 37,
+   "max_per_edition": 2,
+   "stars": 8,
+   "topics": {
+    "leadership and management": 36
+   }
+  },
+  {
+   "domain": "thegoodbusy.substack.com",
+   "picks": 32,
+   "editions": 26,
+   "max_per_edition": 2,
+   "stars": 4,
+   "topics": {
+    "leadership and management": 9,
+    "personal development": 22
+   }
+  },
+  {
+   "domain": "mckinsey.com",
+   "picks": 27,
+   "editions": 23,
+   "max_per_edition": 3,
+   "stars": 4,
+   "topics": {
+    "leadership and management": 8,
+    "innovation": 19
+   }
+  },
+  {
+   "domain": "scotthyoung.com",
+   "picks": 26,
+   "editions": 25,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "personal development": 22
+   }
+  },
+  {
+   "domain": "knowledge.insead.edu",
+   "picks": 25,
+   "editions": 22,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 17
+   }
+  },
+  {
+   "domain": "newsletter.weskao.com",
+   "picks": 23,
+   "editions": 23,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 15,
+    "personal development": 8
+   }
+  },
+  {
+   "domain": "digitalnative.tech",
+   "picks": 22,
+   "editions": 22,
+   "max_per_edition": 1,
+   "stars": 6,
+   "topics": {
+    "innovation": 22
+   }
+  },
+  {
+   "domain": "imd.org",
+   "picks": 21,
+   "editions": 20,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 14
+   }
+  },
+  {
+   "domain": "oneusefulthing.org",
+   "picks": 19,
+   "editions": 18,
+   "max_per_edition": 2,
+   "stars": 5,
+   "topics": {
+    "innovation": 18
+   }
+  },
+  {
+   "domain": "ckarchive.com",
+   "picks": 19,
+   "editions": 16,
+   "max_per_edition": 2,
+   "stars": 4,
+   "topics": {
+    "leadership and management": 9,
+    "personal development": 10
+   }
+  },
+  {
+   "domain": "decision.substack.com",
+   "picks": 18,
+   "editions": 16,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 15
+   }
+  },
+  {
+   "domain": "gorick.com",
+   "picks": 17,
+   "editions": 13,
+   "max_per_edition": 3,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 5,
+    "personal development": 10
+   }
+  },
+  {
+   "domain": "davidepstein.substack.com",
+   "picks": 16,
+   "editions": 16,
+   "max_per_edition": 1,
+   "stars": 4,
+   "topics": {
+    "personal development": 16
+   }
+  },
+  {
+   "domain": "dwarkesh.com",
+   "picks": 16,
+   "editions": 15,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 14
+   }
+  },
+  {
+   "domain": "x.com",
+   "picks": 13,
+   "editions": 12,
+   "max_per_edition": 2,
+   "stars": 4,
+   "topics": {
+    "innovation": 12
+   }
+  },
+  {
+   "domain": "howardyu.substack.com",
+   "picks": 13,
+   "editions": 12,
+   "max_per_edition": 2,
+   "stars": 5,
+   "topics": {
+    "innovation": 11
+   }
+  },
+  {
+   "domain": "metatrends.substack.com",
+   "picks": 13,
+   "editions": 12,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 10
+   }
+  },
+  {
+   "domain": "stratechery.com",
+   "picks": 13,
+   "editions": 13,
+   "max_per_edition": 1,
+   "stars": 2,
+   "topics": {
+    "innovation": 13
+   }
+  },
+  {
+   "domain": "linkedin.com",
+   "picks": 13,
+   "editions": 11,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 9
+   }
+  },
+  {
+   "domain": "maried.substack.com",
+   "picks": 12,
+   "editions": 12,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "innovation": 7
+   }
+  },
+  {
+   "domain": "longform.asmartbear.com",
+   "picks": 12,
+   "editions": 12,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "innovation": 8
+   }
+  },
+  {
+   "domain": "library.hbs.edu",
+   "picks": 12,
+   "editions": 12,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 8
+   }
+  },
+  {
+   "domain": "leanfoundry.com",
+   "picks": 12,
+   "editions": 11,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 12
+   }
+  },
+  {
+   "domain": "thoughtsparks.substack.com",
+   "picks": 11,
+   "editions": 10,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 8
+   }
+  },
+  {
+   "domain": "leadingsapiens.com",
+   "picks": 11,
+   "editions": 11,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 6,
+    "personal development": 5
+   }
+  },
+  {
+   "domain": "readwise-assets.s3.amazonaws.com",
+   "picks": 9,
+   "editions": 9,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "personal development": 5
+   }
+  },
+  {
+   "domain": "techcrunch.com",
+   "picks": 9,
+   "editions": 8,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "innovation": 9
+   }
+  },
+  {
+   "domain": "nfx.com",
+   "picks": 9,
+   "editions": 9,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "innovation": 9
+   }
+  },
+  {
+   "domain": "gallup.com",
+   "picks": 9,
+   "editions": 8,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 7
+   }
+  },
+  {
+   "domain": "facilitatorscorner.substack.com",
+   "picks": 8,
+   "editions": 8,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "strategy-business.com",
+   "picks": 8,
+   "editions": 8,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 7
+   }
+  },
+  {
+   "domain": "review.firstround.com",
+   "picks": 8,
+   "editions": 7,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "ryanholiday.net",
+   "picks": 8,
+   "editions": 7,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {
+    "personal development": 8
+   }
+  },
+  {
+   "domain": "addyo.substack.com",
+   "picks": 7,
+   "editions": 6,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "anthropic.com",
+   "picks": 7,
+   "editions": 7,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "wondertools.substack.com",
+   "picks": 7,
+   "editions": 6,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "justinwelsh.me",
+   "picks": 7,
+   "editions": 7,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "personal development": 7
+   }
+  },
+  {
+   "domain": "vizi.substack.com",
+   "picks": 6,
+   "editions": 6,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "personal development": 6
+   }
+  },
+  {
+   "domain": "hosanagar.substack.com",
+   "picks": 6,
+   "editions": 6,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "hai.stanford.edu",
+   "picks": 6,
+   "editions": 5,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "theatlantic.com",
+   "picks": 6,
+   "editions": 5,
+   "max_per_edition": 2,
+   "stars": 2,
+   "topics": {
+    "personal development": 5
+   }
+  },
+  {
+   "domain": "inc.com",
+   "picks": 6,
+   "editions": 6,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "leadership and management": 5
+   }
+  },
+  {
+   "domain": "susandavid.com",
+   "picks": 6,
+   "editions": 6,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "tim.blog",
+   "picks": 5,
+   "editions": 5,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "marketoonist.com",
+   "picks": 5,
+   "editions": 5,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "time.com",
+   "picks": 4,
+   "editions": 3,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "bcg.com",
+   "picks": 4,
+   "editions": 4,
+   "max_per_edition": 1,
+   "stars": 2,
+   "topics": {
+    "leadership and management": 3
+   }
+  },
+  {
+   "domain": "nir.substack.com",
+   "picks": 4,
+   "editions": 3,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "fs.blog",
+   "picks": 4,
+   "editions": 4,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {
+    "personal development": 4
+   }
+  },
+  {
+   "domain": "iese.edu",
+   "picks": 4,
+   "editions": 3,
+   "max_per_edition": 2,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "marketoonist.beehiiv.com",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "quantamagazine.org",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "pwc.com",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "forbes.com",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "mailchi.mp",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "arxiv.org",
+   "picks": 3,
+   "editions": 3,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "claude.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "thinkers50.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "theconversation.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "pubmed.ncbi.nlm.nih.gov",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "technologyreview.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "wsj.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "derekthompson.org",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "bigthink.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "darioamodei.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "leanspark.ai",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "lucumr.pocoo.org",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "thestillwandering.substack.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "paulgraham.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "terriblesoftware.org",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "theguardian.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  },
+  {
+   "domain": "corporate-rebels.com",
+   "picks": 2,
+   "editions": 2,
+   "max_per_edition": 1,
+   "stars": 0,
+   "topics": {}
+  }
+ ],
+ "topic_authors": {
+  "leadership and management": {
+   "Gustavo Razzetti": 39,
+   "harvardbiz": 35,
+   "Tom Geraghty": 33,
+   "Mike Fisher": 27,
+   "Harvard Business Review": 19,
+   "Rishad Tobaccowala": 18,
+   "Wes Kao": 16,
+   "Kate Sotsenko": 9,
+   "Joost Minnaar": 9,
+   "Lenny Rachitsky": 8,
+   "Gallup": 7,
+   "(not classified)": 6,
+   "Sheril Mathews": 6,
+   "IMD business school": 6,
+   "McKinsey": 6,
+   "Gorick Ng": 5,
+   "INSEAD": 5,
+   "Amy Edmondson": 5,
+   "Jade Garratt": 4,
+   "Tomas Chamorro Premuzic": 4
+  },
+  "personal development": {
+   "Sahil Bloom": 69,
+   "Anne-Laure Le Cunff": 33,
+   "(not classified)": 32,
+   "Kate Sotsenko": 23,
+   "Scott H Young": 22,
+   "Rishad Tobaccowala": 21,
+   "David Epstein": 16,
+   "Oliver Burkeman": 11,
+   "Gorick Ng": 11,
+   "Ryan Holiday": 10,
+   "Wes Kao": 8,
+   "Justin Welsh": 7,
+   "Vizi Andrei": 6,
+   "Lenny Rachitsky": 6,
+   "Mike Fisher": 5,
+   "Sheril Mathews": 5,
+   "Nir Eyal": 4,
+   "Mehdi En-Naizi": 4,
+   "Marie Dollé": 4,
+   "Jeremy Caplan": 4
+  },
+  "innovation": {
+   "(not classified)": 26,
+   "Rex Woodbury": 22,
+   "Lenny Rachitsky": 22,
+   "Ethan Mollick": 20,
+   "Mike Fisher": 17,
+   "McKinsey": 16,
+   "Cassie Kozyrkov": 15,
+   "Ash Maurya": 13,
+   "Ben Thompson": 12,
+   "Dwarkesh Patel": 11,
+   "Howard Yu": 11,
+   "Peter H. Diamandis": 10,
+   "Addy Osmani": 10,
+   "Rishad Tobaccowala": 10,
+   "Jason Cohen": 9,
+   "NfX": 8,
+   "Rita McGrath": 8,
+   "Marie Dollé": 7,
+   "Tom Fishburne": 7,
+   "Dario Amodei": 6
+  }
+ },
+ "stars_by_author": {
+  "Mike Fisher": 9,
+  "Tom Geraghty": 8,
+  "Sahil Bloom": 7,
+  "Anne-Laure Le Cunff": 6,
+  "Rex Woodbury": 6,
+  "harvardbiz": 5,
+  "Howard Yu": 5,
+  "Ethan Mollick": 5,
+  "Kate Sotsenko": 5,
+  "(not classified)": 4,
+  "Rishad Tobaccowala": 4,
+  "David Epstein": 4,
+  "Oliver Burkeman": 4,
+  "McKinsey": 4,
+  "Gustavo Razzetti": 3,
+  "Lenny Rachitsky": 3,
+  "Arthur Brooks": 3,
+  "Dina Denham Smith": 3,
+  "Ben Thompson": 2,
+  "Peter H. Diamandis": 2
+ },
+ "must_read_by_author": {
+  "Tom Geraghty": 4,
+  "Anne-Laure Le Cunff": 4,
+  "Sahil Bloom": 3,
+  "Oliver Burkeman": 3,
+  "Kate Sotsenko": 3,
+  "Justin Bariso": 2,
+  "Arthur Brooks": 2,
+  "Dina Denham Smith": 2,
+  "Shane Parrish": 1,
+  "Rishad Tobaccowala": 1,
+  "Joe Hudson": 1,
+  "David Epstein": 1,
+  "Ethan Mollick": 1,
+  "Elena Verna": 1,
+  "Peter H. Diamandis": 1
+ }
+}

--- a/newsletter/triage/criteria.py
+++ b/newsletter/triage/criteria.py
@@ -78,7 +78,7 @@ RULES: Dict[str, Any] = {
             "themes": ["psychological safety", "culture and change", "feedback and difficult conversations", "trust",
                        "meetings and decision-making", "managers and teams", "emotions at work", "power, politics and influence",
                        "delegation and accountability", "humor and humanity at work", "hiring, performance and careers of others"],
-            "signature_domains": ["hbr.org", "think.fearlessculture.design", "psychsafety.com", "mikefisher.substack.com",
+            "signature_domains": ["hbr.org", "psychsafety.com", "mikefisher.substack.com",
                                   "rishad.substack.com", "knowledge.insead.edu", "newsletter.weskao.com", "imd.org", "library.hbs.edu",
                                   "strategy-business.com", "gallup.com", "corporate-rebels.com", "leadingsapiens.com"],
             "anti_themes": ["executive-education brochures", "program/course promos", "alumni news"],
@@ -122,7 +122,33 @@ RULES: Dict[str, Any] = {
         "one star per topic, the must-read is usually personal development or leadership (innovation 2/48)",
     ],
     "backfill": {"next_checkbox_pool": True, "classics": True},
+    "paywall": {
+        "rule": "never link paywalled content — a paywalled pick is promotion, not content for the reader",
+        "detect": ["Substack 'This post is for paid subscribers' / paywall block", "hard subscribe-to-read walls",
+                   "truncated body with a subscription CTA"],
+        "metered_is_ok": "HBR-style metered/registration walls are accessible and were picked 151 times — only hard walls are excluded",
+        "known_paywalled_senders": "see overrides.json (tier=never, reason=paywalled) — Fearless Culture since 2026",
+    },
+    "cadence": {
+        "rule": "one run covers one review window (last watermark → now, normally one week) and fills ONE edition (8/8/8); "
+                "a backlog of N weeks yields N windows and N editions, oldest first — never drain the whole inbox into one edition",
+        "window_anchor": "Saturday edition day: the run on Friday covers last Saturday → today and feeds the next edition, so the queue stays one edition ahead",
+    },
+    "feedback_loop": {
+        "rule": "after the owner reviews a report (tick = yes, untick = no), ingest the decisions: update sender tiers/weights in overrides.json, "
+                "log every decision to results/newsletter/triage/feedback.jsonl; the weekly Notion re-sync (history.py) refreshes the data priors",
+        "new_senders": "a sender with no history is flagged NEW in the report, scored on content + criteria only, and listed for a manual tier "
+                       "decision (always/usually/rarely/never/review) that persists in overrides.json",
+    },
 }
+
+OVERRIDES_PATH = Path(__file__).with_name("overrides.json")
+
+
+def load_overrides() -> Dict[str, Any]:
+    if OVERRIDES_PATH.exists():
+        return json.loads(OVERRIDES_PATH.read_text(encoding="utf-8"))
+    return {"senders": {}}
 
 # Gmail senders that are system notifications, alumni bulletins or pure promos
 # — kept in the report but ranked at the floor (0 picks in 54 weeks each).
@@ -171,6 +197,7 @@ def build_criteria(stats: Dict[str, Any]) -> Dict[str, Any]:
                    "first_email": w.get("first_email"), "last_email": w.get("last_email"),
                    "match_rate": stats.get("match", {}).get("rate")},
         "rules": RULES,
+        "sender_overrides": load_overrides().get("senders", {}),
         "sender_priors": _sender_priors(stats),
         "domain_priors": _domain_priors(stats),
         "topic_authors": stats.get("topic_authors", {}),
@@ -194,7 +221,8 @@ def main(argv=None) -> int:
     crit = build_criteria(stats)
     Path(args.out).write_text(json.dumps(crit, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
     print(f"✅ criteria.json written: {len(crit['sender_priors']['ranked'])} ranked senders, "
-          f"{len(crit['sender_priors']['floor'])} floor senders, {len(crit['domain_priors'])} domains → {args.out}")
+          f"{len(crit['sender_priors']['floor'])} floor senders, {len(crit['sender_overrides'])} overrides, "
+          f"{len(crit['domain_priors'])} domains → {args.out}")
     if args.print:
         for r in crit["sender_priors"]["ranked"][:25]:
             print(f"  {r['hit_rate_per_email']:.2f}/email  {r['picks']:3} picks / {r['emails']:3} emails  {r['name'][:40]}")

--- a/newsletter/triage/criteria.py
+++ b/newsletter/triage/criteria.py
@@ -1,0 +1,205 @@
+"""Build ``newsletter/triage/criteria.json`` — the machine-readable selection criteria.
+
+Two halves, merged:
+
+* **RULES** (hand-written below, versioned with the code) — the caps, topic
+  signatures, exclusions, news policy, timing and the owner-stated rules. Each
+  carries the number measured on the 54-week history so the rationale travels
+  with the rule (see ``docs/newsletter-triage-criteria.md``).
+* **priors** (derived at build time from ``results/newsletter/triage/history/
+  stats.json``) — per-sender and per-domain hit-rates, topic mix and star rates.
+
+Usage::
+
+    python -m newsletter.triage.criteria            # rebuild criteria.json
+    python -m newsletter.triage.criteria --print    # show a summary
+
+The Step-2 ranker reads ``criteria.json`` only; it never reads ``stats.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from config.console import force_utf8_stdio  # noqa: E402
+
+STATS_PATH = REPO_ROOT / "results" / "newsletter" / "triage" / "history" / "stats.json"
+CRITERIA_PATH = Path(__file__).with_name("criteria.json")
+
+TOPICS = ("leadership and management", "personal development", "innovation")
+
+# ---------------------------------------------------------------------------
+# hand-written rules (numbers = measured on N174–N227, 2025-08 → 2026-08)
+
+RULES: Dict[str, Any] = {
+    "edition": {
+        "per_topic": 8,                 # 8/8/8 in 51 of 54 complete editions (24 articles)
+        "stars_per_topic": 1,           # exactly 3 stars in 51/54 editions
+        "must_read": 1,                 # first sentence of the edition title
+        "must_read_topic_prior": {      # 48 recoverable must-reads
+            "personal development": 0.60, "leadership and management": 0.35, "innovation": 0.04},
+        "fill_ahead_editions": 2,       # review fills the first future edition with <8 per topic; N+1/N+2 already partly filled
+    },
+    "caps": {
+        # per edition — target = the mode, hard = tolerated exception, never = reject
+        "hbr_per_edition": {"target": 3, "hard": 4, "never_above": 5,
+                            "measured_hist": "3:26 · 2:10 · 4:12 · 1:6 · 0:1 · 5:1 (56 editions)"},
+        "same_author_per_edition": {"target": 2, "hard": 3,
+                                    "measured_hist": "2:32 · 3:14 · 1:5 · 4:3 · 5:2 (org-level authors such as 'harvardbiz'/'McKinsey' inflate the tail)"},
+        "same_domain_per_edition": {"target": 3, "hard": 4,
+                                    "measured_hist": "3:30 · 4:13 · 2:11 · 5:1 · 1:1"},
+        "same_sender_per_email": {"typical": 1, "note": "one email almost never yields more than 1–2 picks; Readwise/HBR digests are the exception"},
+    },
+    "timing": {
+        "email_to_edition_lag_days_mode": [10, 17, 20],
+        "review_window_days": [7, 21],
+        "note": "emails are reviewed ~1 week before an edition and land in the first future edition with a free slot; picks dated >21 days before the edition are rare",
+    },
+    "news_policy": {
+        "rule": "a product/model *release* is not an innovation pick; the pick is the commentary that explains what it changes for work, organisations or society",
+        "measured": "news-like titles are 3.5% of innovation picks vs 2.3% of all offered links — no over-weighting; the few release-shaped picks are essays (Mollick 'Sign of the future: GPT-5.5', Thompson 'Gemini! At the disco') or one primary source per event (Google's Gemini 3 post, Anthropic research posts)",
+        "keep_if": ["new capability class (agents, world models, coding agents) explained for a general business reader",
+                    "credible survey / report on AI adoption, jobs, or the economy (McKinsey, Stanford HAI, Gallup, HBS)",
+                    "first-hand essay from a practitioner/thinker (Mollick, Kozyrkov, Thompson, Woodbury, Dwarkesh interviews)"],
+        "drop_if": ["funding rounds, valuations, earnings, executive moves", "benchmark leaderboards, model cards, release notes",
+                    "vendor marketing, 'try it now' product pages", "daily AI-news roundups as a whole (pick at most the one general-interest item)"],
+    },
+    "topics": {
+        "leadership and management": {
+            "themes": ["psychological safety", "culture and change", "feedback and difficult conversations", "trust",
+                       "meetings and decision-making", "managers and teams", "emotions at work", "power, politics and influence",
+                       "delegation and accountability", "humor and humanity at work", "hiring, performance and careers of others"],
+            "signature_domains": ["hbr.org", "think.fearlessculture.design", "psychsafety.com", "mikefisher.substack.com",
+                                  "rishad.substack.com", "knowledge.insead.edu", "newsletter.weskao.com", "imd.org", "library.hbs.edu",
+                                  "strategy-business.com", "gallup.com", "corporate-rebels.com", "leadingsapiens.com"],
+            "anti_themes": ["executive-education brochures", "program/course promos", "alumni news"],
+        },
+        "personal development": {
+            "themes": ["attention, focus and busyness", "habits and motivation", "learning and reading", "meaning, optimism and happiness",
+                       "mental models and decision-making for oneself", "career and identity", "energy, sleep, health (when first-hand and practical)",
+                       "writing and thinking clearly", "psychology of self (paradoxes, effects, traps)"],
+            "signature_domains": ["sahilbloom.com", "nesslabs.com", "scotthyoung.com", "thegoodbusy.substack.com", "rishad.substack.com",
+                                  "davidepstein.substack.com", "ryanholiday.net", "oliverburkeman.com", "gorick.com", "justinwelsh.me",
+                                  "fs.blog", "vizi.substack.com", "theatlantic.com", "youtube.com"],
+            "anti_themes": ["supplements, gear and gift guides", "book pre-orders and courses", "generic listicles without an idea"],
+        },
+        "innovation": {
+            "themes": ["AI and the future of work / organisations", "agents and what they change", "strategy and foresight", "founders, product and growth",
+                       "technology essays (what it means, not what shipped)", "science and long-form interviews (Dwarkesh)", "economics of AI and platforms",
+                       "charts and reports that capture change"],
+            "signature_domains": ["lennysnewsletter.com", "digitalnative.tech", "mckinsey.com", "oneusefulthing.org", "mikefisher.substack.com",
+                                  "decision.substack.com", "dwarkesh.com", "stratechery.com", "hbr.org", "x.com", "leanfoundry.com", "howardyu.substack.com",
+                                  "metatrends.substack.com", "techcrunch.com", "nfx.com", "longform.asmartbear.com", "thoughtsparks.substack.com", "youtube.com"],
+            "anti_themes": ["release notes and model cards", "funding/earnings news", "sports/entertainment posts from tech writers",
+                            "tool directories and 'product pass' drops"],
+        },
+    },
+    "content_exclusions": {
+        "anchors": ["order/pre-order/buy the book", "course, cohort, workshop, masterclass, consultation, coaching", "sponsor, partner, promo code, discount",
+                    "job posting, hiring", "app download", "podcast player links (apple/spotify/overcast) when the episode page is also linked",
+                    "continue in the substack app", "subscribe to rss feed", "view/read online"],
+        "senders_never_selected_min_emails": 20,
+        "note": "senders with ≥20 emails and 0–1 picks get a near-zero prior; still listed in the report, never silently dropped",
+    },
+    "title_style": {
+        "avg_words": 6.8, "avg_chars": 40.7,
+        "note": "evergreen, conceptual titles — 'The X effect', 'Why Y', 'How to Z', a named paradox or metaphor; sentence case is applied later by normalize_names",
+    },
+    "owner_rules": [
+        "≤2 articles from the same person in one edition (measured mode 2; 3 tolerated, above that only for org-level sources)",
+        "≤3 HBR articles per edition (measured mode 3; 4 in 12 editions, 5 once)",
+        "AI model releases are not innovation picks — new capabilities / general-interest shifts are",
+        "when a topic is short, backfill from the `next` pool or classics not yet published",
+        "one star per topic, the must-read is usually personal development or leadership (innovation 2/48)",
+    ],
+    "backfill": {"next_checkbox_pool": True, "classics": True},
+}
+
+# Gmail senders that are system notifications, alumni bulletins or pure promos
+# — kept in the report but ranked at the floor (0 picks in 54 weeks each).
+FLOOR_SENDER_HINTS = ["substack.com", "esade.edu", "iese.edu", "designingyour.life", "workshops.work",
+                      "matthiasfrank.de", "circle.so", "competia", "magda.es"]
+
+
+# ---------------------------------------------------------------------------
+# derived priors
+
+
+def _sender_priors(stats: Dict[str, Any]) -> Dict[str, Any]:
+    out: List[Dict[str, Any]] = []
+    floor: List[Dict[str, Any]] = []
+    for s in stats.get("senders", []):
+        row = {"address": s["address"], "name": s["sender"], "emails": s["emails"], "picks": s["selected"],
+               "hit_rate_per_email": s["hit_rate_per_email"], "hit_rate_per_link": s["hit_rate_per_link"],
+               "stars": s["stars"], "topics": s["topics"]}
+        if s["emails"] >= 5:
+            if s["selected"] == 0 and s["emails"] >= RULES["content_exclusions"]["senders_never_selected_min_emails"]:
+                floor.append(row)
+            elif s["selected"] > 0:
+                out.append(row)
+        if any(h in s["address"] for h in FLOOR_SENDER_HINTS) and row not in floor and s["selected"] == 0:
+            floor.append(row)
+    out.sort(key=lambda r: (-r["hit_rate_per_email"], -r["picks"]))
+    return {"ranked": out, "floor": floor}
+
+
+def _domain_priors(stats: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows = []
+    stars = stats.get("stars_by_domain", {})
+    topic_dom = stats.get("topic_domains", {})
+    for dom, v in list(stats.get("domains", {}).items())[:80]:
+        topics = {t: d.get(dom, 0) for t, d in topic_dom.items() if d.get(dom)}
+        rows.append({"domain": dom, "picks": v["total"], "editions": v["editions"],
+                     "max_per_edition": v["max_per_edition"], "stars": stars.get(dom, 0), "topics": topics})
+    return rows
+
+
+def build_criteria(stats: Dict[str, Any]) -> Dict[str, Any]:
+    w = stats.get("window", {})
+    return {
+        "version": date.today().isoformat(),
+        "window": {"emails": w.get("emails"), "editions": w.get("editions"), "positives": w.get("positives"),
+                   "first_email": w.get("first_email"), "last_email": w.get("last_email"),
+                   "match_rate": stats.get("match", {}).get("rate")},
+        "rules": RULES,
+        "sender_priors": _sender_priors(stats),
+        "domain_priors": _domain_priors(stats),
+        "topic_authors": stats.get("topic_authors", {}),
+        "stars_by_author": stats.get("stars_by_author", {}),
+        "must_read_by_author": stats.get("must_read", {}).get("by_author", {}),
+    }
+
+
+def main(argv=None) -> int:
+    force_utf8_stdio()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--stats", default=str(STATS_PATH))
+    ap.add_argument("--out", default=str(CRITERIA_PATH))
+    ap.add_argument("--print", action="store_true")
+    args = ap.parse_args(argv)
+    stats_path = Path(args.stats)
+    if not stats_path.exists():
+        print(f"❌ stats not found at {stats_path} — run `python -m newsletter.triage.history` first")
+        return 2
+    stats = json.loads(stats_path.read_text(encoding="utf-8"))
+    crit = build_criteria(stats)
+    Path(args.out).write_text(json.dumps(crit, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
+    print(f"✅ criteria.json written: {len(crit['sender_priors']['ranked'])} ranked senders, "
+          f"{len(crit['sender_priors']['floor'])} floor senders, {len(crit['domain_priors'])} domains → {args.out}")
+    if args.print:
+        for r in crit["sender_priors"]["ranked"][:25]:
+            print(f"  {r['hit_rate_per_email']:.2f}/email  {r['picks']:3} picks / {r['emails']:3} emails  {r['name'][:40]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/triage/gmail.py
+++ b/newsletter/triage/gmail.py
@@ -1,0 +1,686 @@
+"""Gmail-label ingestion + link extraction for the newsletter triage.
+
+Adapter over the vendored ``gmail_readonly`` component (read-only scope). It
+adds what the portable component deliberately does not have:
+
+* raw MIME walk that keeps the HTML part (``normalize_message`` drops hrefs);
+* ``<a href>`` extraction with anchor text / image alt;
+* noise filtering (unsubscribe, preferences, share, social, app stores, …);
+* tracking-redirect decoding — local first (ConvertKit/Kit/HBR base64 path
+  segments, McKinsey host rewrite, Substack ``post_id`` dedupe), then a bounded,
+  cached HTTP hop (Substack redirect, beehiiv, SendGrid, Mailchimp, …).
+
+Nothing here writes to Gmail. Credentials / tokens come from
+``config.json → newsletter_triage`` (paths under the gitignored ``auth/``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from urllib.parse import parse_qs, urlsplit, urlunsplit
+
+import requests
+
+from config.loader import load_block
+from gmail_readonly.core import GmailLabel, GmailMailbox, GmailSearch
+from gmail_readonly.google_client import build_google_read_client
+from newsletter.cache import canonicalize_url
+
+logger = logging.getLogger("newsletter_triage.gmail")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MIN_ANCHOR_CHARS = 12
+
+# ---------------------------------------------------------------------------
+# records
+
+
+@dataclass
+class Link:
+    """One anchor found in an email, progressively resolved."""
+
+    href: str
+    text: str = ""
+    alt: str = ""
+    target: Optional[str] = None      # decoded / resolved final URL (None = unresolved)
+    via: str = "raw"                  # raw | direct | b64 | host-rewrite | http | http-fail
+    noise: bool = False
+    noise_reason: str = ""
+
+    @property
+    def label(self) -> str:
+        return self.text or self.alt
+
+    @property
+    def best_url(self) -> str:
+        return self.target or self.href
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.target)
+
+    @property
+    def canonical(self) -> str:
+        return canonicalize_url(canonical_substack(self.best_url))
+
+
+@dataclass
+class EmailRecord:
+    message_id: str
+    thread_id: Optional[str]
+    timestamp: str                    # ISO-8601 UTC
+    sender_name: str
+    sender_address: str
+    subject: str
+    links: List[Link] = field(default_factory=list)
+
+    def to_json(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_json(cls, d: Dict[str, Any]) -> "EmailRecord":
+        return cls(message_id=d["message_id"], thread_id=d.get("thread_id"),
+                   timestamp=d["timestamp"], sender_name=d.get("sender_name", ""),
+                   sender_address=d.get("sender_address", ""),
+                   subject=d.get("subject", ""),
+                   links=[Link(**x) for x in d.get("links", [])])
+
+
+# ---------------------------------------------------------------------------
+# config + mailbox
+
+
+def load_triage_config() -> Dict[str, Any]:
+    return load_block("newsletter_triage")
+
+
+@dataclass
+class TriageMailbox:
+    """The vendored facade plus the underlying client (for raw ``format=full`` reads)."""
+
+    client: Any
+    mailbox: GmailMailbox
+
+    def close(self) -> None:
+        self.mailbox.close()
+
+
+def build_mailbox(cfg: Optional[Dict[str, Any]] = None) -> TriageMailbox:
+    cfg = cfg or load_triage_config()
+    token_path = REPO_ROOT / cfg.get("gmail_token_path", "auth/gmail/token.json")
+    if not token_path.exists():
+        raise FileNotFoundError(
+            f"Gmail token not found at {token_path} — copy auth/gmail/credentials.json + "
+            f"token.json from the sibling repo or run `python -m gmail_readonly.oauth` "
+            f"(see newsletter/README.md)")
+    client = build_google_read_client(token_path)
+    return TriageMailbox(client=client, mailbox=GmailMailbox(client))
+
+
+def label_search(tm: TriageMailbox, label_name: str, *,
+                 lookback_days: Optional[int] = None,
+                 query: str = "") -> GmailSearch:
+    """Resolve ``label_name`` → a ``GmailSearch`` (fails closed if the label is missing)."""
+    (source,) = tm.mailbox.resolve_sources(
+        labels=(GmailLabel(name=label_name, display_name=label_name),),
+        lookback_days=lookback_days,
+    )
+    search = source.search
+    if query:
+        search = GmailSearch(query=" ".join(p for p in (search.query, query) if p),
+                             label_ids=search.label_ids, lookback_days=search.lookback_days)
+    return search
+
+
+def fetch_raw_messages(tm: TriageMailbox, search: GmailSearch, *,
+                       limit: Optional[int] = None,
+                       skip_ids: Optional[set] = None) -> List[Dict[str, Any]]:
+    """Message ids → raw ``format=full`` payloads (batched when the client can)."""
+    ids = tm.mailbox.search_ids(search)
+    if skip_ids:
+        ids = [i for i in ids if i not in skip_ids]
+    if limit is not None:
+        ids = ids[:limit]
+    if not ids:
+        return []
+    bulk = getattr(tm.client, "get_messages", None)
+    if callable(bulk):
+        return bulk(ids, metadata_only=False)
+    return [tm.client.get_message(i, metadata_only=False) for i in ids]
+
+
+# ---------------------------------------------------------------------------
+# MIME walk
+
+
+def _iter_parts(part: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+    yield part
+    for child in part.get("parts") or []:
+        yield from _iter_parts(child)
+
+
+def _decode_body(data: str) -> str:
+    raw = base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+    return raw.decode("utf-8", "replace")
+
+
+def message_html(raw: Dict[str, Any]) -> Tuple[str, str]:
+    """Return ``(html, plain)`` bodies of a Gmail ``format=full`` message.
+
+    Parts with a filename (attachments) are skipped — never downloaded.
+    """
+    html_parts: List[str] = []
+    plain_parts: List[str] = []
+    for part in _iter_parts(raw.get("payload") or {}):
+        if part.get("filename"):
+            continue
+        data = (part.get("body") or {}).get("data")
+        if not data:
+            continue
+        mime = (part.get("mimeType") or "").lower()
+        if mime == "text/html":
+            html_parts.append(_decode_body(data))
+        elif mime == "text/plain":
+            plain_parts.append(_decode_body(data))
+    return "".join(html_parts), "".join(plain_parts)
+
+
+def _headers(raw: Dict[str, Any]) -> Dict[str, str]:
+    return {str(h.get("name", "")).lower(): str(h.get("value", ""))
+            for h in (raw.get("payload") or {}).get("headers") or [] if h.get("name")}
+
+
+def _timestamp(raw: Dict[str, Any], hdr: Dict[str, str]) -> str:
+    try:
+        ms = int(raw.get("internalDate") or 0)
+        if ms:
+            return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat()
+    except (TypeError, ValueError):
+        pass
+    if hdr.get("date"):
+        try:
+            return parsedate_to_datetime(hdr["date"]).astimezone(timezone.utc).isoformat()
+        except (TypeError, ValueError):
+            pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# anchor extraction
+
+
+class _AnchorParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.links: List[Link] = []
+        self._cur: Optional[Link] = None
+        self._skip_depth = 0          # inside <style>/<script>
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        a = {k: (v or "") for k, v in attrs}
+        if tag in ("style", "script"):
+            self._skip_depth += 1
+            return
+        if tag == "a":
+            self._cur = Link(href=a.get("href", "").strip())
+            return
+        if tag == "img" and self._cur is not None:
+            alt = " ".join(a.get("alt", "").split())
+            if alt and not self._cur.alt:
+                self._cur.alt = alt
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("style", "script"):
+            self._skip_depth = max(0, self._skip_depth - 1)
+            return
+        if tag == "a" and self._cur is not None:
+            self._cur.text = " ".join(self._cur.text.split())
+            if self._cur.href:
+                self.links.append(self._cur)
+            self._cur = None
+
+    def handle_data(self, data: str) -> None:
+        if self._cur is not None and not self._skip_depth:
+            self._cur.text += " " + data
+
+
+_URL_IN_TEXT = re.compile(r"https?://[^\s<>\"')\]]+")
+
+
+def extract_links(html: str, plain: str = "") -> List[Link]:
+    """Anchors from the HTML part; bare URLs from the text part if there is no HTML."""
+    if html:
+        parser = _AnchorParser()
+        try:
+            parser.feed(html)
+            parser.close()
+        except Exception as exc:  # malformed markup — keep what we have
+            logger.debug("anchor parse stopped early: %s", exc)
+        return parser.links
+    return [Link(href=m.group(0).rstrip(".,;")) for m in _URL_IN_TEXT.finditer(plain or "")]
+
+
+# ---------------------------------------------------------------------------
+# noise filter
+
+_NOISE_ANCHOR = re.compile(
+    r"^(?:\W*)(?:unsubscribe|manage (?:your )?(?:email )?preferences|update (?:your )?preferences|"
+    r"email preferences|preferences|view (?:this )?(?:email |newsletter |message )?(?:in|on) (?:your )?browser|"
+    r"view online|read online|open in (?:app|browser)|view in browser|forward(?: this)?(?: email)?(?: to a friend)?|"
+    r"share(?: this)?(?: post| newsletter| email)?(?: (?:on|to|via) [\w+ ]+)?|tweet|like|comment|restack|reply|"
+    r"subscribe(?: now| here)?|upgrade(?: to paid| your subscription)?|become a (?:paid )?(?:member|subscriber)|sign in|log in|start writing|"
+    r"privacy(?: policy)?|terms(?: of (?:service|use))?|contact(?: us)?|about(?: us)?|advertise|sponsor(?:ship)?s?|"
+    r"refer a friend|leave a comment|download (?:the )?app|get the app|app store|google play|"
+    r"twitter|x|facebook|linkedin|instagram|youtube|threads|tiktok|spotify|apple podcasts|"
+    r"here|click here|read more|learn more|more|continue reading|keep reading|read the full (?:article|story|post)|"
+    r"©.*|\d{4})\W*$",
+    re.IGNORECASE,
+)
+# Generic CTAs ("read more") are noise *as anchor text* — the same target is
+# almost always present as a titled anchor too; dedupe keeps the titled one.
+
+_NOISE_URL = re.compile(
+    r"(?:unsubscribe|/preferences|/profile\b|list-manage\.com/(?:profile|vcard|about)|"
+    r"manage[_-]?(?:subscription|preferences)|/email-settings|/settings|"
+    r"substack\.com/(?:app-link/(?:comment|reaction|restack|share|cancel|subscribe|profile|open-app)|"
+    r"subscribe|signup|profile/|users/|redirect/ios|app-store|sign-in|account|leaderboard|notes)|"
+    r"open\.substack\.com/users/|"
+    r"(?:twitter|x)\.com/intent|facebook\.com/sharer|linkedin\.com/(?:share|shareArticle|company/|in/)|"
+    r"apps\.apple\.com|play\.google\.com|itunes\.apple\.com|"
+    r"/privacy|/terms|/legal|^mailto:|^tel:|^sms:|"
+    r"^https?://(?:www\.)?(?:facebook|instagram|tiktok|pinterest|threads)\.(?:com|net)/?[^/]*/?$|"
+    r"^https?://(?:www\.)?(?:twitter|x)\.com/[^/]+/?$|"
+    r"^https?://(?:www\.)?youtube\.com/(?:@|channel/|c/|user/)[^/]*/?$|"
+    r"^https?://(?:www\.)?linkedin\.com/?$|"
+    r"beehiiv\.com/(?:login|subscribe)|"
+    r"convertkit-mail\d*\.com/\w+/(?:unsubscribe|preferences)|preferences\.convertkit|"
+    r"\.(?:png|jpe?g|gif|webp|svg|ico)(?:\?|$))",
+    re.IGNORECASE,
+)
+
+
+def classify_noise(link: Link, *, min_anchor_chars: int = DEFAULT_MIN_ANCHOR_CHARS) -> None:
+    """Mark ``link.noise`` in place. Rules are deliberately conservative."""
+    href = link.href
+    if not href.lower().startswith(("http://", "https://")):
+        link.noise, link.noise_reason = True, "non-http"
+        return
+    if _NOISE_URL.search(href):
+        link.noise, link.noise_reason = True, "url-pattern"
+        return
+    label = link.label
+    if _NOISE_ANCHOR.match(label or ""):
+        link.noise, link.noise_reason = True, "anchor-pattern"
+        return
+    if len(label) < min_anchor_chars:
+        link.noise, link.noise_reason = True, "short-anchor"
+        return
+
+
+# ---------------------------------------------------------------------------
+# redirect decoding — local
+
+
+def _b64_url(segment: str) -> Optional[str]:
+    seg = segment.strip()
+    if len(seg) < 12:
+        return None
+    for decoder in (base64.urlsafe_b64decode, base64.b64decode):
+        try:
+            out = decoder(seg + "=" * (-len(seg) % 4))
+        except Exception:
+            continue
+        text = out.decode("utf-8", "ignore")
+        if text.startswith(("http://", "https://")):
+            return re.split(r"[\x00-\x1f\x7f]", text, 1)[0]
+        if text.startswith("{"):
+            url = _json_url(text)
+            if url:
+                return url
+    return None
+
+
+def _json_url(text: str) -> Optional[str]:
+    """``{"e": "https://…"}`` (Substack ``redirect/2/``) and friends."""
+    try:
+        data = json.loads(re.split(r"[\x00-\x1f\x7f]", text, 1)[0])
+    except Exception:
+        return None
+    if isinstance(data, dict):
+        for key in ("e", "u", "url", "href", "link", "redirect"):
+            val = data.get(key)
+            if isinstance(val, str) and val.startswith("http"):
+                return val
+    return None
+
+
+def _jwt_url(segment: str) -> Optional[str]:
+    if segment.count(".") != 2:
+        return None
+    try:
+        payload = base64.urlsafe_b64decode(segment.split(".")[1] + "==")
+        data = json.loads(payload)
+    except Exception:
+        return None
+    if isinstance(data, dict):
+        for key in ("u", "url", "href", "link", "redirect"):
+            val = data.get(key)
+            if isinstance(val, str) and val.startswith("http"):
+                return val
+    return None
+
+
+_HOST_REWRITE = {
+    "email.mckinsey.com": "www.mckinsey.com",
+}
+
+_SUBSTACK_POST = re.compile(r"^https?://(?:www\.)?substack\.com/app-link/post\?")
+_OPEN_SUBSTACK = re.compile(r"^https?://open\.substack\.com/pub/([^/]+)/p/([^/?#]+)")
+
+_CTA_LAST_SEGMENT_HOSTS = ("convertkit-mail", "kit-mail", "click.fourhourmail", "link.hbr.org")
+
+# Subdomain labels that mark a tracking / click redirector (matched against the
+# labels *before* the registrable domain, so ``news.ycombinator.com`` is not one
+# but ``link.mail.beehiiv.com`` and ``59b90e10.click.convertkit-mail4.com`` are).
+_REDIRECT_LABELS = {
+    "click", "clicks", "trk", "track", "tracking", "link", "links", "lnk", "email",
+    "email2", "mail", "mg", "go", "t", "ct", "cl", "url", "e", "mailer", "mta",
+    "links2", "clk", "r", "redirect", "eomail", "em", "l", "c",
+}
+_REDIRECT_HOST_SUBSTR = (
+    "sendgrid.net", "list-manage.com", "convertkit", "kit-mail", "hubspotlinks",
+    "mailchi.mp", "bit.ly", "t.co", "lnkd.in", "buff.ly", "ow.ly", "r20.rs6.net",
+    "mandrillapp.com", "e2ma.net", "acemlnb.com", "activehosted.com", "campaign-archive",
+    "beehiiv.com", "mailgun", "sparkpostmail", "exacttarget", "rs6.net",
+)
+_REDIRECT_PATH_SUBSTR = ("substack.com/redirect/", "substack.com/app-link/",
+                         "firstround.com/c/", "/ls/click", "/track/click", "/lt.php")
+
+
+def is_redirector(url: str) -> bool:
+    low = url.lower()
+    parts = urlsplit(low)
+    host = parts.netloc
+    hostpath = host + parts.path
+    if any(s in hostpath for s in _REDIRECT_PATH_SUBSTR):
+        return True
+    if any(s in host for s in _REDIRECT_HOST_SUBSTR):
+        return True
+    labels = host.split(".")
+    return any(lbl in _REDIRECT_LABELS for lbl in labels[:-2])
+
+
+def decode_local(link: Link) -> None:
+    """Fill ``link.target`` without any network call when the href encodes it."""
+    href = link.href
+    parts = urlsplit(href)
+    host = parts.netloc.lower()
+    if host in _HOST_REWRITE:
+        link.target = urlunsplit((parts.scheme, _HOST_REWRITE[host], parts.path, parts.query, ""))
+        link.via = "host-rewrite"
+        return
+    segments = [s for s in parts.path.split("/") if s]
+    query_vals = [v for vs in parse_qs(parts.query).values() for v in vs]
+    ordered = list(reversed(segments)) if any(h in host for h in _CTA_LAST_SEGMENT_HOSTS) else segments
+    for seg in ordered:
+        url = _b64_url(seg)
+        if url:
+            link.target, link.via = url, "b64"
+            return
+    for val in query_vals:
+        url = _b64_url(val) or _jwt_url(val)
+        if url:
+            link.target, link.via = url, "b64"
+            return
+    if not is_redirector(href):
+        link.target, link.via = href, "direct"
+
+
+def substack_post_key(link: Link) -> Optional[str]:
+    """Dedupe/cache key for Substack app-link anchors pointing at the same post."""
+    if _SUBSTACK_POST.match(link.href):
+        q = parse_qs(urlsplit(link.href).query)
+        pid = (q.get("post_id") or [None])[0]
+        if pid:
+            return f"substack:post:{pid}"
+    return None
+
+
+def canonical_substack(url: str) -> str:
+    """``open.substack.com/pub/<pub>/p/<slug>`` → ``<pub>.substack.com/p/<slug>``."""
+    m = _OPEN_SUBSTACK.match(url or "")
+    if m:
+        return f"https://{m.group(1)}.substack.com/p/{m.group(2)}"
+    return url
+
+
+# ---------------------------------------------------------------------------
+# redirect resolution — HTTP, cached, bounded
+
+
+class RedirectCache:
+    """JSON-file cache ``{href_or_key: final_url | ""}`` with atomic writes."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._lock = threading.Lock()
+        self._data: Dict[str, str] = {}
+        if path.exists():
+            try:
+                self._data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("⚠️ redirect cache unreadable (%s) — starting empty", exc)
+        self._dirty = 0
+
+    def get(self, key: str) -> Optional[str]:
+        return self._data.get(key)
+
+    def put(self, key: str, value: str) -> None:
+        with self._lock:
+            self._data[key] = value
+            self._dirty += 1
+            if self._dirty >= 200:
+                self._flush_locked()
+
+    def flush(self) -> None:
+        with self._lock:
+            self._flush_locked()
+
+    def _flush_locked(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._data, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(self.path)
+        self._dirty = 0
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+       "(KHTML, like Gecko) Chrome/128.0 Safari/537.36")
+
+
+def _session(pool_size: int = 16) -> requests.Session:
+    s = requests.Session()
+    s.headers["User-Agent"] = _UA
+    s.max_redirects = 10
+    adapter = requests.adapters.HTTPAdapter(pool_connections=pool_size, pool_maxsize=pool_size)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
+_MAX_HOPS = 10
+
+
+def _follow(session: requests.Session, method: str, url: str, *, timeout: float,
+            deadline: float) -> Tuple[int, str]:
+    """Follow ``Location`` hops manually — bodies are never read.
+
+    ``requests``' own ``allow_redirects`` consumes every intermediate body, and
+    a single endless / huge response (streaming endpoint, gzip bomb, bot wall
+    page) then pins a CPU core forever with no timeout firing. Here each hop is
+    a streamed request closed immediately, bounded by ``_MAX_HOPS`` and a wall-
+    clock ``deadline``. Returns ``(status_code, final_url)``.
+    """
+    cur = url
+    for _ in range(_MAX_HOPS):
+        if time.monotonic() > deadline:
+            raise requests.Timeout("resolve deadline exceeded")
+        resp = session.request(method, cur, allow_redirects=False, timeout=timeout, stream=True)
+        try:
+            status = resp.status_code
+            loc = resp.headers.get("Location")
+        finally:
+            resp.close()
+        if status in (301, 302, 303, 307, 308) and loc:
+            cur = requests.compat.urljoin(cur, loc)
+            continue
+        return status, cur
+    return 599, cur  # too many redirects — treated as a failure
+
+
+def resolve_one(session: requests.Session, href: str, *, timeout: float = 10.0) -> Tuple[str, str]:
+    """Follow redirects; return ``(final_url, status)`` where status ∈ http|http-fail.
+
+    HEAD first; GET (streamed, body never read) when HEAD is refused (405/404
+    on e2ma/firstround-style redirectors) or when HEAD did not leave the
+    redirector. A URL that simply answers for itself is its own target.
+    """
+    deadline = time.monotonic() + 3 * timeout
+    try:
+        status, final = _follow(session, "HEAD", href, timeout=timeout, deadline=deadline)
+        if status < 400 and (final != href or not is_redirector(final)):
+            return final, "http"
+        status, final = _follow(session, "GET", href, timeout=timeout, deadline=deadline)
+        if status < 400:
+            return final, "http"
+        return "", "http-fail"
+    except (requests.RequestException, ValueError) as exc:
+        logger.debug("resolve failed for %s: %s", href[:80], type(exc).__name__)
+        return "", "http-fail"
+
+
+def resolve_links(links: Iterable[Link], cache: RedirectCache, *, workers: int = 8,
+                  timeout: float = 10.0, budget: Optional[int] = None) -> Dict[str, int]:
+    """Resolve unresolved, non-noise links over HTTP, using/filling ``cache``.
+
+    ``budget`` caps the number of *network* keys this call may spend; cache
+    hits are free. N anchors with the same key cost one request.
+    """
+    stats = {"cached": 0, "resolved": 0, "failed": 0, "skipped-budget": 0}
+    by_key: Dict[str, List[Link]] = {}
+    for link in links:
+        if link.resolved or link.noise or link.via == "http-fail":
+            continue
+        key = substack_post_key(link) or link.href
+        hit = cache.get(key)
+        if hit is not None:
+            if hit:
+                link.target, link.via = hit, "http"
+                if _NOISE_URL.search(hit):
+                    link.noise, link.noise_reason = True, "url-pattern-resolved"
+            else:
+                link.via = "http-fail"
+            stats["cached"] += 1
+            continue
+        by_key.setdefault(key, []).append(link)
+    keys = list(by_key)
+    if budget is not None and len(keys) > budget:
+        stats["skipped-budget"] = len(keys) - budget
+        keys = keys[:budget]
+    if not keys:
+        return stats
+    session = _session(pool_size=max(16, workers))
+    started = time.monotonic()
+
+    def work(key: str) -> Tuple[str, str, str]:
+        final, status = resolve_one(session, by_key[key][0].href, timeout=timeout)
+        return key, final, status
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(work, k) for k in keys]
+        done = 0
+        for fut in as_completed(futures):
+            key, final, _status = fut.result()
+            cache.put(key, final)
+            for link in by_key[key]:
+                if final:
+                    link.target, link.via = final, "http"
+                    stats["resolved"] += 1
+                    if _NOISE_URL.search(final):
+                        link.noise, link.noise_reason = True, "url-pattern-resolved"
+                else:
+                    link.via = "http-fail"
+                    stats["failed"] += 1
+            done += 1
+            if done % 500 == 0:
+                logger.info("  … %d/%d redirect keys resolved (%.0fs)", done, len(keys),
+                            time.monotonic() - started)
+    cache.flush()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# per-email pipeline
+
+
+def dedupe_links(links: List[Link]) -> List[Link]:
+    """Keep one anchor per target, preferring the one with the longest label."""
+    best: Dict[str, Link] = {}
+    order: List[str] = []
+    for link in links:
+        if link.resolved:
+            key = link.canonical
+        else:
+            key = substack_post_key(link) or (f"text:{link.label.lower()}" if link.label else link.href)
+        cur = best.get(key)
+        if cur is None:
+            best[key] = link
+            order.append(key)
+        elif len(link.label) > len(cur.label):
+            best[key] = link
+    return [best[k] for k in order]
+
+
+def build_record(raw: Dict[str, Any], *,
+                 min_anchor_chars: int = DEFAULT_MIN_ANCHOR_CHARS) -> Tuple[EmailRecord, str]:
+    """Gmail ``format=full`` message → ``EmailRecord`` (+ the HTML for caching).
+
+    Links are extracted, noise-classified, locally decoded and deduped; HTTP
+    resolution is a separate, explicit step (``resolve_links``).
+    """
+    hdr = _headers(raw)
+    html, plain = message_html(raw)
+    name, addr = parseaddr(hdr.get("from", ""))
+    rec = EmailRecord(message_id=str(raw.get("id") or ""), thread_id=raw.get("threadId"),
+                      timestamp=_timestamp(raw, hdr), sender_name=name or addr,
+                      sender_address=addr.lower(), subject=(hdr.get("subject") or "").strip())
+    rec.links = links_from_html(html, plain, min_anchor_chars=min_anchor_chars)
+    return rec, html
+
+
+def links_from_html(html: str, plain: str = "", *,
+                    min_anchor_chars: int = DEFAULT_MIN_ANCHOR_CHARS) -> List[Link]:
+    """Extract → noise-classify → local-decode → dedupe. Pure; no network."""
+    links = extract_links(html, plain)
+    for link in links:
+        classify_noise(link, min_anchor_chars=min_anchor_chars)
+        if not link.noise:
+            decode_local(link)
+            if link.target and link.target != link.href and _NOISE_URL.search(link.target):
+                link.noise, link.noise_reason = True, "url-pattern-decoded"
+    return dedupe_links([l for l in links if not l.noise])

--- a/newsletter/triage/history.py
+++ b/newsletter/triage/history.py
@@ -1,0 +1,609 @@
+"""Build the newsletter-triage history dataset and its statistics.
+
+Ground truth for the criteria (issue #210):
+
+* **positives** — every Notion article with an edition (``news``) relation in
+  the window: title, URL, topic, author, edition number/date, star, must-read;
+* **offered** — every non-noise link in every email of the Gmail label over the
+  same window (sender, subject, date, anchor text, decoded/resolved URL);
+* **join** — positives → the email link they came from (exact canonical URL →
+  Substack slug → fuzzy anchor-vs-title), with the unmatched share reported;
+* **stats** — per-sender offered/selected/hit-rate, per-domain and per-author
+  caps actually observed per edition, topic mix, star rate, title patterns.
+
+Outputs under ``results/newsletter/triage/history/`` (gitignored):
+``emails.jsonl``, ``positives.jsonl``, ``matches.jsonl``, ``stats.json``,
+``stats.md``, ``raw/<message_id>.html.gz``.
+
+Usage::
+
+    python -m newsletter.triage.history [--weeks 54] [--no-gmail] [--no-resolve]
+                                        [--budget N] [--reextract] [--debug]
+
+Incremental: already-downloaded emails are not re-fetched; ``--reextract``
+re-runs link extraction from the cached HTML (after a rule change).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import re
+import sys
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rapidfuzz import fuzz, utils as rf_utils  # noqa: E402
+
+from config.console import force_utf8_stdio  # noqa: E402
+from config.loader import load_block, load_full_config  # noqa: E402
+from newsletter import notion_io  # noqa: E402
+from newsletter.cache import canonicalize_url  # noqa: E402
+from newsletter.triage import gmail as gm  # noqa: E402
+
+logger = logging.getLogger("newsletter_triage.history")
+
+HISTORY_DIR = REPO_ROOT / "results" / "newsletter" / "triage" / "history"
+REDIRECT_CACHE = REPO_ROOT / "results" / "newsletter" / "triage" / "redirects.json"
+
+TOPICS = ("leadership and management", "personal development", "innovation")
+
+# ---------------------------------------------------------------------------
+# small io helpers
+
+
+def _write_jsonl(path: Path, rows: Iterable[Dict[str, Any]]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    n = 0
+    with tmp.open("w", encoding="utf-8") as fp:
+        for row in rows:
+            fp.write(json.dumps(row, ensure_ascii=False) + "\n")
+            n += 1
+    tmp.replace(path)
+    return n
+
+
+def _read_jsonl(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as fp:
+        return [json.loads(line) for line in fp if line.strip()]
+
+
+def _domain(url: str) -> str:
+    host = urlsplit(url or "").netloc.lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def _slug(url: str) -> str:
+    path = urlsplit(url or "").path.rstrip("/")
+    seg = path.rsplit("/", 1)[-1] if path else ""
+    return seg.lower() if len(seg) >= 12 else ""
+
+
+def _norm(text: str) -> str:
+    return rf_utils.default_process(text or "")
+
+
+# ---------------------------------------------------------------------------
+# 1. Gmail pull (incremental, cached HTML)
+
+
+def pull_emails(weeks: int, *, cfg: Dict[str, Any], reextract: bool = False,
+                limit: Optional[int] = None) -> List[gm.EmailRecord]:
+    emails_path = HISTORY_DIR / "emails.jsonl"
+    raw_dir = HISTORY_DIR / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    existing = {r["message_id"]: gm.EmailRecord.from_json(r) for r in _read_jsonl(emails_path)}
+    min_anchor = int(cfg.get("min_anchor_chars", gm.DEFAULT_MIN_ANCHOR_CHARS))
+
+    if reextract and existing:
+        logger.info("♻️ re-extracting links from %d cached HTML bodies", len(existing))
+        for mid, rec in existing.items():
+            gz = raw_dir / f"{mid}.html.gz"
+            if not gz.exists():
+                continue
+            with gzip.open(gz, "rt", encoding="utf-8") as fp:
+                html = fp.read()
+            rec.links = gm.links_from_html(html, min_anchor_chars=min_anchor)
+
+    tm = gm.build_mailbox(cfg)
+    try:
+        search = gm.label_search(tm, cfg.get("gmail_label", "newsletters"), lookback_days=weeks * 7)
+        ids = tm.mailbox.search_ids(search)
+        new_ids = [i for i in ids if i not in existing]
+        if limit is not None:
+            new_ids = new_ids[:limit]
+        logger.info("📬 label '%s': %d messages in %d weeks — %d already cached, %d to fetch",
+                    cfg.get("gmail_label", "newsletters"), len(ids), weeks, len(ids) - len(new_ids), len(new_ids))
+        batch = 200
+        for start in range(0, len(new_ids), batch):
+            chunk = new_ids[start:start + batch]
+            raws = tm.client.get_messages(chunk, metadata_only=False)
+            for raw in raws:
+                rec, html = gm.build_record(raw, min_anchor_chars=min_anchor)
+                existing[rec.message_id] = rec
+                with gzip.open(raw_dir / f"{rec.message_id}.html.gz", "wt", encoding="utf-8") as fp:
+                    fp.write(html)
+            _write_jsonl(emails_path, (r.to_json() for r in existing.values()))
+            logger.info("  … %d/%d fetched", min(start + batch, len(new_ids)), len(new_ids))
+    finally:
+        tm.close()
+    records = sorted(existing.values(), key=lambda r: r.timestamp)
+    _write_jsonl(emails_path, (r.to_json() for r in records))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# 2. Notion positives
+
+
+def _title(page: Dict[str, Any], prop: str) -> str:
+    return notion_io._read_title(page, prop)  # noqa: SLF001 — shared reader
+
+
+def _rich(page: Dict[str, Any], prop: str) -> str:
+    arr = page.get("properties", {}).get(prop, {}).get("rich_text", [])
+    return "".join(x.get("plain_text", "") for x in arr).strip()
+
+
+def load_positives(weeks: int) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Return ``(positives, editions)`` from Notion for editions dated within the window."""
+    cfg = load_full_config()
+    na = cfg["newsletter_archive"]
+    client = notion_io.init_client(cfg["notion"]["api_token"])
+    since = (date.today() - timedelta(weeks=weeks)).isoformat()
+
+    editions: Dict[str, Dict[str, Any]] = {}
+    for page in notion_io._iter_database(  # noqa: SLF001
+            client, na["newsletter_db_id"],
+            query_filter={"property": "Date", "date": {"on_or_after": since}},
+            sorts=[{"property": "Date", "direction": "ascending"}]):
+        props = page["properties"]
+        d = (props.get("Date", {}).get("date") or {}).get("start")
+        editions[page["id"]] = {
+            "id": page["id"], "number": _title(page, "number"), "date": d,
+            "title": _rich(page, "title"),
+            "n_leader": notion_io._read_rollup_number(page, "n leader"),  # noqa: SLF001
+            "n_innov": notion_io._read_rollup_number(page, "n innov"),  # noqa: SLF001
+            "n_persdev": notion_io._read_rollup_number(page, "n persdev"),  # noqa: SLF001
+            "substack": (props.get("substack", {}).get("url") or ""),
+        }
+    logger.info("📰 %d editions since %s", len(editions), since)
+
+    connections: Dict[str, str] = {}
+    for page in notion_io._iter_database(client, na["connections_db_id"]):  # noqa: SLF001
+        connections[page["id"]] = _title(page, "name")
+    logger.info("👤 %d connections", len(connections))
+
+    created_since = (date.today() - timedelta(weeks=weeks + 6)).isoformat()
+    positives: List[Dict[str, Any]] = []
+    for page in notion_io._iter_database(  # noqa: SLF001
+            client, na["articles_db_id"],
+            query_filter={"property": "created", "created_time": {"on_or_after": created_since}}):
+        props = page["properties"]
+        news = [r["id"] for r in props.get("news", {}).get("relation", [])]
+        eds = [editions[n] for n in news if n in editions]
+        if not eds:
+            continue
+        ed = eds[0]
+        url = props.get("link", {}).get("url") or ""
+        authors = [connections.get(r["id"], "?") for r in props.get("author or source", {}).get("relation", [])]
+        topic = (props.get("topic", {}).get("select") or {}).get("name")
+        positives.append({
+            "article_id": page["id"],
+            "title": _title(page, "article"),
+            "url": url,
+            "canonical": canonicalize_url(gm.canonical_substack(url)),
+            "domain": _domain(url),
+            "topic": topic,
+            "type": (props.get("type", {}).get("select") or {}).get("name"),
+            "authors": authors,
+            "author": authors[0] if authors else "",
+            "star": bool(props.get("star", {}).get("checkbox")),
+            "next": bool(props.get("next", {}).get("checkbox")),
+            "edition": ed["number"],
+            "edition_date": ed["date"],
+            "created": page.get("created_time", "")[:10],
+            "summary": _rich(page, "summary")[:400],
+            "niche": [n["name"] for n in props.get("niche", {}).get("multi_select", [])],
+        })
+    # must-read = first sentence of the edition title (build_newsletter._MUST_READ_PERM)
+    by_ed: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for p in positives:
+        by_ed[p["edition"]].append(p)
+    for ed in editions.values():
+        first = (ed["title"] or "").split(". ")[0].strip().rstrip(".")
+        if not first:
+            continue
+        best, score = None, 0.0
+        for p in by_ed.get(ed["number"], []):
+            s = fuzz.ratio(_norm(first), _norm(p["title"]))
+            if s > score:
+                best, score = p, s
+        if best is not None and score >= 85:
+            best["must_read"] = True
+        ed["must_read_title"] = first
+    for p in positives:
+        p.setdefault("must_read", False)
+    logger.info("✅ %d positives with an edition relation", len(positives))
+    return positives, sorted(editions.values(), key=lambda e: e["date"] or "")
+
+
+# ---------------------------------------------------------------------------
+# 3. HTTP resolution (bounded, prioritised)
+
+
+def resolve_offered(records: List[gm.EmailRecord], *, cfg: Dict[str, Any],
+                    budget: Optional[int]) -> Dict[str, int]:
+    cache = gm.RedirectCache(REDIRECT_CACHE)
+    todo: List[gm.Link] = []
+    for rec in records:
+        for link in rec.links:
+            if not link.resolved and not link.noise and link.via != "http-fail":
+                todo.append(link)
+    # priority: Substack headline posts first, then title-like anchors, then the rest
+    todo.sort(key=lambda l: (0 if gm.substack_post_key(l) else 1 if len(l.label) >= 25 else 2,
+                             -len(l.label)))
+    logger.info("🔗 %d unresolved redirector links (cache has %d entries, budget %s)",
+                len(todo), len(cache), budget)
+    stats = gm.resolve_links(todo, cache,
+                             workers=int(cfg.get("redirect_workers", 8)),
+                             timeout=float(cfg.get("redirect_timeout_s", 10)),
+                             budget=budget)
+    logger.info("🔗 resolve: %s", stats)
+    _write_jsonl(HISTORY_DIR / "emails.jsonl", (r.to_json() for r in records))
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# 4. join positives → offered links
+
+
+def join(positives: List[Dict[str, Any]], records: List[gm.EmailRecord]) -> List[Dict[str, Any]]:
+    by_canon: Dict[str, List[Tuple[gm.EmailRecord, gm.Link]]] = defaultdict(list)
+    by_slug: Dict[str, List[Tuple[gm.EmailRecord, gm.Link]]] = defaultdict(list)
+    all_links: List[Tuple[gm.EmailRecord, gm.Link, str]] = []
+    for rec in records:
+        for link in rec.links:
+            if link.noise:
+                continue
+            if link.resolved:
+                by_canon[link.canonical].append((rec, link))
+                s = _slug(link.canonical)
+                if s:
+                    by_slug[s].append((rec, link))
+            all_links.append((rec, link, _norm(link.label)))
+
+    # domain → senders (from resolved links) for the last-resort attribution
+    domain_senders: Dict[str, Counter] = defaultdict(Counter)
+    for rec in records:
+        for link in rec.links:
+            if link.resolved and not link.noise:
+                domain_senders[_domain(link.best_url)][rec.sender_address] += 1
+    by_sender: Dict[str, List[gm.EmailRecord]] = defaultdict(list)
+    for rec in records:
+        by_sender[rec.sender_address].append(rec)
+
+    matches: List[Dict[str, Any]] = []
+    for p in positives:
+        ed_date = date.fromisoformat(p["edition_date"]) if p.get("edition_date") else None
+        lo = (ed_date - timedelta(days=35)).isoformat() if ed_date else ""
+        hi = (ed_date + timedelta(days=2)).isoformat() if ed_date else "9999"
+
+        def in_window(rec: gm.EmailRecord) -> bool:
+            return lo <= rec.timestamp[:10] <= hi
+
+        found: Optional[Tuple[gm.EmailRecord, gm.Link]] = None
+        method = ""
+        cands = [c for c in by_canon.get(p["canonical"], []) if in_window(c[0])] or \
+                by_canon.get(p["canonical"], [])
+        if cands:
+            found, method = cands[0], "url"
+        if found is None:
+            s = _slug(p["canonical"])
+            if s:
+                cands = [c for c in by_slug.get(s, []) if in_window(c[0])] or by_slug.get(s, [])
+                if cands:
+                    found, method = cands[0], "slug"
+        if found is None and p["title"]:
+            title_n = _norm(p["title"])
+            best, score = None, 0.0
+            for rec, link, label_n in all_links:
+                if not label_n or not in_window(rec):
+                    continue
+                s = fuzz.ratio(title_n, label_n)
+                if s > score:
+                    best, score = (rec, link), s
+            if best is not None and score >= 90:
+                found, method = best, "title"
+            elif best is not None and score >= 80 and (
+                    _domain(best[1].best_url) == p["domain"] or not best[1].resolved):
+                found, method = best, "title~"
+        if found is None and p["domain"] in domain_senders:
+            # last resort: the sender that usually carries this domain, if it
+            # mailed inside the window (attribution only — link unknown)
+            for addr, _n in domain_senders[p["domain"]].most_common(3):
+                recs = [r for r in by_sender.get(addr, []) if in_window(r)]
+                if recs:
+                    found, method = (recs[-1], gm.Link(href="", text="")), "domain"
+                    break
+        row = {"article_id": p["article_id"], "title": p["title"], "edition": p["edition"],
+               "topic": p["topic"], "author": p["author"], "star": p["star"],
+               "must_read": p["must_read"], "domain": p["domain"], "method": method or "none"}
+        if found:
+            rec, link = found
+            row.update({"message_id": rec.message_id, "sender_name": rec.sender_name,
+                        "sender_address": rec.sender_address, "email_subject": rec.subject,
+                        "email_date": rec.timestamp[:10], "anchor": link.label,
+                        "link_url": link.best_url})
+        matches.append(row)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# 5. statistics
+
+
+_NEWS_HINT = re.compile(
+    r"\b(launch|launches|launched|releases?|released|announc|introduc|unveil|new model|"
+    r"gpt-?\d|claude \d|gemini \d|llama \d|openai|anthropic|deepmind|nvidia|funding|raises|"
+    r"valuation|ipo|acquir|ceo steps|layoffs?|earnings)\b", re.IGNORECASE)
+
+
+def compute_stats(positives: List[Dict[str, Any]], editions: List[Dict[str, Any]],
+                  records: List[gm.EmailRecord], matches: List[Dict[str, Any]]) -> Dict[str, Any]:
+    st: Dict[str, Any] = {}
+    st["window"] = {"emails": len(records),
+                    "first_email": records[0].timestamp[:10] if records else None,
+                    "last_email": records[-1].timestamp[:10] if records else None,
+                    "editions": len(editions), "positives": len(positives)}
+    # emails per week
+    per_week = Counter(datetime.fromisoformat(r.timestamp).strftime("%G-W%V") for r in records if r.timestamp)
+    st["emails_per_week"] = dict(sorted(per_week.items()))
+    weeks_vals = list(per_week.values())
+    st["emails_per_week_summary"] = {"min": min(weeks_vals) if weeks_vals else 0,
+                                     "median": sorted(weeks_vals)[len(weeks_vals) // 2] if weeks_vals else 0,
+                                     "max": max(weeks_vals) if weeks_vals else 0}
+    # links
+    all_links = [l for r in records for l in r.links]
+    st["links"] = {"kept_total": len(all_links),
+                   "per_email_avg": round(len(all_links) / max(1, len(records)), 1),
+                   "via": dict(Counter(l.via for l in all_links)),
+                   "noise": dict(Counter(l.noise_reason for l in all_links if l.noise))}
+    # match rate
+    st["match"] = dict(Counter(m["method"] for m in matches))
+    matched = [m for m in matches if m["method"] != "none"]
+    st["match"]["rate"] = round(len(matched) / max(1, len(matches)), 3)
+
+    # per sender: emails, offered, selected, topics, stars
+    sender_emails = Counter(); sender_offered = Counter()
+    sender_name: Dict[str, str] = {}
+    for r in records:
+        sender_emails[r.sender_address] += 1
+        sender_offered[r.sender_address] += sum(1 for l in r.links if not l.noise)
+        sender_name.setdefault(r.sender_address, r.sender_name)
+    sender_sel = Counter(); sender_star = Counter(); sender_topics: Dict[str, Counter] = defaultdict(Counter)
+    sender_eds: Dict[str, set] = defaultdict(set)
+    for m in matched:
+        a = m["sender_address"]
+        sender_sel[a] += 1
+        sender_star[a] += int(bool(m["star"]))
+        sender_topics[a][m["topic"] or "?"] += 1
+        sender_eds[a].add(m["edition"])
+    senders = []
+    for addr, n_em in sender_emails.most_common():
+        senders.append({"sender": sender_name.get(addr, addr), "address": addr, "emails": n_em,
+                        "offered_links": sender_offered[addr], "selected": sender_sel[addr],
+                        "editions_with_pick": len(sender_eds[addr]),
+                        "hit_rate_per_email": round(sender_sel[addr] / n_em, 2),
+                        "hit_rate_per_link": round(sender_sel[addr] / max(1, sender_offered[addr]), 3),
+                        "stars": sender_star[addr],
+                        "topics": dict(sender_topics[addr].most_common())})
+    senders.sort(key=lambda s: (-s["selected"], -s["emails"]))
+    st["senders"] = senders
+    st["senders_never_selected"] = [s for s in senders if s["selected"] == 0 and s["emails"] >= 3]
+
+    # per domain / per author caps observed per edition
+    def per_edition_max(key: str) -> Dict[str, Dict[str, Any]]:
+        out: Dict[str, Dict[str, Any]] = {}
+        counts: Dict[str, Counter] = defaultdict(Counter)
+        for p in positives:
+            counts[p[key]][p["edition"]] += 1
+        for val, c in counts.items():
+            if not val:
+                continue
+            total = sum(c.values())
+            out[val] = {"total": total, "editions": len(c), "max_per_edition": max(c.values()),
+                        "avg_per_edition": round(total / len(c), 2),
+                        "per_edition_hist": dict(Counter(c.values()))}
+        return dict(sorted(out.items(), key=lambda kv: -kv[1]["total"]))
+    st["domains"] = per_edition_max("domain")
+    st["authors"] = per_edition_max("author")
+
+    # topics / stars / must-read / type
+    st["topics"] = dict(Counter(p["topic"] for p in positives))
+    st["types"] = dict(Counter(p["type"] for p in positives))
+    st["stars"] = {"total": sum(p["star"] for p in positives),
+                   "per_topic": dict(Counter(p["topic"] for p in positives if p["star"])),
+                   "per_edition_hist": dict(Counter(Counter(p["edition"] for p in positives if p["star"]).values()))}
+    st["must_read"] = {"total": sum(p["must_read"] for p in positives),
+                       "per_topic": dict(Counter(p["topic"] for p in positives if p["must_read"])),
+                       "by_domain": dict(Counter(p["domain"] for p in positives if p["must_read"]).most_common(15)),
+                       "by_author": dict(Counter(p["author"] for p in positives if p["must_read"]).most_common(15))}
+    st["stars_by_domain"] = dict(Counter(p["domain"] for p in positives if p["star"]).most_common(20))
+    st["stars_by_author"] = dict(Counter(p["author"] for p in positives if p["star"]).most_common(20))
+
+    # per-edition composition
+    ed_rows = []
+    for ed in editions:
+        ps = [p for p in positives if p["edition"] == ed["number"]]
+        if not ps:
+            continue
+        doms = Counter(p["domain"] for p in ps)
+        auths = Counter(p["author"] for p in ps)
+        ed_rows.append({"edition": ed["number"], "date": ed["date"], "n": len(ps),
+                        "topics": dict(Counter(p["topic"] for p in ps)),
+                        "hbr": doms.get("hbr.org", 0),
+                        "max_same_domain": max(doms.values()), "max_same_author": max(auths.values()),
+                        "distinct_authors": len(auths), "stars": sum(p["star"] for p in ps),
+                        "must_read_topic": next((p["topic"] for p in ps if p["must_read"]), None)})
+    st["editions"] = ed_rows
+    st["edition_caps"] = {
+        "hbr_hist": dict(Counter(e["hbr"] for e in ed_rows)),
+        "max_same_author_hist": dict(Counter(e["max_same_author"] for e in ed_rows)),
+        "max_same_domain_hist": dict(Counter(e["max_same_domain"] for e in ed_rows)),
+        "must_read_topic_hist": dict(Counter(e["must_read_topic"] for e in ed_rows)),
+    }
+
+    # email date → edition date lag
+    lags = []
+    for m in matched:
+        ed = next((e for e in editions if e["number"] == m["edition"]), None)
+        if ed and ed.get("date") and m.get("email_date"):
+            lags.append((date.fromisoformat(ed["date"]) - date.fromisoformat(m["email_date"])).days)
+    st["lag_days_email_to_edition"] = dict(Counter(lags).most_common()) if lags else {}
+
+    # title / news-like
+    titles = [p["title"] for p in positives if p["title"]]
+    st["title_len"] = {"avg_chars": round(sum(map(len, titles)) / max(1, len(titles)), 1),
+                       "avg_words": round(sum(len(t.split()) for t in titles) / max(1, len(titles)), 1)}
+    st["news_like_selected"] = {"count": sum(1 for t in titles if _NEWS_HINT.search(t)),
+                                "share": round(sum(1 for t in titles if _NEWS_HINT.search(t)) / max(1, len(titles)), 3)}
+    offered_labels = [l.label for r in records for l in r.links if not l.noise and len(l.label) >= 25]
+    st["news_like_offered"] = {"count": sum(1 for t in offered_labels if _NEWS_HINT.search(t)),
+                               "share": round(sum(1 for t in offered_labels if _NEWS_HINT.search(t)) / max(1, len(offered_labels)), 3)}
+    # innovation picks: domain + keyword flavour
+    innov = [p for p in positives if p["topic"] == "innovation"]
+    st["innovation_domains"] = dict(Counter(p["domain"] for p in innov).most_common(25))
+    st["topic_domains"] = {t: dict(Counter(p["domain"] for p in positives if p["topic"] == t).most_common(20))
+                           for t in TOPICS}
+    st["topic_authors"] = {t: dict(Counter(p["author"] for p in positives if p["topic"] == t and p["author"]).most_common(20))
+                           for t in TOPICS}
+    st["innovation_news_like"] = {"count": sum(1 for p in innov if _NEWS_HINT.search(p["title"] or "")),
+                                  "share": round(sum(1 for p in innov if _NEWS_HINT.search(p["title"] or "")) / max(1, len(innov)), 3)}
+    st["unmatched_positives"] = [{"title": m["title"], "domain": m["domain"], "edition": m["edition"],
+                                  "topic": m["topic"]} for m in matches if m["method"] == "none"]
+    return st
+
+
+def render_stats_md(st: Dict[str, Any]) -> str:
+    L: List[str] = []
+    w = st["window"]
+    L.append("# Newsletter triage — history stats\n")
+    L.append(f"- emails: **{w['emails']}** ({w['first_email']} → {w['last_email']}), per week min/median/max "
+             f"{st['emails_per_week_summary']['min']}/{st['emails_per_week_summary']['median']}/{st['emails_per_week_summary']['max']}")
+    L.append(f"- editions: **{w['editions']}**, positives (selected articles): **{w['positives']}**")
+    lk = st["links"]
+    L.append(f"- kept links: {lk['kept_total']} ({lk['per_email_avg']}/email), via {lk['via']}")
+    L.append(f"- positives → email match: **{st['match']['rate']:.1%}** — {st['match']}\n")
+    L.append("## Per-edition caps observed\n")
+    L.append(f"- HBR per edition histogram: {st['edition_caps']['hbr_hist']}")
+    L.append(f"- max same author per edition: {st['edition_caps']['max_same_author_hist']}")
+    L.append(f"- max same domain per edition: {st['edition_caps']['max_same_domain_hist']}")
+    L.append(f"- must-read topic: {st['edition_caps']['must_read_topic_hist']}")
+    L.append(f"- stars per topic: {st['stars']['per_topic']} · must-read by domain: {st['must_read']['by_domain']}\n")
+    L.append(f"- topics: {st['topics']} · types: {st['types']}")
+    L.append(f"- title length: {st['title_len']} · news-like selected {st['news_like_selected']} vs offered {st['news_like_offered']}")
+    L.append(f"- innovation news-like: {st['innovation_news_like']}")
+    for t, doms in st["topic_domains"].items():
+        L.append(f"- **{t}** domains: {doms}")
+        L.append(f"  authors: {st['topic_authors'][t]}")
+    L.append(f"- email→edition lag (days: count): {st['lag_days_email_to_edition']}\n")
+    L.append("## Senders (sorted by selected)\n")
+    L.append("| sender | emails | offered | selected | eds w/ pick | hit/email | hit/link | stars | topics |")
+    L.append("|---|---:|---:|---:|---:|---:|---:|---:|---|")
+    for s in st["senders"][:80]:
+        L.append(f"| {s['sender'][:40]} | {s['emails']} | {s['offered_links']} | {s['selected']} | {s['editions_with_pick']} | "
+                 f"{s['hit_rate_per_email']} | {s['hit_rate_per_link']} | {s['stars']} | {s['topics']} |")
+    L.append("\n### Senders with ≥3 emails and 0 picks\n")
+    L.append(", ".join(f"{s['sender']} ({s['emails']})" for s in st["senders_never_selected"][:80]) or "(none)")
+    L.append("\n## Domains of selected articles\n")
+    L.append("| domain | total | editions | max/edition | avg/edition |")
+    L.append("|---|---:|---:|---:|---:|")
+    for d, v in list(st["domains"].items())[:40]:
+        L.append(f"| {d} | {v['total']} | {v['editions']} | {v['max_per_edition']} | {v['avg_per_edition']} |")
+    L.append("\n## Authors of selected articles\n")
+    L.append("| author | total | editions | max/edition | avg/edition |")
+    L.append("|---|---:|---:|---:|---:|")
+    for a, v in list(st["authors"].items())[:50]:
+        L.append(f"| {a} | {v['total']} | {v['editions']} | {v['max_per_edition']} | {v['avg_per_edition']} |")
+    L.append(f"\n- stars by domain: {st['stars_by_domain']}")
+    L.append(f"- stars by author: {st['stars_by_author']}")
+    L.append(f"- must-read by author: {st['must_read']['by_author']}")
+    L.append("\n## Editions\n")
+    L.append("| edition | date | n | HBR | max same author | max same domain | distinct authors | stars | must-read topic |")
+    L.append("|---|---|---:|---:|---:|---:|---:|---:|---|")
+    for e in st["editions"]:
+        L.append(f"| {e['edition']} | {e['date']} | {e['n']} | {e['hbr']} | {e['max_same_author']} | {e['max_same_domain']} | "
+                 f"{e['distinct_authors']} | {e['stars']} | {e['must_read_topic']} |")
+    L.append(f"\n## Unmatched positives ({len(st['unmatched_positives'])})\n")
+    for u in st["unmatched_positives"][:200]:
+        L.append(f"- {u['edition']} · {u['topic']} · {u['domain']} · {u['title']}")
+    return "\n".join(L) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    force_utf8_stdio()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--weeks", type=int, default=None)
+    ap.add_argument("--no-gmail", action="store_true", help="use cached emails.jsonl only")
+    ap.add_argument("--no-resolve", action="store_true", help="skip HTTP redirect resolution")
+    ap.add_argument("--budget", type=int, default=None, help="max HTTP resolutions this run")
+    ap.add_argument("--reextract", action="store_true", help="re-run link extraction from cached HTML")
+    ap.add_argument("--limit", type=int, default=None, help="fetch at most N new emails (smoke test)")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s", stream=sys.stdout)
+    logging.getLogger("googleapiclient").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("notion_client").setLevel(logging.WARNING)
+
+    cfg = load_block("newsletter_triage")
+    weeks = args.weeks or int(cfg.get("history_weeks", 54))
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.no_gmail:
+        records = [gm.EmailRecord.from_json(r) for r in _read_jsonl(HISTORY_DIR / "emails.jsonl")]
+        if args.reextract:
+            records = pull_emails(weeks, cfg=cfg, reextract=True, limit=0)
+        logger.info("📬 %d cached emails", len(records))
+    else:
+        records = pull_emails(weeks, cfg=cfg, reextract=args.reextract, limit=args.limit)
+
+    positives, editions = load_positives(weeks)
+    _write_jsonl(HISTORY_DIR / "positives.jsonl", positives)
+    _write_jsonl(HISTORY_DIR / "editions.jsonl", editions)
+
+    if not args.no_resolve:
+        budget = args.budget if args.budget is not None else int(cfg.get("redirect_budget_history", 6000))
+        resolve_offered(records, cfg=cfg, budget=budget)
+
+    matches = join(positives, records)
+    _write_jsonl(HISTORY_DIR / "matches.jsonl", matches)
+    st = compute_stats(positives, editions, records, matches)
+    (HISTORY_DIR / "stats.json").write_text(json.dumps(st, ensure_ascii=False, indent=1), encoding="utf-8")
+    (HISTORY_DIR / "stats.md").write_text(render_stats_md(st), encoding="utf-8")
+    logger.info("📊 match rate %.1f%% (%s) — stats at %s", st["match"]["rate"] * 100, st["match"],
+                HISTORY_DIR / "stats.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/triage/overrides.json
+++ b/newsletter/triage/overrides.json
@@ -1,0 +1,15 @@
+{
+  "_doc": "Owner-maintained sender decisions, merged into criteria.json by `python -m newsletter.triage.criteria` and applied by the ranker BEFORE the data-derived priors. Keyed by sender address (lowercase). tier: never | rarely | usually | always | review. Updated by the Step-2 feedback loop (report ticks) and by hand for new senders.",
+  "senders": {
+    "gustavorazzetti@substack.com": {
+      "tier": "never",
+      "reason": "paywalled since 2026 — the newsletter never links paywalled content (it would be promotion, not content)",
+      "since": "2026-08-21"
+    },
+    "gustavorazzetti+fearless-culture@substack.com": {
+      "tier": "never",
+      "reason": "paywalled since 2026 — same publication as gustavorazzetti@substack.com",
+      "since": "2026-08-21"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,8 @@ scikit-learn>=1.9,<1.10
 # routed through the local LLM hub at http://127.0.0.1:8000 using the
 # version-free alias "claude_haiku" — no direct vendor traffic.
 anthropic
+# Read-only Gmail access for the newsletter triage (vendored gmail_readonly/ +
+# google_oauth_common/ from whatsapp-radar, byte-for-byte — see newsletter/README.md).
+google-api-python-client>=2.100
+google-auth-httplib2>=0.2
+google-auth-oauthlib>=1.2

--- a/tests/test_gmail_readonly.py
+++ b/tests/test_gmail_readonly.py
@@ -1,0 +1,558 @@
+"""Portable offline contract tests for the root-level Gmail component."""
+
+from __future__ import annotations
+
+import ast
+import base64
+from pathlib import Path
+from typing import Any
+
+import pytest
+from gmail_readonly import (
+    GMAIL_READONLY_SCOPE,
+    GmailLabel,
+    GmailMailbox,
+    GmailReadError,
+    GmailSearch,
+    GmailSender,
+    GoogleGmailReadClient,
+    build_google_read_client,
+    masked_email_address,
+)
+from gmail_readonly.oauth import authorize
+
+
+def _encoded(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, list[str] | None]] = []
+        self.metadata_modes: list[bool] = []
+        self.closed = False
+        self.messages = {
+            "newer": {
+                "id": "newer",
+                "threadId": "thread-2",
+                "internalDate": "1783681200000",
+                "labelIds": ["LBL_ACT"],
+                "payload": {
+                    "mimeType": "multipart/mixed",
+                    "headers": [
+                        {"name": "From", "value": "School Office <school@example.com>"},
+                        {"name": "To", "value": "family@example.net"},
+                        {"name": "Subject", "value": "Trip form"},
+                        {"name": "Message-ID", "value": "<newer@example.com>"},
+                    ],
+                    "parts": [
+                        {
+                            "mimeType": "text/plain",
+                            "filename": "",
+                            "body": {"data": _encoded("Return by Friday.")},
+                        },
+                        {
+                            "mimeType": "application/pdf",
+                            "filename": "private.pdf",
+                            "body": {"data": _encoded("must never be decoded")},
+                        },
+                    ],
+                },
+            },
+            "older": {
+                "id": "older",
+                "threadId": "thread-1",
+                "internalDate": "1783594800000",
+                "payload": {
+                    "mimeType": "text/html",
+                    "headers": [
+                        {"name": "From", "value": "Coach <coach@example.com>"},
+                        {"name": "Subject", "value": "Practice"},
+                    ],
+                    "body": {"data": _encoded("<p>Bring <strong>water</strong>.</p>")},
+                },
+            },
+        }
+
+    def get_profile(self) -> dict[str, Any]:
+        return {
+            "emailAddress": "family@example.net",
+            "messagesTotal": 12,
+            "threadsTotal": 8,
+        }
+
+    def list_labels(self) -> list[dict[str, Any]]:
+        return [
+            {"id": "LBL_ACT", "name": "Family/Activities"},
+            {"id": "LBL_URG", "name": "Family/Urgent"},
+        ]
+
+    def list_message_ids(
+        self,
+        *,
+        query: str,
+        label_ids: list[str] | None = None,
+    ) -> list[str]:
+        self.queries.append((query, label_ids))
+        return ["newer", "older"]
+
+    def get_message(
+        self,
+        message_id: str,
+        *,
+        metadata_only: bool = False,
+    ) -> dict[str, Any]:
+        self.metadata_modes.append(metadata_only)
+        return self.messages[message_id]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_component_imports_no_application_modules() -> None:
+    component_root = Path(__file__).parents[1] / "gmail_readonly"
+    imported_modules: set[str] = set()
+    for path in component_root.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_modules.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported_modules.add(node.module)
+    assert not any(
+        module == prefix or module.startswith(f"{prefix}.")
+        for module in imported_modules
+        for prefix in ("src", "app", "scripts")
+    )
+
+
+def test_whitelist_precedence_label_validation_and_bounded_queries() -> None:
+    mailbox = GmailMailbox(_FakeClient())
+    sources = mailbox.resolve_sources(
+        senders=(GmailSender("SCHOOL@example.com", "School"),),
+        labels=(
+            GmailLabel("Family/Activities", "Activities"),
+            GmailLabel("Family/Urgent", "Urgent"),
+        ),
+        lookback_days=60,
+    )
+
+    assert sources[0].source_id == "sender:school@example.com"
+    assert sources[0].search.api_query() == "from:school@example.com newer_than:60d"
+    assert sources[1].search.api_query() == "-from:school@example.com newer_than:60d"
+    assert sources[1].search.label_ids == ("LBL_ACT",)
+    assert sources[2].search.api_query() == (
+        '-from:school@example.com -label:"Family/Activities" newer_than:60d'
+    )
+    with pytest.raises(ValueError, match="not found"):
+        mailbox.resolve_sources(labels=(GmailLabel("Missing", "Missing"),))
+    with pytest.raises(ValueError, match="duplicate sender"):
+        mailbox.resolve_sources(
+            senders=(
+                GmailSender("same@example.com", "One"),
+                GmailSender("same@example.com", "Two"),
+            )
+        )
+
+
+def test_count_metadata_and_normalized_search_modes() -> None:
+    client = _FakeClient()
+    mailbox = GmailMailbox(client)
+    search = GmailSearch(query="from:school@example.com", lookback_days=60)
+
+    assert mailbox.count(search) == 2
+    assert client.metadata_modes == []
+    metadata = mailbox.metadata(search)
+    assert client.metadata_modes == [True, True]
+    assert metadata[0].message_id == "older"
+    client.metadata_modes.clear()
+    messages = mailbox.messages(search)
+
+    assert client.queries == [
+        ("from:school@example.com newer_than:60d", None),
+        ("from:school@example.com newer_than:60d", None),
+        ("from:school@example.com newer_than:60d", None),
+    ]
+    assert client.metadata_modes == [False, False]
+    assert [message.message_id for message in messages] == ["older", "newer"]
+    assert messages[0].text == "Subject: Practice\n\nBring water."
+    assert messages[1].text == "Subject: Trip form\n\nReturn by Friday."
+    assert "must never be decoded" not in str(messages)
+    assert messages[1].thread_id == "thread-2"
+    assert messages[1].headers["message-id"] == "<newer@example.com>"
+
+
+def test_discover_senders_groups_recent_metadata_by_address() -> None:
+    client = _FakeClient()
+    mailbox = GmailMailbox(client)
+
+    discovered = mailbox.discover_senders(days=30, limit=100)
+
+    # One entry per distinct From address, friendliest name kept, newest first.
+    assert [(sender.address, sender.display_name) for sender in discovered] == [
+        ("school@example.com", "School Office"),
+        ("coach@example.com", "Coach"),
+    ]
+    assert all(sender.message_count == 1 for sender in discovered)
+    # Discovery scans a bounded recent window and reads metadata only — never bodies.
+    assert client.queries[-1][0] == "newer_than:30d"
+    assert client.metadata_modes == [True, True]
+    with pytest.raises(ValueError, match="at least 1"):
+        mailbox.discover_senders(days=0, limit=100)
+    with pytest.raises(ValueError, match="at least 1"):
+        mailbox.discover_senders(days=30, limit=0)
+
+
+def test_profile_mask_safe_failures_and_cleanup() -> None:
+    client = _FakeClient()
+    mailbox = GmailMailbox(client)
+    profile = mailbox.profile()
+
+    assert profile.masked_email_address == "f***@example.net"
+    assert profile.messages_total == 12
+    assert masked_email_address("invalid") == "***"
+    mailbox.close()
+    assert client.closed is True
+
+    class _Response:
+        status = 429
+
+    class _FailingClient(_FakeClient):
+        def list_message_ids(
+            self,
+            *,
+            query: str,
+            label_ids: list[str] | None = None,
+        ) -> list[str]:
+            error = RuntimeError("private query and message content")
+            error.resp = _Response()  # type: ignore[attr-defined]
+            raise error
+
+    with pytest.raises(GmailReadError, match="quota exceeded") as caught:
+        GmailMailbox(_FailingClient()).count(GmailSearch(query="private"))
+    assert "private" not in str(caught.value)
+
+
+def test_message_retrieval_limit_bounds_full_fetches() -> None:
+    client = _FakeClient()
+    mailbox = GmailMailbox(client)
+
+    messages = mailbox.messages(GmailSearch(query="in:inbox"), limit=1)
+
+    assert [message.message_id for message in messages] == ["newer"]
+    assert client.metadata_modes == [False]
+    with pytest.raises(ValueError, match="limit must be at least 1"):
+        mailbox.messages(GmailSearch(query="in:inbox"), limit=0)
+
+
+def test_query_validation_rejects_unbounded_control_characters() -> None:
+    with pytest.raises(ValueError, match="single line"):
+        GmailSearch(query="from:a@example.com\nsubject:private").api_query()
+    with pytest.raises(ValueError, match="at least 1"):
+        GmailSearch(lookback_days=0).api_query()
+
+
+class _Request:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def execute(self) -> dict[str, Any]:
+        return self.payload
+
+
+class _MessagesResource:
+    def __init__(self) -> None:
+        self.list_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _Request:
+        self.list_calls.append(kwargs)
+        if len(self.list_calls) == 1:
+            return _Request({"messages": [{"id": "one"}], "nextPageToken": "next"})
+        return _Request({"messages": [{"id": "two"}]})
+
+    def get(self, **kwargs: Any) -> _Request:
+        self.get_calls.append(kwargs)
+        return _Request({"id": kwargs["id"]})
+
+
+class _UsersResource:
+    def __init__(self) -> None:
+        self.message_resource = _MessagesResource()
+
+    def messages(self) -> _MessagesResource:
+        return self.message_resource
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.user_resource = _UsersResource()
+
+    def users(self) -> _UsersResource:
+        return self.user_resource
+
+
+def test_google_client_paginates_and_requests_metadata_only() -> None:
+    service = _Service()
+    client = GoogleGmailReadClient(service)
+
+    assert client.list_message_ids(query="newer_than:60d", label_ids=["LBL"]) == [
+        "one",
+        "two",
+    ]
+    calls = service.user_resource.message_resource.list_calls
+    assert calls[0]["includeSpamTrash"] is False
+    assert calls[1]["pageToken"] == "next"
+    client.get_message("one", metadata_only=True)
+    get_call = service.user_resource.message_resource.get_calls[0]
+    assert get_call["format"] == "metadata"
+    assert "Subject" in get_call["metadataHeaders"]
+
+
+def test_token_absence_refresh_and_exact_scope(tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    with pytest.raises(FileNotFoundError, match="OAuth token missing"):
+        build_google_read_client(token_path)
+    token_path.write_text("{}", encoding="utf-8")
+    observed: dict[str, Any] = {}
+
+    class _Credentials:
+        expired = True
+        refresh_token = "present"
+        valid = True
+
+        def refresh(self, request: object) -> None:
+            observed["request"] = request
+
+        def to_json(self) -> str:
+            return '{"refreshed": true}'
+
+    credentials = _Credentials()
+
+    def load_credentials(path: str, scopes: list[str]) -> _Credentials:
+        observed["token_path"] = path
+        observed["scopes"] = scopes
+        return credentials
+
+    service = _Service()
+    client = build_google_read_client(
+        token_path,
+        credential_loader=load_credentials,
+        request_factory=lambda: "request",
+        service_builder=lambda *args, **kwargs: service,
+    )
+
+    assert isinstance(client, GoogleGmailReadClient)
+    assert observed["scopes"] == [GMAIL_READONLY_SCOPE]
+    assert observed["request"] == "request"
+    assert token_path.read_text(encoding="utf-8") == '{"refreshed": true}'
+    assert not token_path.with_suffix(".json.tmp").exists()
+
+
+def test_oauth_uses_explicit_paths_readonly_scope_and_atomic_write(tmp_path: Path) -> None:
+    credentials_path = tmp_path / "credentials.json"
+    token_path = tmp_path / "auth" / "token.json"
+    credentials_path.write_text("{}", encoding="utf-8")
+    observed: dict[str, Any] = {}
+
+    class _Credentials:
+        refresh_token = "present"
+
+        def to_json(self) -> str:
+            return '{"token": "secret"}'
+
+    class _Flow:
+        def run_local_server(self, **kwargs: Any) -> _Credentials:
+            observed["server"] = kwargs
+            return _Credentials()
+
+    def load_flow(path: str, scopes: list[str]) -> _Flow:
+        observed["credentials_path"] = path
+        observed["scopes"] = scopes
+        return _Flow()
+
+    authorize(
+        credentials_path=credentials_path,
+        token_path=token_path,
+        host="127.0.0.1",
+        port=8765,
+        open_browser=False,
+        flow_loader=load_flow,
+    )
+
+    assert observed["scopes"] == [GMAIL_READONLY_SCOPE]
+    assert observed["server"]["open_browser"] is False
+    assert observed["server"]["port"] == 8765
+    assert token_path.read_text(encoding="utf-8") == '{"token": "secret"}'
+
+
+def test_public_core_exposes_no_write_operations() -> None:
+    forbidden = {
+        "send",
+        "draft",
+        "modify",
+        "archive",
+        "trash",
+        "delete",
+        "insert",
+        "label",
+    }
+    assert forbidden.isdisjoint(set(dir(GmailMailbox)))
+    assert forbidden.isdisjoint(set(dir(GoogleGmailReadClient)))
+
+
+def test_mailbox_prefers_batched_get_messages_when_available() -> None:
+    class _BulkClient(_FakeClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bulk_calls: list[tuple[list[str], bool]] = []
+
+        def get_messages(
+            self, message_ids: list[str], *, metadata_only: bool = False
+        ) -> list[dict[str, Any]]:
+            self.bulk_calls.append((list(message_ids), metadata_only))
+            return [self.messages[message_id] for message_id in message_ids]
+
+    client = _BulkClient()
+    mailbox = GmailMailbox(client)
+
+    messages = mailbox.messages(GmailSearch(query="from:school@example.com"))
+
+    assert client.bulk_calls == [(["newer", "older"], False)]
+    assert client.metadata_modes == []  # per-message get_message never used
+    assert [message.message_id for message in messages] == ["older", "newer"]
+
+
+def test_timeout_surfaces_distinct_error_instead_of_generic_detail() -> None:
+    class _TimeoutClient(_FakeClient):
+        def get_message(
+            self, message_id: str, *, metadata_only: bool = False
+        ) -> dict[str, Any]:
+            raise TimeoutError("socket timed out")
+
+    mailbox = GmailMailbox(_TimeoutClient())
+
+    with pytest.raises(GmailReadError, match="timed out"):
+        mailbox.messages(GmailSearch(query="from:school@example.com"))
+
+
+def test_google_client_batches_gets_in_chunks_of_fifty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "gmail_readonly.google_client.time.sleep", lambda seconds: sleeps.append(seconds)
+    )
+
+    class _FakeRequest:
+        def __init__(self, response: dict[str, Any]) -> None:
+            self._response = response
+
+        def execute(self) -> dict[str, Any]:
+            return self._response
+
+    class _FakeBatch:
+        def __init__(self, callback: Any) -> None:
+            self._callback = callback
+            self.size = 0
+
+        def add(self, request: _FakeRequest, request_id: str) -> None:
+            self.size += 1
+            self._pending = getattr(self, "_pending", [])
+            self._pending.append((request_id, request))
+
+        def execute(self) -> None:
+            for request_id, request in self._pending:
+                self._callback(request_id, request.execute(), None)
+
+    class _BatchService:
+        def __init__(self) -> None:
+            self.batches: list[_FakeBatch] = []
+
+        def users(self) -> _BatchService:
+            return self
+
+        def messages(self) -> _BatchService:
+            return self
+
+        def get(self, **kwargs: Any) -> _FakeRequest:
+            return _FakeRequest({"id": kwargs["id"]})
+
+        def new_batch_http_request(self, callback: Any) -> _FakeBatch:
+            batch = _FakeBatch(callback)
+            self.batches.append(batch)
+            return batch
+
+    service = _BatchService()
+    client = GoogleGmailReadClient(service)
+    message_ids = [f"m{i}" for i in range(120)]
+
+    results = client.get_messages(message_ids)
+
+    assert [batch.size for batch in service.batches] == [50, 50, 20]
+    assert [raw["id"] for raw in results] == message_ids
+    # One pace pause between consecutive batches, none before the first.
+    assert sleeps == [1.0, 1.0]
+
+
+def test_google_client_retries_rate_limited_batch_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "gmail_readonly.google_client.time.sleep", lambda seconds: sleeps.append(seconds)
+    )
+
+    class _Response:
+        status = 429
+
+    class _FakeRequest:
+        def __init__(self, message_id: str) -> None:
+            self.message_id = message_id
+
+    class _RateLimitedService:
+        def __init__(self) -> None:
+            self.attempts: dict[str, int] = {}
+
+        def users(self) -> _RateLimitedService:
+            return self
+
+        def messages(self) -> _RateLimitedService:
+            return self
+
+        def get(self, **kwargs: Any) -> _FakeRequest:
+            return _FakeRequest(kwargs["id"])
+
+        def new_batch_http_request(self, callback: Any) -> Any:
+            service = self
+
+            class _Batch:
+                def __init__(self) -> None:
+                    self.pending: list[tuple[str, _FakeRequest]] = []
+
+                def add(self, request: _FakeRequest, request_id: str) -> None:
+                    self.pending.append((request_id, request))
+
+                def execute(self) -> None:
+                    for request_id, _request in self.pending:
+                        attempt = service.attempts.get(request_id, 0) + 1
+                        service.attempts[request_id] = attempt
+                        if request_id == "flaky" and attempt == 1:
+                            error = RuntimeError("rate limited")
+                            error.resp = _Response()  # type: ignore[attr-defined]
+                            callback(request_id, None, error)
+                        else:
+                            callback(request_id, {"id": request_id}, None)
+
+            return _Batch()
+
+    service = _RateLimitedService()
+    client = GoogleGmailReadClient(service)
+
+    results = client.get_messages(["steady", "flaky"])
+
+    # The 429'd item is retried alone after a backoff pause; nothing is lost
+    # and nothing non-flaky is re-fetched.
+    assert [raw["id"] for raw in results] == ["steady", "flaky"]
+    assert service.attempts == {"steady": 1, "flaky": 2}
+    assert sleeps == [1]

--- a/tests/test_triage_criteria.py
+++ b/tests/test_triage_criteria.py
@@ -1,0 +1,58 @@
+"""Pure tests for newsletter.triage.criteria — rules shape + priors derivation."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from newsletter.triage import criteria as cr  # noqa: E402
+
+_STATS = {
+    "window": {"emails": 10, "editions": 2, "positives": 5, "first_email": "2025-08-08", "last_email": "2026-08-21"},
+    "match": {"rate": 0.9},
+    "senders": [
+        {"sender": "Strong", "address": "strong@example.com", "emails": 10, "selected": 9, "hit_rate_per_email": 0.9,
+         "hit_rate_per_link": 0.1, "stars": 2, "topics": {"innovation": 9}},
+        {"sender": "Floor", "address": "news@alumni.example.edu", "emails": 25, "selected": 0, "hit_rate_per_email": 0.0,
+         "hit_rate_per_link": 0.0, "stars": 0, "topics": {}},
+        {"sender": "Rare", "address": "rare@example.com", "emails": 2, "selected": 1, "hit_rate_per_email": 0.5,
+         "hit_rate_per_link": 0.2, "stars": 0, "topics": {"personal development": 1}},
+    ],
+    "domains": {"hbr.org": {"total": 3, "editions": 2, "max_per_edition": 2, "avg_per_edition": 1.5, "per_edition_hist": {}}},
+    "stars_by_domain": {"hbr.org": 1},
+    "topic_domains": {"leadership and management": {"hbr.org": 3}, "personal development": {}, "innovation": {}},
+    "topic_authors": {}, "stars_by_author": {}, "must_read": {"by_author": {}},
+}
+
+
+class CriteriaTests(unittest.TestCase):
+    def test_rules_carry_the_owner_caps(self) -> None:
+        self.assertEqual(cr.RULES["edition"]["per_topic"], 8)
+        self.assertEqual(cr.RULES["caps"]["hbr_per_edition"]["target"], 3)
+        self.assertEqual(cr.RULES["caps"]["same_author_per_edition"]["target"], 2)
+        for topic in cr.TOPICS:
+            self.assertIn(topic, cr.RULES["topics"])
+            self.assertTrue(cr.RULES["topics"][topic]["themes"])
+
+    def test_sender_priors_split_ranked_and_floor(self) -> None:
+        crit = cr.build_criteria(_STATS)
+        ranked = [r["address"] for r in crit["sender_priors"]["ranked"]]
+        floor = [r["address"] for r in crit["sender_priors"]["floor"]]
+        self.assertEqual(ranked, ["strong@example.com"])      # ≥5 emails and picks
+        self.assertEqual(floor, ["news@alumni.example.edu"])  # ≥20 emails, 0 picks
+        self.assertEqual(crit["window"]["match_rate"], 0.9)
+
+    def test_domain_priors_merge_topics_and_stars(self) -> None:
+        crit = cr.build_criteria(_STATS)
+        self.assertEqual(crit["domain_priors"][0],
+                         {"domain": "hbr.org", "picks": 3, "editions": 2, "max_per_edition": 2, "stars": 1,
+                          "topics": {"leadership and management": 3}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_triage_criteria.py
+++ b/tests/test_triage_criteria.py
@@ -47,6 +47,14 @@ class CriteriaTests(unittest.TestCase):
         self.assertEqual(floor, ["news@alumni.example.edu"])  # ≥20 emails, 0 picks
         self.assertEqual(crit["window"]["match_rate"], 0.9)
 
+    def test_owner_overrides_are_merged(self) -> None:
+        crit = cr.build_criteria(_STATS)
+        ov = crit["sender_overrides"]
+        self.assertEqual(ov["gustavorazzetti@substack.com"]["tier"], "never")   # paywalled — owner rule
+        self.assertIn("paywall", cr.RULES)
+        self.assertIn("cadence", cr.RULES)
+        self.assertIn("feedback_loop", cr.RULES)
+
     def test_domain_priors_merge_topics_and_stars(self) -> None:
         crit = cr.build_criteria(_STATS)
         self.assertEqual(crit["domain_priors"][0],

--- a/tests/test_triage_links.py
+++ b/tests/test_triage_links.py
@@ -1,0 +1,207 @@
+"""Pure tests for newsletter.triage.gmail — link extraction, noise rules, local
+redirect decoding, dedupe. No network, no Gmail, no Notion.
+
+Run: `& .\\.venv\\Scripts\\python.exe -m unittest tests.test_triage_links -v`
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from newsletter.triage import gmail as gm  # noqa: E402
+
+
+def _b64(url: str) -> str:
+    return base64.urlsafe_b64encode(url.encode()).decode().rstrip("=")
+
+
+FIXTURE_HTML = f"""
+<html><head><style>a {{ color: red }}</style></head><body>
+<a href="https://59b90e10.click.convertkit-mail4.com/abc/def/{_b64('https://jamesclear.com/3-2-1/august-20-2026')}">
+  3-2-1: What good judgement requires, how to direct your attention</a>
+<a href="https://link.hbr.org/click/47115533.43303/{_b64('https://hbr.org/2026/08/is-your-organizational-culture-too-nice?utm_medium=email')}/x">
+  Is Your Organizational Culture Too Nice?</a>
+<a href="https://link.hbr.org/click/47115533.43303/{_b64('https://hbr.org/my-library/preferences')}/y">Manage email preferences</a>
+<a href="https://substack.com/app-link/post?publication_id=6133698&post_id=211910543&utm_source=post-email-title">
+  Everything in Tech Gets Faster. The Grid Doesn't.</a>
+<a href="https://substack.com/app-link/post?publication_id=6133698&post_id=211910543&utm_source=substack"><img alt="cover" src="x.png"></a>
+<a href="https://substack.com/redirect/2/{_b64(json.dumps({'e': 'https://metatrends.substack.com/subscribe?x=1'}))}">upgrade your subscription.</a>
+<a href="https://substack.com/redirect/2/{_b64(json.dumps({'e': 'https://example.org/deep-dive-on-world-models'}))}">A functional taxonomy of world models</a>
+<a href="https://email.mckinsey.com/capabilities/mckinsey-technology/our-insights/quantum-monitor-2026?stcr=1">
+  McKinsey Quantum Technology Monitor 2026: A commercial tipping point</a>
+<a href="https://link.mail.beehiiv.com/v2/c/deadbeef">Why you can't get rid of bad habits, explained</a>
+<a href="https://link.mail.beehiiv.com/v2/c/cafebabe">share on facebook</a>
+<a href="https://u25296327.ct.sendgrid.net/ls/click?upn=u001.abc">Share to LinkedIn</a>
+<a href="https://insead.us2.list-manage.com/unsubscribe?u=1&id=2">unsubscribe</a>
+<a href="mailto:someone@example.com">someone@example.com</a>
+<a href="https://www.scotthyoung.com/blog/2026/08/12/some-article-slug/">Read this long article about learning faster</a>
+<a href="https://x.com/intent/tweet?url=https%3A%2F%2Fexample.org">Share to Twitter X</a>
+<a href="https://twitter.com/someone">@someone</a>
+<a href="https://example.com/a.png">An image link with a long enough label</a>
+<script>var a = "<a href='https://evil.example/script'>ignored</a>";</script>
+</body></html>
+"""
+
+
+class ExtractionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.links = gm.links_from_html(FIXTURE_HTML)
+        self.by_label = {l.label: l for l in self.links}
+
+    def test_script_and_style_anchors_are_ignored(self) -> None:
+        self.assertFalse(any("evil.example" in l.href for l in self.links))
+
+    def test_convertkit_and_hbr_base64_decode_locally(self) -> None:
+        jc = self.by_label["3-2-1: What good judgement requires, how to direct your attention"]
+        self.assertEqual(jc.target, "https://jamesclear.com/3-2-1/august-20-2026")
+        self.assertEqual(jc.via, "b64")
+        hbr = self.by_label["Is Your Organizational Culture Too Nice?"]
+        self.assertTrue(hbr.target.startswith("https://hbr.org/2026/08/is-your-organizational-culture-too-nice"))
+        # canonical strips utm_*
+        self.assertNotIn("utm_", hbr.canonical)
+
+    def test_substack_redirect2_json_decodes_locally(self) -> None:
+        link = self.by_label["A functional taxonomy of world models"]
+        self.assertEqual(link.target, "https://example.org/deep-dive-on-world-models")
+        self.assertEqual(link.via, "b64")
+
+    def test_substack_post_anchors_dedupe_by_post_id(self) -> None:
+        posts = [l for l in self.links if gm.substack_post_key(l)]
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0].label, "Everything in Tech Gets Faster. The Grid Doesn't.")
+        self.assertFalse(posts[0].resolved)  # needs an HTTP hop
+
+    def test_mckinsey_host_rewrite(self) -> None:
+        link = self.by_label["McKinsey Quantum Technology Monitor 2026: A commercial tipping point"]
+        self.assertTrue(link.target.startswith("https://www.mckinsey.com/capabilities/"))
+        self.assertEqual(link.via, "host-rewrite")
+
+    def test_direct_links_are_their_own_target(self) -> None:
+        link = self.by_label["Read this long article about learning faster"]
+        self.assertEqual(link.via, "direct")
+        self.assertEqual(link.canonical, "https://scotthyoung.com/blog/2026/08/12/some-article-slug")
+
+    def test_noise_is_dropped(self) -> None:
+        labels = set(self.by_label)
+        for noisy in ("Manage email preferences", "share on facebook", "Share to LinkedIn", "unsubscribe",
+                      "someone@example.com", "upgrade your subscription.", "Share to Twitter X", "@someone",
+                      "An image link with a long enough label"):
+            self.assertNotIn(noisy, labels, noisy)
+
+    def test_opaque_redirectors_stay_unresolved(self) -> None:
+        link = self.by_label["Why you can't get rid of bad habits, explained"]
+        self.assertFalse(link.resolved)
+        self.assertEqual(link.via, "raw")
+        self.assertTrue(gm.is_redirector(link.href))
+
+
+class RuleTests(unittest.TestCase):
+    def test_is_redirector_labels(self) -> None:
+        self.assertTrue(gm.is_redirector("https://link.mail.beehiiv.com/v2/c/x"))
+        self.assertTrue(gm.is_redirector("https://59b90e10.click.convertkit-mail4.com/a/b/c"))
+        self.assertTrue(gm.is_redirector("https://substack.com/redirect/abc?j=x"))
+        self.assertTrue(gm.is_redirector("https://insead.us2.list-manage.com/track/click?u=1"))
+        self.assertFalse(gm.is_redirector("https://news.ycombinator.com/item?id=1"))
+        self.assertFalse(gm.is_redirector("https://hbr.org/2026/08/some-article"))
+        self.assertFalse(gm.is_redirector("https://open.substack.com/pub/x/p/y"))
+
+    def test_canonical_substack(self) -> None:
+        self.assertEqual(gm.canonical_substack("https://open.substack.com/pub/metatrends/p/everything?utm=1"),
+                         "https://metatrends.substack.com/p/everything")
+        self.assertEqual(gm.canonical_substack("https://nesslabs.com/x"), "https://nesslabs.com/x")
+
+    def test_short_anchor_threshold(self) -> None:
+        link = gm.Link(href="https://example.org/some/path", text="Accountability.")
+        gm.classify_noise(link, min_anchor_chars=12)
+        self.assertFalse(link.noise)
+        link2 = gm.Link(href="https://example.org/some/path", text="Blog")
+        gm.classify_noise(link2, min_anchor_chars=12)
+        self.assertTrue(link2.noise)
+        self.assertEqual(link2.noise_reason, "short-anchor")
+
+    def test_plain_text_fallback(self) -> None:
+        links = gm.extract_links("", "see https://example.org/article-one. and https://example.org/two")
+        self.assertEqual([l.href for l in links], ["https://example.org/article-one", "https://example.org/two"])
+
+    def test_message_html_skips_attachments(self) -> None:
+        body = base64.urlsafe_b64encode(b"<p>hi</p>").decode()
+        raw = {"payload": {"mimeType": "multipart/mixed", "parts": [
+            {"mimeType": "text/html", "body": {"data": body}},
+            {"mimeType": "text/html", "filename": "attached.html", "body": {"data": body}},
+            {"mimeType": "text/plain", "body": {"data": base64.urlsafe_b64encode(b"hi").decode()}},
+        ]}}
+        html, plain = gm.message_html(raw)
+        self.assertEqual(html, "<p>hi</p>")
+        self.assertEqual(plain, "hi")
+
+    def test_redirect_cache_roundtrip(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "r.json"
+            cache = gm.RedirectCache(path)
+            cache.put("k", "https://final.example/")
+            cache.put("f", "")
+            cache.flush()
+            again = gm.RedirectCache(path)
+            self.assertEqual(again.get("k"), "https://final.example/")
+            self.assertEqual(again.get("f"), "")
+            self.assertIsNone(again.get("missing"))
+
+
+class _StubResp:
+    def __init__(self, status, location=None):
+        self.status_code = status
+        self.headers = {"Location": location} if location else {}
+    def close(self): pass
+
+
+class _StubSession:
+    """Scripted redirect chains keyed by (method, url)."""
+    def __init__(self, table): self.table, self.calls = table, []
+    def request(self, method, url, **kw):
+        self.calls.append((method, url))
+        assert kw.get("allow_redirects") is False and kw.get("stream") is True
+        return self.table.get((method, url)) or self.table.get(("*", url)) or _StubResp(404)
+
+
+class ResolveTests(unittest.TestCase):
+    def test_manual_redirect_following_never_reads_bodies(self) -> None:
+        sess = _StubSession({
+            ("*", "https://link.mail.beehiiv.com/v2/c/abc"): _StubResp(302, "https://pub.beehiiv.com/p/post?x=1"),
+            ("*", "https://pub.beehiiv.com/p/post?x=1"): _StubResp(200),
+        })
+        final, status = gm.resolve_one(sess, "https://link.mail.beehiiv.com/v2/c/abc", timeout=1)
+        self.assertEqual((final, status), ("https://pub.beehiiv.com/p/post?x=1", "http"))
+        self.assertEqual([m for m, _ in sess.calls], ["HEAD", "HEAD"])
+
+    def test_head_refused_falls_back_to_get(self) -> None:
+        sess = _StubSession({
+            ("HEAD", "https://t.e2ma.net/click/a/b/c"): _StubResp(404),
+            ("GET", "https://t.e2ma.net/click/a/b/c"): _StubResp(302, "/relative/path"),
+            ("GET", "https://t.e2ma.net/relative/path"): _StubResp(200),
+        })
+        final, status = gm.resolve_one(sess, "https://t.e2ma.net/click/a/b/c", timeout=1)
+        self.assertEqual((final, status), ("https://t.e2ma.net/relative/path", "http"))
+
+    def test_redirect_loop_is_bounded(self) -> None:
+        sess = _StubSession({("*", "https://go.example.com/x"): _StubResp(302, "https://go.example.com/x")})
+        final, status = gm.resolve_one(sess, "https://go.example.com/x", timeout=1)
+        self.assertEqual(status, "http-fail")
+        self.assertLessEqual(len(sess.calls), 2 * gm._MAX_HOPS)
+
+    def test_self_answering_url_is_its_own_target(self) -> None:
+        sess = _StubSession({("*", "https://news.ycombinator.com/item?id=1"): _StubResp(200)})
+        final, status = gm.resolve_one(sess, "https://news.ycombinator.com/item?id=1", timeout=1)
+        self.assertEqual((final, status), ("https://news.ycombinator.com/item?id=1", "http"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Step 1/3 of the newsletter triage (series: #210 → #211 → #212). Builds the ground truth the Step-2 ranker is scored against and infers the selection criteria from it.

- Vendored `gmail_readonly/` + `google_oauth_common/` byte-for-byte from the sibling repo (read-only Gmail scope, drift check empty); one-time onboarding + re-auth recipe in `newsletter/README.md`.
- `newsletter/triage/gmail.py` — label ingestion, `<a href>` extraction, noise filter, local redirect decoding (ConvertKit/Kit/HBR base64 path, Substack `redirect/2` JSON, McKinsey host rewrite, Substack `post_id` dedupe), bounded + cached HTTP hop that follows `Location` manually (never reads bodies — `allow_redirects=True` pinned a core on one endless response).
- `newsletter/triage/history.py` — 54-week dataset: 4,383 emails (median 82/week), 57,849 non-noise links, 58 editions, 1,317 picks; 93.9% of picks traced to their source email (45% URL, 27% Substack slug, 8% anchor≈title, 14% sender-domain in window). Outputs `results/newsletter/triage/history/` (gitignored) + `stats.md`.
- `newsletter/triage/criteria.py` → `criteria.json` (rules + sender/domain priors) and `docs/newsletter-triage-criteria.md` — every rule carries its measured number (HBR per edition 3:26·4:12·2:10; same author 2:32·3:14; must-read topic persdev 60% / leadership 35% / innovation 4%; news-like 3.5% of innovation picks vs 2.3% offered; sender hit-rates).
- `docs/architecture.mmd` gains the triage node + Gmail API edge.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 114 tests OK (new: `test_triage_links` 18, `test_triage_criteria` 3; vendored `test_gmail_readonly` 15 via pytest)
- [x] `py_compile` on all new modules
- [x] `git diff --no-index` vs the sibling repo's `gmail_readonly/` + `google_oauth_common/` — byte-identical
- [x] `python -m newsletter.triage.history --weeks 54` end-to-end (Gmail pull 4,383 msgs ≈ 6 min; redirect resolution 30k keys ≈ 34 min at 32 workers; cache persisted)
- [x] per-week email counts sane (min 25 opening week, median 82, max 102) vs the 143/14-day probe
- [x] sender table spot-checked by hand against N226 / N220 / N200 picks
- [ ] criteria doc reviewed by the owner (acceptance gate — PR stays draft until then)

Closes #210
