### PR TITLE
Newsletter triage: Step 2/3 — weekly engine, report, skill, backtest

### DIFF
--- a/.agents/skills/newsletter-triage/SKILL.md
+++ b/.agents/skills/newsletter-triage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: newsletter-triage
+description: Triage the 'newsletters' Gmail label into an edition-sized markdown shortlist (8 × 3 topics) using the owner's inferred criteria — one review window → one edition, paywall/promo vetoes, sender weights that learn from the reviewed report. E.g. "/newsletter-triage", "/newsletter-triage --days 7", "/newsletter-triage --backtest N226,N227", "/newsletter-triage --feedback results/newsletter/triage/triage-2026-08-08_2026-08-15.md".
+---
+
+# newsletter-triage
+
+**Goal:** replace the manual inbox review with a report the owner validates. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. Never write to Notion, Gmail or Chrome from this skill (that is `--open` / `--mark-reviewed`, issue #212).
+
+This is a **public repo** — never put secrets, tokens or private identifiers in issues, PRs, commits or the report.
+
+## Arguments
+
+`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--backtest N226[,N227]] [--feedback <report.md>] [--no-llm] [--source cache]`
+
+- default = window from the last watermark (`results/newsletter/triage/state.json → reviewed_until`, else today−7) to today, split into 7-day windows oldest first — **one report per window, one edition per report** (owner rule: never drain the inbox into one edition).
+- `--backtest` = replay past editions offline from the history cache and print precision/recall.
+- `--feedback <report>` = ingest the owner's ticks (yes/no) → `newsletter/triage/overrides.json` sender tiers + `results/newsletter/triage/feedback.jsonl`.
+
+## Step 1 — pre-flight
+
+- `newsletter/triage/criteria.json` exists (else `& .\.venv\Scripts\python.exe -m newsletter.triage.criteria`; that needs the history stats from `-m newsletter.triage.history`).
+- `auth/gmail/token.json` exists (else point the owner to `newsletter/README.md` → Gmail one-time setup; do not run the consent flow unattended).
+- Hub up at `http://127.0.0.1:8000` — the engine health-checks and degrades to a rule-only report (`stats.llm_calls = 0`) if not; say so.
+
+## Step 2 — run (synchronously — no background + wait; a headless session has no wake-up)
+
+```powershell
+& .\.venv\Scripts\python.exe -m newsletter.triage.run [--days N | --since … --until …]      # live, from Gmail
+& .\.venv\Scripts\python.exe -m newsletter.triage.run --backtest N226,N227                    # offline replay
+& .\.venv\Scripts\python.exe -m newsletter.triage.feedback <report.md>                        # ingest ticks
+```
+
+Typical live run: ~80 emails → ~1,000 links → stage-A batched scoring (~40 hub calls) → fetch + stage-B for the top-90 → `results/newsletter/triage/triage-<start>_<end>.md`. 5–10 minutes.
+
+## Step 3 — report back
+
+Read the report(s) and tell the owner, per window: the 8/8/8 shortlist (title · sender · one-line why), the ⭐/🏆 suggestions, any topic short of 8 (backfill from `next` / classics), new senders needing a tier, and the stats line (emails / links / scored / fetched / LLM calls / paywalled / unknown). If something could not be fetched or scored, say it is **unknown**, not "skipped".
+
+After the owner reviews: remind them to run `--feedback <report>` (or do it when asked) so the next run uses classification + criteria.
+
+## Guardrails (non-negotiable)
+
+- Read-only: no Notion writes, no Gmail writes, no Chrome tabs from this skill.
+- Paywalled content is never a pick (criteria §8); `overrides.json` `tier: never` wins over every score.
+- One window → one edition. Do not merge windows.
+- Don't re-inline Gmail / LLM / Chrome helpers — the engine imports the existing ones.
+
+## Verification gate (before declaring done)
+
+- Report file exists and every email in the window appears once; shortlist ≤ 8 per topic; stats footer present.
+- `& .\.venv\Scripts\python.exe -m unittest tests.test_triage_links tests.test_triage_criteria tests.test_triage_engine` green when the engine code was touched.

--- a/.claude/skills/newsletter-triage/SKILL.md
+++ b/.claude/skills/newsletter-triage/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: newsletter-triage
+description: Triage the 'newsletters' Gmail label into an edition-sized markdown shortlist (8 × 3 topics) using the owner's inferred criteria — one review window → one edition, paywall/promo vetoes, sender weights that learn from the reviewed report. E.g. "/newsletter-triage", "/newsletter-triage --days 7", "/newsletter-triage --backtest N226,N227", "/newsletter-triage --feedback results/newsletter/triage/triage-2026-08-08_2026-08-15.md".
+---
+
+# newsletter-triage
+
+**Goal:** replace the manual inbox review with a report the owner validates. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. Never write to Notion, Gmail or Chrome from this skill (that is `--open` / `--mark-reviewed`, issue #212).
+
+This is a **public repo** — never put secrets, tokens or private identifiers in issues, PRs, commits or the report.
+
+## Arguments
+
+`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--backtest N226[,N227]] [--feedback <report.md>] [--no-llm] [--source cache]`
+
+- default = window from the last watermark (`results/newsletter/triage/state.json → reviewed_until`, else today−7) to today, split into 7-day windows oldest first — **one report per window, one edition per report** (owner rule: never drain the inbox into one edition).
+- `--backtest` = replay past editions offline from the history cache and print precision/recall.
+- `--feedback <report>` = ingest the owner's ticks (yes/no) → `newsletter/triage/overrides.json` sender tiers + `results/newsletter/triage/feedback.jsonl`.
+
+## Step 1 — pre-flight
+
+- `newsletter/triage/criteria.json` exists (else `& .\.venv\Scripts\python.exe -m newsletter.triage.criteria`; that needs the history stats from `-m newsletter.triage.history`).
+- `auth/gmail/token.json` exists (else point the owner to `newsletter/README.md` → Gmail one-time setup; do not run the consent flow unattended).
+- Hub up at `http://127.0.0.1:8000` — the engine health-checks and degrades to a rule-only report (`stats.llm_calls = 0`) if not; say so.
+
+## Step 2 — run (synchronously — no background + wait; a headless session has no wake-up)
+
+```powershell
+& .\.venv\Scripts\python.exe -m newsletter.triage.run [--days N | --since … --until …]      # live, from Gmail
+& .\.venv\Scripts\python.exe -m newsletter.triage.run --backtest N226,N227                    # offline replay
+& .\.venv\Scripts\python.exe -m newsletter.triage.feedback <report.md>                        # ingest ticks
+```
+
+Typical live run: ~80 emails → ~1,000 links → stage-A batched scoring (~40 hub calls) → fetch + stage-B for the top-90 → `results/newsletter/triage/triage-<start>_<end>.md`. 5–10 minutes.
+
+## Step 3 — report back
+
+Read the report(s) and tell the owner, per window: the 8/8/8 shortlist (title · sender · one-line why), the ⭐/🏆 suggestions, any topic short of 8 (backfill from `next` / classics), new senders needing a tier, and the stats line (emails / links / scored / fetched / LLM calls / paywalled / unknown). If something could not be fetched or scored, say it is **unknown**, not "skipped".
+
+After the owner reviews: remind them to run `--feedback <report>` (or do it when asked) so the next run uses classification + criteria.
+
+## Guardrails (non-negotiable)
+
+- Read-only: no Notion writes, no Gmail writes, no Chrome tabs from this skill.
+- Paywalled content is never a pick (criteria §8); `overrides.json` `tier: never` wins over every score.
+- One window → one edition. Do not merge windows.
+- Don't re-inline Gmail / LLM / Chrome helpers — the engine imports the existing ones.
+
+## Verification gate (before declaring done)
+
+- Report file exists and every email in the window appears once; shortlist ≤ 8 per topic; stats footer present.
+- `& .\.venv\Scripts\python.exe -m unittest tests.test_triage_links tests.test_triage_criteria tests.test_triage_engine` green when the engine code was touched.

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -294,7 +294,13 @@
         "min_anchor_chars": 12,
         "redirect_workers": 8,
         "redirect_timeout_s": 10,
-        "redirect_budget_history": 6000
+        "redirect_budget_history": 6000,
+        "llm_hub_base_url": "http://127.0.0.1:8000",
+        "llm_model": "claude_haiku",
+        "stage_b_top_k": 90,
+        "fetch_workers": 8,
+        "fetch_timeout_s": 15,
+        "llm_workers": 3
     },
     "engagement": {
         "default_days": 5,

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -73,12 +73,19 @@ flowchart TB
     NNORM["normalize_names + normalize_url"]
     NBUILD["build_newsletter.py"]
     NSBDRAFT["substack_draft.py\n(optional, explicit step)"]
-    NTRIAGE["triage/ — gmail.py + history.py\n(label ingest, link decode, 54-week\nground truth + criteria)"]
+    NTRIAGE["triage/ — gmail.py + history.py + criteria.py\n(label ingest, link decode, 54-week\nground truth → criteria.json + overrides.json)"]
+    NTRIAGERUN["triage/run.py — weekly engine\nfetch + score (2 stages) + rank + report\n+ feedback.py (ticks → sender tiers)"]
   end
   NPIPE --> NBOOT --> NARCHIVE --> NNORM --> NBUILD
   NTRIAGE -->|"gmail.readonly via vendored\ngmail_readonly/ + google_oauth_common/"| GMAILAPI[("Gmail API\nlabel 'newsletters'")]
   NTRIAGE -->|"positives: articles + editions"| NOTION
   NTRIAGE --> RESULTSTRIAGE[["results/newsletter/triage/\nhistory/ + redirects.json"]]
+  NTRIAGE -->|"criteria.json"| NTRIAGERUN
+  NTRIAGERUN --> GMAILAPI
+  NTRIAGERUN -->|"dedupe: article URLs (read-only)"| NOTION
+  NTRIAGERUN -->|"stage A/B scoring\n(claude_haiku alias)"| LLMHUB
+  NTRIAGERUN --> TRIAGEREPORT[["results/newsletter/triage/\ntriage-<window>.md (review surface)"]]
+  TRIAGESKILL["newsletter-triage skill\n(.claude/skills/, .agents/skills/)"] --> NTRIAGERUN
   NARCHIVE -->|"readability-lxml extraction"| NOTION
   NARCHIVE --> LLMHUB[("local LLM hub\n127.0.0.1:8000\ntopic + 3-line summary")]
   NBUILD --> RESULTSNEWS[["results/newsletter/N{NNN}.html"]]

--- a/docs/newsletter-triage-criteria.md
+++ b/docs/newsletter-triage-criteria.md
@@ -2,7 +2,7 @@
 
 The weekly newsletter picks 8 articles × 3 topics (leadership and management · personal development · innovation), stars one per topic and names one must-read. This document states the criteria that reproduce those picks, **each with the number it was measured on**, so a reader (or the Step-2 ranker, which consumes the machine-readable twin `newsletter/triage/criteria.json`) can tell a rule from a guess.
 
-**Ground truth** (`python -m newsletter.triage.history`, built 2026-08-21): Gmail label `newsletters`, 2025-08-08 → 2026-08-21 — 4,383 emails (median 82/week, min 25 in the opening week, max 102), 57,849 non-noise links; Notion editions N174–N229 (58 rows, 54 complete) with 1,317 picks. 93.9% of picks were traced to the email that offered them (45% exact URL, 27% Substack slug, 8% anchor-title fuzzy, 14% by the sender's domain in the window); the 80 unmatched are mostly Rishad/Mike Fisher posts whose email anchor is an image or a one-word title.
+**Ground truth** (`python -m newsletter.triage.history`, built 2026-08-21): Gmail label `newsletters`, 2025-08-08 → 2026-08-21 — 4,383 emails (median 82/week, min 25 in the opening week, max 102), 57,849 non-noise links; Notion editions N174–N229 (58 rows, 54 complete) with 1,317 picks. 94.7% of picks were traced to the email that offered them (46% exact URL, 26% Substack slug, 8% anchor-title fuzzy, 14% by the sender's domain in the window); the 70 unmatched are mostly Rishad/Mike Fisher posts whose email anchor is an image or a one-word title.
 
 Regenerate: `python -m newsletter.triage.history --no-gmail --reextract --no-resolve` (cached HTML, no network) then `python -m newsletter.triage.criteria`.
 

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -260,8 +260,41 @@ is scored against, under `newsletter/triage/`:
 | Command | What it does |
 |---|---|
 | `python -m newsletter.triage.history` | Full build with `newsletter_triage.history_weeks` (54) and `redirect_budget_history`. |
-| `python -m newsletter.triage.history --no-gmail --reextract --no-resolve` | Re-run extraction + join + stats from the cached HTML after a rule change (no network). |
+| `python -m newsletter.triage.history --no-gmail --reextract --budget 0` | Re-run extraction + join + stats from the cached HTML after a rule change (redirects re-applied from the cache, no new network). |
 | `python -m newsletter.triage.history --limit 150 --budget 100` | Smoke test. |
+| `python -m newsletter.triage.criteria` | Rebuild `criteria.json` from `stats.json` + `overrides.json`. |
+
+### Weekly engine (Step 2/3, issue #211)
+
+`run.py` turns one review window into one edition-sized shortlist — the owner's
+cadence rule: the run covers last watermark → now (normally Saturday → Friday)
+and fills **one** edition (8/8/8); a backlog of N weeks is split into N 7-day
+windows, oldest first, one report each. Nothing is written to Notion, Gmail or
+Chrome (that is Step 3).
+
+Pipeline per window: emails → non-noise links (decoded / resolved) → drop
+already-in-Notion → sender/domain priors (`criteria.json` + `overrides.json`) →
+**stage A** batched metadata scoring via the hub (`llm_model`, default
+`claude_haiku`) → fetch + **stage B** content scoring for the top-K
+(`stage_b_top_k`, 90) with paywall detection (`fetch.py`) → vetoes (`tier: never`,
+paywalled, promo) → caps (HBR ≤ 3, same author ≤ 2, same domain ≤ 3, one pick
+per email except digests) → 8 per topic + ⭐/🏆 suggestions →
+`results/newsletter/triage/triage-<start>_<end>.md`.
+
+| Command | What it does |
+|---|---|
+| `python -m newsletter.triage.run` | Live: window from `state.json → reviewed_until` (else today−7) to today, one report per 7-day window. |
+| `python -m newsletter.triage.run --since 2026-08-08 --until 2026-08-22` | Explicit range (split into windows). |
+| `python -m newsletter.triage.run --backtest N224,N225,N226,N227` | Offline replay from the history cache: precision of the shortlist vs real picks, recall of the edition's picks sourced in the window. |
+| `python -m newsletter.triage.run --no-llm` | Rule-only report (sender/domain priors) when the hub is down. |
+| `python -m newsletter.triage.feedback <report.md>` | Ingest the reviewed report (tick = yes): sender tiers in `overrides.json` + `results/newsletter/triage/feedback.jsonl`. |
+
+The report is the review surface: shortlist per topic with checkboxes (ticked =
+suggested), runners-up, a "new senders — set a tier" list, then every email in
+inbox order with every link and its verdict (`selected / runner-up / candidate /
+low / vetoed / duplicate / unknown`) — an unfetchable or unscorable link is
+`unknown`, never "skipped". Skill: `/newsletter-triage`
+(`.claude/skills/newsletter-triage/SKILL.md`, mirrored in `.agents/skills/`).
 
 ### Gmail one-time setup
 

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -289,6 +289,15 @@ per email except digests) → 8 per topic + ⭐/🏆 suggestions →
 | `python -m newsletter.triage.run --no-llm` | Rule-only report (sender/domain priors) when the hub is down. |
 | `python -m newsletter.triage.feedback <report.md>` | Ingest the reviewed report (tick = yes): sender tiers in `overrides.json` + `results/newsletter/triage/feedback.jsonl`. |
 
+First dry run (2026-08-21, `claude_haiku`, 2-week windows ending 7 days before
+each edition): N224 precision 54 % / recall 16 %, N225 54 % / 26 %, N226 62 % /
+50 %, N227 42 % / 29 % (+runners-up 21–56 %). Precision = share of the 24
+suggestions that were real picks in some edition; recall = share of the
+edition's picks sourced in the window that made the shortlist. Misses are mostly
+caps doing their job (HBR ≤ 3 where the edition had 4, author ≤ 2) and picks
+ranked just below the fold — the feedback loop and wider stage-B depth are the
+levers.
+
 The report is the review surface: shortlist per topic with checkboxes (ticked =
 suggested), runners-up, a "new senders — set a tier" list, then every email in
 inbox order with every link and its verdict (`selected / runner-up / candidate /

--- a/newsletter/triage/criteria.json
+++ b/newsletter/triage/criteria.json
@@ -6,7 +6,7 @@
   "positives": 1317,
   "first_email": "2025-08-08",
   "last_email": "2026-08-21",
-  "match_rate": 0.939
+  "match_rate": 0.947
  },
  "rules": {
   "edition": {
@@ -601,6 +601,20 @@
     }
    },
    {
+    "address": "lenny@substack.com",
+    "name": "Lenny's Newsletter",
+    "emails": 123,
+    "picks": 50,
+    "hit_rate_per_email": 0.41,
+    "hit_rate_per_link": 0.015,
+    "stars": 6,
+    "topics": {
+     "innovation": 29,
+     "leadership and management": 11,
+     "personal development": 10
+    }
+   },
+   {
     "address": "hello@gorick.com",
     "name": "Gorick Ng",
     "emails": 66,
@@ -618,13 +632,14 @@
     "address": "dwarkesh@substack.com",
     "name": "Dwarkesh Patel",
     "emails": 32,
-    "picks": 12,
-    "hit_rate_per_email": 0.38,
-    "hit_rate_per_link": 0.005,
+    "picks": 13,
+    "hit_rate_per_email": 0.41,
+    "hit_rate_per_link": 0.006,
     "stars": 1,
     "topics": {
      "innovation": 11,
-     "personal development": 1
+     "personal development": 1,
+     "leadership and management": 1
     }
    },
    {
@@ -691,20 +706,6 @@
      "leadership and management": 14,
      "personal development": 4,
      "innovation": 3
-    }
-   },
-   {
-    "address": "lenny@substack.com",
-    "name": "Lenny's Newsletter",
-    "emails": 123,
-    "picks": 39,
-    "hit_rate_per_email": 0.32,
-    "hit_rate_per_link": 0.01,
-    "stars": 5,
-    "topics": {
-     "innovation": 22,
-     "leadership and management": 10,
-     "personal development": 7
     }
    },
    {
@@ -775,19 +776,6 @@
     }
    },
    {
-    "address": "email@stratechery.com",
-    "name": "Ben Thompson",
-    "emails": 78,
-    "picks": 17,
-    "hit_rate_per_email": 0.22,
-    "hit_rate_per_link": 0.013,
-    "stars": 2,
-    "topics": {
-     "innovation": 15,
-     "personal development": 2
-    }
-   },
-   {
     "address": "ash@leanstack.com",
     "name": "ash@leanstack.com",
     "emails": 60,
@@ -812,6 +800,19 @@
     }
    },
    {
+    "address": "email@stratechery.com",
+    "name": "Ben Thompson",
+    "emails": 78,
+    "picks": 16,
+    "hit_rate_per_email": 0.21,
+    "hit_rate_per_link": 0.012,
+    "stars": 2,
+    "topics": {
+     "innovation": 15,
+     "personal development": 1
+    }
+   },
+   {
     "address": "marketoon@marketoonist.com",
     "name": "Tom Fishburne",
     "emails": 44,
@@ -822,20 +823,6 @@
     "topics": {
      "innovation": 7,
      "leadership and management": 1,
-     "personal development": 1
-    }
-   },
-   {
-    "address": "review@firstround.com",
-    "name": "First Round Review",
-    "emails": 44,
-    "picks": 9,
-    "hit_rate_per_email": 0.2,
-    "hit_rate_per_link": 0.045,
-    "stars": 0,
-    "topics": {
-     "innovation": 6,
-     "leadership and management": 2,
      "personal development": 1
     }
    },
@@ -862,6 +849,20 @@
     "stars": 0,
     "topics": {
      "personal development": 5,
+     "leadership and management": 1
+    }
+   },
+   {
+    "address": "review@firstround.com",
+    "name": "First Round Review",
+    "emails": 44,
+    "picks": 8,
+    "hit_rate_per_email": 0.18,
+    "hit_rate_per_link": 0.04,
+    "stars": 0,
+    "topics": {
+     "innovation": 6,
+     "personal development": 1,
      "leadership and management": 1
     }
    },
@@ -959,12 +960,12 @@
     "address": "superhuman@mail.joinsuperhuman.ai",
     "name": "Superhuman – Zain Kahn",
     "emails": 372,
-    "picks": 51,
-    "hit_rate_per_email": 0.14,
+    "picks": 50,
+    "hit_rate_per_email": 0.13,
     "hit_rate_per_link": 0.007,
     "stars": 4,
     "topics": {
-     "innovation": 41,
+     "innovation": 40,
      "personal development": 5,
      "leadership and management": 5
     }
@@ -1048,6 +1049,18 @@
     }
    },
    {
+    "address": "lenny+how-i-ai@substack.com",
+    "name": "Lenny's Newsletter",
+    "emails": 56,
+    "picks": 3,
+    "hit_rate_per_email": 0.05,
+    "hit_rate_per_link": 0.005,
+    "stars": 0,
+    "topics": {
+     "innovation": 3
+    }
+   },
+   {
     "address": "simonw@substack.com",
     "name": "Simon Willison from Simon Willison’s Newsletter",
     "emails": 19,
@@ -1057,18 +1070,6 @@
     "stars": 1,
     "topics": {
      "innovation": 1
-    }
-   },
-   {
-    "address": "lenny+how-i-ai@substack.com",
-    "name": "Lenny's Newsletter",
-    "emails": 56,
-    "picks": 2,
-    "hit_rate_per_email": 0.04,
-    "hit_rate_per_link": 0.003,
-    "stars": 0,
-    "topics": {
-     "innovation": 2
     }
    },
    {

--- a/newsletter/triage/feedback.py
+++ b/newsletter/triage/feedback.py
@@ -1,0 +1,130 @@
+"""Ingest a reviewed triage report: ticks → sender weights (overrides.json) + a decision log.
+
+    python -m newsletter.triage.feedback results/newsletter/triage/triage-2026-08-08_2026-08-15.md [--dry-run]
+
+Every shortlist / runner-up line in the report ends with ``<!-- cand:ID sender:ADDR -->``.
+``- [x]`` = yes, ``- [ ]`` = no. Decisions are appended to
+``results/newsletter/triage/feedback.jsonl`` and the per-sender tally over the
+whole log drives the tier in ``overrides.json``:
+
+* n ≥ 3 and yes-rate ≥ 0.75 → ``usually``; n ≥ 6 and yes-rate ≥ 0.9 → ``always``
+* n ≥ 5 and yes-rate == 0 → ``rarely``
+* ``never`` (owner-set, e.g. paywalled) is never changed automatically; entries
+  with ``"source": "manual"`` are reported, not overwritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from config.console import force_utf8_stdio  # noqa: E402
+from newsletter.triage.criteria import OVERRIDES_PATH  # noqa: E402
+
+FEEDBACK_LOG = REPO_ROOT / "results" / "newsletter" / "triage" / "feedback.jsonl"
+_LINE = re.compile(r"^\s*-\s\[( |x|X)\]\s(.*?)<!--\s*cand:(\S+)\s+sender:(\S+)\s*-->\s*$")
+_TITLE = re.compile(r"\[([^\]]+)\]\((https?://[^)]+)\)")
+
+
+def parse_report(text: str) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for line in text.splitlines():
+        m = _LINE.match(line)
+        if not m:
+            continue
+        ticked = m.group(1).lower() == "x"
+        body, cid, sender = m.group(2), m.group(3), m.group(4).lower()
+        t = _TITLE.search(body)
+        out.append({"cid": cid, "sender": sender, "yes": ticked,
+                    "title": t.group(1) if t else body.strip()[:120], "url": t.group(2) if t else ""})
+    return out
+
+
+def tally(log_rows: List[Dict[str, Any]]) -> Dict[str, Tuple[int, int]]:
+    counts: Dict[str, List[int]] = defaultdict(lambda: [0, 0])
+    seen = set()
+    for r in log_rows:
+        key = (r.get("cid"), r.get("report"))
+        if key in seen:
+            continue
+        seen.add(key)
+        c = counts[r["sender"]]
+        c[0] += 1
+        c[1] += int(bool(r["yes"]))
+    return {k: (v[0], v[1]) for k, v in counts.items()}
+
+
+def tier_for(n: int, yes: int) -> str | None:
+    rate = yes / n if n else 0.0
+    if n >= 6 and rate >= 0.9:
+        return "always"
+    if n >= 3 and rate >= 0.75:
+        return "usually"
+    if n >= 5 and yes == 0:
+        return "rarely"
+    return None
+
+
+def apply(decisions: List[Dict[str, Any]], *, report_name: str, overrides_path: Path = OVERRIDES_PATH,
+          log_path: Path = FEEDBACK_LOG, dry_run: bool = False) -> Dict[str, Any]:
+    now = datetime.now(timezone.utc).isoformat()
+    rows = [dict(d, report=report_name, at=now) for d in decisions]
+    existing: List[Dict[str, Any]] = []
+    if log_path.exists():
+        existing = [json.loads(l) for l in log_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    existing = [r for r in existing if r.get("report") != report_name]   # re-ingesting a report replaces its rows
+    all_rows = existing + rows
+    counts = tally(all_rows)
+    ov = json.loads(overrides_path.read_text(encoding="utf-8")) if overrides_path.exists() else {"senders": {}}
+    senders = ov.setdefault("senders", {})
+    changes: List[str] = []
+    for addr, (n, yes) in counts.items():
+        new_tier = tier_for(n, yes)
+        cur = senders.get(addr)
+        if cur and cur.get("tier") == "never":
+            continue
+        if cur and cur.get("source") == "manual" and new_tier and cur.get("tier") != new_tier:
+            changes.append(f"{addr}: manual tier {cur.get('tier')} kept (feedback suggests {new_tier}, {yes}/{n})")
+            continue
+        if new_tier and (not cur or cur.get("tier") != new_tier):
+            senders[addr] = {"tier": new_tier, "reason": f"feedback {yes}/{n} yes", "since": now[:10], "source": "feedback"}
+            changes.append(f"{addr}: → {new_tier} ({yes}/{n})")
+    if not dry_run:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("".join(json.dumps(r, ensure_ascii=False) + "\n" for r in all_rows), encoding="utf-8")
+        overrides_path.write_text(json.dumps(ov, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {"decisions": len(rows), "yes": sum(1 for r in rows if r["yes"]), "senders_tallied": len(counts),
+            "changes": changes}
+
+
+def main(argv=None) -> int:
+    force_utf8_stdio()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("report")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+    path = Path(args.report)
+    decisions = parse_report(path.read_text(encoding="utf-8"))
+    if not decisions:
+        print("❌ no candidate lines found — is this a triage report?")
+        return 2
+    res = apply(decisions, report_name=path.name, dry_run=args.dry_run)
+    print(f"✅ {res['decisions']} decisions ({res['yes']} yes) from {path.name}; {res['senders_tallied']} senders tallied"
+          + (" (dry run)" if args.dry_run else ""))
+    for c in res["changes"]:
+        print("  •", c)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/triage/fetch.py
+++ b/newsletter/triage/fetch.py
@@ -1,0 +1,251 @@
+"""Fetch candidate article pages: title / author / body excerpt / paywall state.
+
+``requests`` + readability-lxml (same extraction the archive step uses, minus
+the Playwright page), with a persistent JSON cache so backtests and re-runs
+never re-download. YouTube links use oEmbed for the title; x.com posts are not
+fetched (anchor text stays the title). Every failure is its own state —
+``fetched.ok`` False with ``error`` — never folded into "not relevant".
+
+Paywall policy (owner rule, criteria §8): hard walls (Substack "for paid
+subscribers", subscribe-to-read) → ``paywalled=True`` and the link is never a
+candidate; metered walls on the ``METERED_OK`` domains (HBR…) stay eligible.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urlsplit
+
+import requests
+from lxml import html as lxml_html
+from readability import Document
+
+from newsletter.extractor import _AUTHOR_META_NAMES, _meta, _normalise_author
+
+logger = logging.getLogger("newsletter_triage.fetch")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FETCH_CACHE = REPO_ROOT / "results" / "newsletter" / "triage" / "fetch_cache.json"
+
+_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+       "(KHTML, like Gecko) Chrome/128.0 Safari/537.36")
+MAX_BYTES = 3_000_000
+EXCERPT_CHARS = 3000
+
+METERED_OK = ("hbr.org", "nytimes.com", "wsj.com", "ft.com", "economist.com", "theatlantic.com",
+              "newyorker.com", "wired.com", "bloomberg.com", "technologyreview.com", "inc.com", "fastcompany.com")
+
+_PAYWALL_HARD = re.compile(
+    r"(this post is for paid subscribers|for paid subscribers|already a paid subscriber\?|"
+    r"subscribe to keep reading|upgrade to paid to keep reading|to continue reading, (?:please )?subscribe|"
+    r"this article is for (?:paid )?(?:subscribers|members)|become a (?:paid )?(?:member|subscriber) to (?:read|continue)|"
+    r"unlock this (?:article|post|story)|members[- ]only (?:content|post|article)|"
+    r"the rest of this (?:post|article) is for paid)", re.IGNORECASE)
+_SUBSTACK_PAYWALL_MARKUP = re.compile(r'class="[^"]*\bpaywall\b[^"]*"', re.IGNORECASE)
+
+
+@dataclass
+class Fetched:
+    url: str
+    ok: bool = False
+    final_url: str = ""
+    status: int = 0
+    kind: str = "article"           # article | video | post | pdf
+    title: str = ""
+    author: Optional[str] = None
+    excerpt: str = ""
+    body_chars: int = 0
+    paywalled: Optional[bool] = None   # None = not established
+    paywall_reason: str = ""
+    error: str = ""
+    fetched_at: float = 0.0
+
+    def to_json(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def domain_of(url: str) -> str:
+    host = urlsplit(url or "").netloc.lower()
+    return host[4:] if host.startswith("www.") else host
+
+
+def detect_paywall(html: str, body_text: str, url: str) -> tuple[Optional[bool], str]:
+    dom = domain_of(url)
+    sentence = _PAYWALL_HARD.search(html or "")
+    markup = _SUBSTACK_PAYWALL_MARKUP.search(html or "")
+    if sentence or markup:
+        if any(dom.endswith(m) for m in METERED_OK):
+            return False, "metered-ok"
+        marker = sentence.group(0).lower() if sentence else "paywall markup"
+        # the explicit paid-subscriber sentence / Substack paywall block is decisive;
+        # weaker CTAs only count when the extracted body is short (cut off)
+        explicit = bool(markup) or any(k in marker for k in ("paid subscriber", "keep reading", "continue reading",
+                                                              "members", "unlock", "subscribers"))
+        if explicit or len(body_text) < 1200:
+            return True, marker[:60]
+    return False, ""
+
+
+def _youtube_oembed(session: requests.Session, url: str, timeout: float) -> Fetched:
+    f = Fetched(url=url, kind="video", final_url=url)
+    try:
+        r = session.get("https://www.youtube.com/oembed", params={"url": url, "format": "json"}, timeout=timeout)
+        f.status = r.status_code
+        if r.ok:
+            data = r.json()
+            f.title = (data.get("title") or "").strip()
+            f.author = (data.get("author_name") or "").strip() or None
+            f.ok = bool(f.title)
+            f.paywalled = False
+        else:
+            f.error = f"oembed {r.status_code}"
+    except requests.RequestException as exc:
+        f.error = type(exc).__name__
+    return f
+
+
+def fetch_one(session: requests.Session, url: str, *, timeout: float = 15.0) -> Fetched:
+    dom = domain_of(url)
+    if dom in ("youtube.com", "youtu.be", "m.youtube.com"):
+        return _youtube_oembed(session, url, timeout)
+    if dom in ("x.com", "twitter.com"):
+        return Fetched(url=url, kind="post", final_url=url, ok=True, paywalled=False, error="not-fetched:x.com")
+    f = Fetched(url=url)
+    try:
+        r = session.get(url, timeout=timeout, stream=True, allow_redirects=True)
+        f.status, f.final_url = r.status_code, r.url
+        ctype = (r.headers.get("Content-Type") or "").lower()
+        if "pdf" in ctype or f.final_url.lower().endswith(".pdf"):
+            r.close()
+            f.kind, f.ok, f.paywalled = "pdf", True, False
+            f.title = urlsplit(f.final_url).path.rsplit("/", 1)[-1]
+            return f
+        if r.status_code >= 400:
+            r.close()
+            f.error = f"http {r.status_code}"
+            return f
+        chunks, size = [], 0
+        for chunk in r.iter_content(65536):
+            chunks.append(chunk)
+            size += len(chunk)
+            if size > MAX_BYTES:
+                break
+        r.close()
+        raw = b"".join(chunks)
+        enc = r.encoding or "utf-8"
+        try:
+            html = raw.decode(enc, "replace")
+        except LookupError:
+            html = raw.decode("utf-8", "replace")
+    except requests.RequestException as exc:
+        f.error = type(exc).__name__
+        return f
+    try:
+        doc = Document(html)
+        article_html = doc.summary(html_partial=True)
+        f.title = (doc.short_title() or "").strip()
+        tree = lxml_html.fromstring(article_html) if article_html else None
+        body = ""
+        if tree is not None:
+            body = "\n".join(line.strip() for line in tree.text_content().splitlines() if line.strip())
+        page_tree = lxml_html.fromstring(html)
+        if not f.title:
+            t = page_tree.xpath("//title/text()")
+            f.title = (t[0] if t else "").strip()
+        f.author = _normalise_author(_meta(page_tree, _AUTHOR_META_NAMES))
+        f.excerpt = body[:EXCERPT_CHARS]
+        f.body_chars = len(body)
+        f.paywalled, f.paywall_reason = detect_paywall(html, body, f.final_url or url)
+        f.ok = bool(f.title or body)
+        if not f.ok:
+            f.error = "empty-extraction"
+    except Exception as exc:  # lxml/readability on odd markup
+        f.error = f"extract:{type(exc).__name__}"
+    return f
+
+
+class FetchCache:
+    def __init__(self, path: Path = FETCH_CACHE) -> None:
+        self.path = path
+        self._lock = threading.Lock()
+        self._data: Dict[str, Dict[str, Any]] = {}
+        if path.exists():
+            try:
+                self._data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("⚠️ fetch cache unreadable (%s) — starting empty", exc)
+
+    def get(self, url: str) -> Optional[Fetched]:
+        d = self._data.get(url)
+        return Fetched(**d) if d else None
+
+    def put(self, f: Fetched) -> None:
+        with self._lock:
+            self._data[f.url] = f.to_json()
+
+    def flush(self) -> None:
+        with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(self.path)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+def _session(pool: int) -> requests.Session:
+    s = requests.Session()
+    s.headers["User-Agent"] = _UA
+    s.headers["Accept"] = "text/html,application/xhtml+xml,application/pdf;q=0.9,*/*;q=0.8"
+    s.headers["Accept-Language"] = "en-US,en;q=0.9"
+    adapter = requests.adapters.HTTPAdapter(pool_connections=pool, pool_maxsize=pool)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
+def fetch_many(urls: Iterable[str], cache: FetchCache, *, workers: int = 8, timeout: float = 15.0,
+               retry_failed: bool = False) -> Dict[str, Fetched]:
+    """Fetch every URL (cache first). Returns ``{url: Fetched}``."""
+    out: Dict[str, Fetched] = {}
+    todo: List[str] = []
+    for u in dict.fromkeys(urls):
+        hit = cache.get(u)
+        if hit is not None and (hit.ok or not retry_failed):
+            out[u] = hit
+        else:
+            todo.append(u)
+    if todo:
+        session = _session(max(8, workers))
+        started = time.monotonic()
+
+        def work(u: str) -> Fetched:
+            f = fetch_one(session, u, timeout=timeout)
+            f.fetched_at = time.time()
+            return f
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futs = {pool.submit(work, u): u for u in todo}
+            done = 0
+            for fut in as_completed(futs):
+                f = fut.result()
+                out[f.url] = f
+                cache.put(f)
+                done += 1
+                if done % 100 == 0:
+                    logger.info("  … %d/%d pages fetched (%.0fs)", done, len(todo), time.monotonic() - started)
+        cache.flush()
+    ok = sum(1 for f in out.values() if f.ok)
+    logger.info("📄 fetched %d pages (%d cached, %d ok, %d paywalled, %d failed)",
+                len(out), len(out) - len(todo), ok, sum(1 for f in out.values() if f.paywalled),
+                sum(1 for f in out.values() if not f.ok))
+    return out

--- a/newsletter/triage/gmail.py
+++ b/newsletter/triage/gmail.py
@@ -444,6 +444,13 @@ def decode_local(link: Link) -> None:
         if url:
             link.target, link.via = url, "b64"
             return
+    # Substack link previews (and some plain-text newsletters) print the target
+    # URL as the anchor text — that *is* the destination, no network needed.
+    label = (link.text or "").strip()
+    if label.lower().startswith(("http://", "https://")) and " " not in label and is_redirector(href) \
+            and not is_redirector(label):
+        link.target, link.via = (label.split("?utm_")[0] if "?utm_" in label else label), "anchor-url"
+        return
     if not is_redirector(href):
         link.target, link.via = href, "direct"
 

--- a/newsletter/triage/rank.py
+++ b/newsletter/triage/rank.py
@@ -1,0 +1,197 @@
+"""Candidates → one edition: vetoes, caps, 8 per topic, star + must-read suggestions.
+
+Pure functions over ``Candidate`` records so the rules are unit-testable
+without Gmail, the hub or the network. The numbers come from
+``criteria.json → rules`` (see ``docs/newsletter-triage-criteria.md``).
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from newsletter.triage.score import ContentScore, MetaScore
+
+TOPICS = ("leadership and management", "personal development", "innovation")
+MIN_SCORE = 3.0          # below this a link is a "candidate", never auto-selected
+WEAK_FILL = 7.0          # selected but below this = "weak fill": listed, unticked, flagged
+ORG_AUTHORS = {"harvardbiz", "harvard business review", "mckinsey", "(not classified)", ""}
+# Multi-author publishers: when the byline is missing, two articles are NOT the same
+# author — the domain cap governs them, not the author cap.
+# Digest-style senders (several distinct articles per email): up to 3 picks per email.
+DIGEST_SENDER_HINTS = ("readwise", "hbr.org", "insead", "hbs.edu", "mckinsey", "strategy-business", "imd.org",
+                       "gallup", "thinkers50", "techcrunch", "joinsuperhuman", "quanta", "firstround", "stanford",
+                       "bcg.com", "simonsfoundation")
+MULTI_AUTHOR_DOMAINS = {"hbr.org", "mckinsey.com", "knowledge.insead.edu", "library.hbs.edu", "strategy-business.com",
+                        "imd.org", "bcg.com", "sloanreview.mit.edu", "inc.com", "fastcompany.com", "forbes.com",
+                        "theatlantic.com", "wired.com", "youtube.com", "x.com", "techcrunch.com", "readwise.io"}
+
+
+@dataclass
+class Candidate:
+    cid: str
+    message_id: str
+    sender_name: str
+    sender_address: str
+    subject: str
+    email_ts: str
+    label: str
+    url: str
+    canonical: str
+    domain: str
+    title: str = ""
+    author: Optional[str] = None
+    kind: str = "article"
+    fetched_ok: Optional[bool] = None
+    paywalled: Optional[bool] = None
+    in_notion: bool = False
+    sender_weight: float = 1.0
+    sender_basis: str = ""
+    is_new_sender: bool = False
+    domain_bonus: float = 0.0
+    meta: Optional[MetaScore] = None
+    content: Optional[ContentScore] = None
+    score: Optional[float] = None
+    topic: Optional[str] = None
+    verdict: str = "pending"   # selected | runner-up | candidate | vetoed | unknown | duplicate | low
+    reason: str = ""
+    summary: str = ""
+
+    @property
+    def display_title(self) -> str:
+        return (self.title or self.label or self.url)[:160]
+
+    @property
+    def author_key(self) -> str:
+        a = (self.author or "").strip().lower()
+        if a and a not in ORG_AUTHORS:
+            return a
+        if self.domain in MULTI_AUTHOR_DOMAINS:
+            return f"unknown:{self.cid}"
+        return f"sender:{self.sender_address}"
+
+
+@dataclass
+class Selection:
+    picks: Dict[str, List[Candidate]] = field(default_factory=lambda: {t: [] for t in TOPICS})
+    runners: Dict[str, List[Candidate]] = field(default_factory=lambda: {t: [] for t in TOPICS})
+    stars: Dict[str, Optional[Candidate]] = field(default_factory=lambda: {t: None for t in TOPICS})
+    must_read: Optional[Candidate] = None
+    short: Dict[str, int] = field(default_factory=dict)   # topic → missing count
+
+    def all_picks(self) -> List[Candidate]:
+        return [c for t in TOPICS for c in self.picks[t]]
+
+
+def resolve_topic(c: Candidate) -> Optional[str]:
+    if c.content is not None and c.content.ok and c.content.topic:
+        return c.content.topic
+    if c.meta is not None and c.meta.ok and c.meta.topic:
+        return c.meta.topic
+    return None
+
+
+def apply_vetoes(c: Candidate) -> None:
+    """Set verdict for anything that can never be selected; leave others ``pending``."""
+    if c.in_notion:
+        c.verdict, c.reason = "duplicate", "already in Notion"
+    elif c.sender_weight <= 0.0:
+        c.verdict, c.reason = "vetoed", f"sender {c.sender_basis}"
+    elif c.paywalled is True:
+        c.verdict, c.reason = "vetoed", "paywalled"   # fetch-level hard wall only — the LLM's
+        # "text looks cut off" flag over-fires on metered sites (HBR, INSEAD) and is advisory
+    elif (c.content is not None and c.content.ok and c.content.promo) or \
+            (c.content is None and c.meta is not None and c.meta.ok and c.meta.promo):
+        c.verdict, c.reason = "vetoed", "promo"
+    elif c.score is None:
+        c.verdict = "unknown"
+        c.reason = c.reason or ("not scored" if c.fetched_ok is not False else "fetch failed")
+    elif c.score < MIN_SCORE:
+        c.verdict = "low"
+        c.reason = (c.content.reason if c.content and c.content.ok else (c.meta.reason if c.meta and c.meta.ok else "")) or "below threshold"
+
+
+def select(cands: List[Candidate], rules: Dict[str, Any], *, per_topic: int = 8, runners_n: int = 6,
+           multi_pick_addrs: Optional[set] = None) -> Selection:
+    caps = rules.get("caps", {})
+    hbr_cap = int(caps.get("hbr_per_edition", {}).get("target", 3))
+    author_cap = int(caps.get("same_author_per_edition", {}).get("target", 2))
+    domain_cap = int(caps.get("same_domain_per_edition", {}).get("target", 3))
+    multi = multi_pick_addrs or set()
+
+    for c in cands:
+        if c.verdict == "pending":
+            apply_vetoes(c)
+        c.topic = resolve_topic(c) or c.topic     # LLM topic first, sender/domain prior as fallback
+
+    sel = Selection()
+    eligible = [c for c in cands if c.verdict == "pending" and c.topic in TOPICS and c.score is not None]
+    eligible.sort(key=lambda c: (-(c.score or 0), c.email_ts))
+
+    hbr_n = 0
+    author_n: Counter = Counter()
+    domain_n: Counter = Counter()
+    email_n: Counter = Counter()
+    seen_canon: set = set()
+    for c in eligible:
+        t = c.topic
+        if c.canonical in seen_canon:
+            c.verdict, c.reason = "duplicate", "same article already picked"
+            continue
+        if len(sel.picks[t]) >= per_topic:
+            continue
+        if c.domain == "hbr.org" and hbr_n >= hbr_cap:
+            c.reason = f"HBR cap {hbr_cap}"
+            continue
+        if author_n[c.author_key] >= author_cap:
+            c.reason = f"author cap {author_cap}"
+            continue
+        if domain_n[c.domain] >= domain_cap:
+            c.reason = f"domain cap {domain_cap}"
+            continue
+        per_email_cap = 3 if c.sender_address in multi or any(h in c.sender_address for h in DIGEST_SENDER_HINTS) else 1
+        if email_n[c.message_id] >= per_email_cap:
+            c.reason = "one pick per email"
+            continue
+        sel.picks[t].append(c)
+        c.verdict = "selected"
+        seen_canon.add(c.canonical)
+        if c.domain == "hbr.org":
+            hbr_n += 1
+        author_n[c.author_key] += 1
+        domain_n[c.domain] += 1
+        email_n[c.message_id] += 1
+
+    for c in eligible:
+        if c.verdict != "pending":
+            continue
+        t = c.topic
+        if c.canonical in seen_canon:
+            c.verdict, c.reason = "duplicate", "same article already listed"
+            continue
+        seen_canon.add(c.canonical)
+        if len(sel.runners[t]) < runners_n:
+            sel.runners[t].append(c)
+            c.verdict = "runner-up"
+            c.reason = c.reason or "next in line"
+        else:
+            c.verdict = "candidate"
+            c.reason = c.reason or "scored, below the fold"
+
+    # star per topic: best content.star, tie → score; must-read by topic prior × score
+    prior = rules.get("edition", {}).get("must_read_topic_prior", {})
+    best_mr, best_val = None, -1.0
+    for t in TOPICS:
+        picks = sel.picks[t]
+        if picks:
+            star = max(picks, key=lambda c: ((c.content.star or 0) if c.content and c.content.ok else 0, c.score or 0))
+            sel.stars[t] = star
+            val = (star.score or 0) * float(prior.get(t, 0.1))
+            if val > best_val:
+                best_mr, best_val = star, val
+        missing = per_topic - len(picks)
+        if missing > 0:
+            sel.short[t] = missing
+    sel.must_read = best_mr
+    return sel

--- a/newsletter/triage/report.py
+++ b/newsletter/triage/report.py
@@ -1,0 +1,126 @@
+"""Markdown report — the review surface for one window → one edition.
+
+Layout: ① shortlist per topic (ticked = suggested pick; runners-up unticked;
+⭐ / 🏆 suggestions flagged as suggestions), ② new senders to classify,
+③ one section per email in inbox order with every link and its verdict,
+④ stats footer. Each candidate line carries a hidden ``<!-- cand:ID -->`` so
+``feedback.py`` can read the owner's ticks back.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from newsletter.triage.rank import TOPICS, WEAK_FILL, Candidate, Selection
+
+VERDICT_ICON = {"selected": "✅", "runner-up": "🟡", "candidate": "⚪", "low": "⚪", "vetoed": "⛔",
+                "duplicate": "♻️", "unknown": "❔", "pending": "❔"}
+
+
+def _cand_line(c: Candidate, *, checked: bool, star: bool = False, must_read: bool = False) -> str:
+    box = "[x]" if checked else "[ ]"
+    flags = ("⭐ " if star else "") + ("🏆 " if must_read else "")
+    score = f"{c.score:.1f}" if c.score is not None else "?"
+    new = " **NEW sender**" if c.is_new_sender else ""
+    summ = f" — {c.summary}" if c.summary else ""
+    why = f" _({c.reason})_" if c.reason else ""
+    return (f"- {box} {flags}**{score}** [{c.display_title}]({c.url}) · {c.sender_name}{new}"
+            f"{summ}{why} <!-- cand:{c.cid} sender:{c.sender_address} -->")
+
+
+def _link_line(c: Candidate) -> str:
+    icon = VERDICT_ICON.get(c.verdict, "❔")
+    score = f"{c.score:.1f}" if c.score is not None else "–"
+    topic = c.topic or "–"
+    why = c.reason or (c.content.reason if c.content and c.content.ok else (c.meta.reason if c.meta and c.meta.ok else ""))
+    pay = " 🔒" if c.paywalled else ""
+    return f"  - {icon} `{c.verdict:9}` {score:>4} · {topic[:12]:12} · [{c.display_title[:90]}]({c.url}){pay} — {why}"
+
+
+def render_report(*, title: str, window_start: str, window_end: str, edition_hint: str, sel: Selection,
+                  emails: Sequence[Dict[str, Any]], cands_by_email: Dict[str, List[Candidate]],
+                  new_senders: Sequence[Tuple[str, str, int]], floor_senders: Sequence[Tuple[str, int]],
+                  stats: Dict[str, Any], backtest: Optional[Dict[str, Any]] = None) -> str:
+    L: List[str] = []
+    L.append(f"# {title}")
+    L.append("")
+    L.append(f"Window **{window_start} → {window_end}** · target edition **{edition_hint}** · "
+             f"{stats.get('emails', 0)} emails · {stats.get('links', 0)} links · {stats.get('scored', 0)} scored · "
+             f"{stats.get('fetched', 0)} fetched · {stats.get('llm_calls', 0)} LLM calls")
+    L.append("")
+    L.append("Tick = keep, untick = drop. ⭐ = suggested star, 🏆 = suggested must-read (suggestions, not decisions). "
+             "Run `python -m newsletter.triage.feedback <this file>` after reviewing to teach the sender weights.")
+    L.append("")
+    if backtest:
+        L.append(f"> **Backtest vs {backtest.get('edition')}** — precision@shortlist {backtest.get('precision', 0):.0%} "
+                 f"({backtest.get('hits', 0)}/{backtest.get('shortlist', 0)} were real picks in some edition), "
+                 f"recall of {backtest.get('edition')}'s picks from this window {backtest.get('recall', 0):.0%} "
+                 f"({backtest.get('recalled', 0)}/{backtest.get('truth', 0)}; +runners-up {backtest.get('recall_runners', 0):.0%}). "
+                 f"Missed: {backtest.get('missed_preview', '')}")
+        L.append("")
+        if backtest.get("diag"):
+            L.append("<details><summary>where each real pick ended up</summary>")
+            L.append("")
+            for d in backtest["diag"]:
+                L.append(f"- {d}")
+            L.append("")
+            L.append("</details>")
+            L.append("")
+    L.append("## Shortlist")
+    L.append("")
+    for t in TOPICS:
+        picks, runners = sel.picks[t], sel.runners[t]
+        short = sel.short.get(t, 0)
+        L.append(f"### {t} — {len(picks)}/8" + (f" ⚠️ short by {short} (backfill from `next` / classics)" if short else ""))
+        L.append("")
+        for c in picks:
+            weak = (c.score or 0) < WEAK_FILL
+            if weak and not c.reason:
+                c.reason = "weak fill — tick only if you agree"
+            L.append(_cand_line(c, checked=not weak, star=sel.stars.get(t) is c, must_read=sel.must_read is c))
+        if runners:
+            L.append("")
+            L.append("<details><summary>runners-up</summary>")
+            L.append("")
+            for c in runners:
+                L.append(_cand_line(c, checked=False))
+            L.append("")
+            L.append("</details>")
+        L.append("")
+    if new_senders:
+        L.append("## New senders — set a tier in `overrides.json` (always / usually / rarely / never / review)")
+        L.append("")
+        for name, addr, n in new_senders:
+            L.append(f"- `{addr}` — {name} ({n} email{'s' if n != 1 else ''} in window)")
+        L.append("")
+    L.append("## Emails (inbox order)")
+    L.append("")
+    for em in emails:
+        cands = cands_by_email.get(em["message_id"], [])
+        n_sel = sum(1 for c in cands if c.verdict == "selected")
+        n_run = sum(1 for c in cands if c.verdict == "runner-up")
+        head = f"{'✅' if n_sel else ('🟡' if n_run else '▫️')} **{em['sender_name']}** — {em['subject'][:100]} · {em['timestamp'][:10]}"
+        tier = em.get("sender_basis") or ""
+        L.append(f"### {head}")
+        L.append(f"_{len(cands)} link{'s' if len(cands) != 1 else ''} · sender prior: {tier}_" + (" · **NEW**" if em.get("is_new") else ""))
+        L.append("")
+        for c in cands:
+            L.append(_link_line(c))
+        if not cands:
+            L.append("  - (no candidate links)")
+        L.append("")
+    if floor_senders:
+        L.append("<details><summary>Floor senders in this window (0 picks in 54 weeks — listed, ranked last)</summary>")
+        L.append("")
+        for name, n in floor_senders:
+            L.append(f"- {name} ({n})")
+        L.append("")
+        L.append("</details>")
+        L.append("")
+    L.append("## Stats")
+    L.append("")
+    for k, v in stats.items():
+        L.append(f"- {k}: {v}")
+    L.append("")
+    return "\n".join(L)

--- a/newsletter/triage/run.py
+++ b/newsletter/triage/run.py
@@ -1,0 +1,521 @@
+"""Weekly triage engine — one review window → one edition-sized shortlist + report.
+
+    python -m newsletter.triage.run [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--days 7]
+                                    [--source gmail|cache] [--no-llm] [--no-fetch] [--top-k 90]
+                                    [--model claude_haiku] [--out DIR] [--debug]
+    python -m newsletter.triage.run --backtest N226[,N227,…]   # offline, from the history cache
+
+Cadence (owner rule): a run covers the window from the last watermark (or
+``--since``) to now and fills ONE edition (8/8/8); longer ranges are split into
+7-day windows, oldest first, one report each. Never drains the inbox into one
+edition. Nothing here writes to Notion, Gmail or Chrome.
+
+Pipeline per window: emails → non-noise links (decoded / resolved) → drop
+already-in-Notion → sender/domain priors (criteria.json + overrides.json) →
+stage-A metadata scoring (batched LLM) → fetch + stage-B content scoring for
+the top-K → vetoes (never-tier, paywalled, promo) → caps → shortlist →
+``results/newsletter/triage/triage-<start>_<end>.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rapidfuzz import fuzz, utils as rf_utils  # noqa: E402
+
+from config.console import force_utf8_stdio  # noqa: E402
+from config.loader import load_block, load_full_config  # noqa: E402
+from newsletter import llm, notion_io  # noqa: E402
+from newsletter.cache import canonicalize_url  # noqa: E402
+from newsletter.triage import fetch as fx  # noqa: E402
+from newsletter.triage import gmail as gm  # noqa: E402
+from newsletter.triage import rank as rk  # noqa: E402
+from newsletter.triage import report as rp  # noqa: E402
+from newsletter.triage import score as sc  # noqa: E402
+from newsletter.triage.criteria import CRITERIA_PATH  # noqa: E402
+
+logger = logging.getLogger("newsletter_triage.run")
+
+TRIAGE_DIR = REPO_ROOT / "results" / "newsletter" / "triage"
+HISTORY_DIR = TRIAGE_DIR / "history"
+STATE_PATH = TRIAGE_DIR / "state.json"
+NOTION_URLS_CACHE = TRIAGE_DIR / "notion_urls.json"
+DEFAULT_MODEL = "claude_haiku"
+
+
+# ---------------------------------------------------------------------------
+# inputs
+
+
+def load_criteria() -> Dict[str, Any]:
+    if not CRITERIA_PATH.exists():
+        raise FileNotFoundError(f"{CRITERIA_PATH} missing — run `python -m newsletter.triage.criteria`")
+    return json.loads(CRITERIA_PATH.read_text(encoding="utf-8"))
+
+
+def load_state() -> Dict[str, Any]:
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {}
+
+
+def save_state(state: Dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state, ensure_ascii=False, indent=1), encoding="utf-8")
+
+
+def _norm(text: str) -> str:
+    return rf_utils.default_process(text or "")
+
+
+def load_notion_urls(*, ttl_hours: int = 24, refresh: bool = False,
+                     created_before: Optional[str] = None) -> Tuple[set, Dict[str, str]]:
+    """Canonical URLs (+ normalised titles) of articles already in Notion — the dedupe set.
+
+    ``created_before`` (YYYY-MM-DD) restricts the set to articles created before
+    that day — a backtest must not "know" the picks it is trying to reproduce.
+    """
+    data: Optional[Dict[str, Any]] = None
+    if NOTION_URLS_CACHE.exists() and not refresh:
+        try:
+            d = json.loads(NOTION_URLS_CACHE.read_text(encoding="utf-8"))
+            if time.time() - float(d.get("fetched_at", 0)) < ttl_hours * 3600 and "created" in d:
+                data = d
+        except Exception:
+            data = None
+    if data is None:
+        cfg = load_full_config()
+        na = cfg["newsletter_archive"]
+        client = notion_io.init_client(cfg["notion"]["api_token"])
+        created: Dict[str, str] = {}
+        titles: Dict[str, List[str]] = {}
+        for page in notion_io._iter_database(client, na["articles_db_id"]):  # noqa: SLF001
+            link = (page["properties"].get("link", {}).get("url") or "").strip()
+            if not link:
+                continue
+            c = canonicalize_url(gm.canonical_substack(link))
+            day = (page.get("created_time") or "")[:10]
+            if c not in created or day < created[c]:
+                created[c] = day
+            t = notion_io._read_title(page, "article")  # noqa: SLF001
+            if t:
+                titles[_norm(t)] = [c, day]
+        data = {"fetched_at": time.time(), "created": created, "titles": titles}
+        NOTION_URLS_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        NOTION_URLS_CACHE.write_text(json.dumps(data), encoding="utf-8")
+        logger.info("🗂️ Notion dedupe set: %d article URLs", len(created))
+    created = data["created"]
+    titles = data["titles"]
+    if created_before:
+        urls = {c for c, day in created.items() if day < created_before}
+        tmap = {t: v[0] for t, v in titles.items() if v[1] < created_before}
+    else:
+        urls = set(created)
+        tmap = {t: v[0] for t, v in titles.items()}
+    return urls, tmap
+
+
+def emails_from_cache(start: date, end: date) -> List[gm.EmailRecord]:
+    path = HISTORY_DIR / "emails.jsonl"
+    if not path.exists():
+        raise FileNotFoundError(f"{path} missing — run `python -m newsletter.triage.history` first")
+    lo, hi = start.isoformat(), end.isoformat()
+    out: List[gm.EmailRecord] = []
+    with path.open("r", encoding="utf-8") as fp:
+        for line in fp:
+            if not line.strip():
+                continue
+            d = json.loads(line)
+            if lo <= d.get("timestamp", "")[:10] < hi:
+                out.append(gm.EmailRecord.from_json(d))
+    out.sort(key=lambda r: r.timestamp)
+    return out
+
+
+def emails_from_gmail(start: date, end: date, *, cfg: Dict[str, Any], budget: Optional[int] = None) -> List[gm.EmailRecord]:
+    tm = gm.build_mailbox(cfg)
+    try:
+        query = f"after:{start:%Y/%m/%d} before:{end:%Y/%m/%d}"
+        search = gm.label_search(tm, cfg.get("gmail_label", "newsletters"), query=query)
+        raws = gm.fetch_raw_messages(tm, search)
+    finally:
+        tm.close()
+    min_anchor = int(cfg.get("min_anchor_chars", gm.DEFAULT_MIN_ANCHOR_CHARS))
+    records = [gm.build_record(r, min_anchor_chars=min_anchor)[0] for r in raws]
+    records = [r for r in records if start.isoformat() <= r.timestamp[:10] < end.isoformat()]
+    records.sort(key=lambda r: r.timestamp)
+    cache = gm.RedirectCache(TRIAGE_DIR / "redirects.json")
+    stats = gm.resolve_links([l for r in records for l in r.links], cache,
+                             workers=int(cfg.get("redirect_workers", 8)),
+                             timeout=float(cfg.get("redirect_timeout_s", 10)), budget=budget)
+    logger.info("📬 %d emails in window, redirect resolve %s", len(records), stats)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# candidates
+
+
+def build_candidates(records: Sequence[gm.EmailRecord], priors: sc.Priors, notion_urls: set,
+                     notion_titles: Dict[str, str]) -> Tuple[List[rk.Candidate], Dict[str, List[rk.Candidate]]]:
+    cands: List[rk.Candidate] = []
+    by_email: Dict[str, List[rk.Candidate]] = defaultdict(list)
+    for rec in records:
+        weight, basis, is_new = priors.sender(rec.sender_address)
+        seen_in_email: set = set()
+        for i, link in enumerate(rec.links):
+            if link.noise:
+                continue
+            canonical = link.canonical
+            if link.resolved:
+                if canonical in seen_in_email:
+                    continue          # same article via two anchors (resolved after extraction-time dedupe)
+                seen_in_email.add(canonical)
+            dom = fx.domain_of(link.best_url)
+            bonus, _ = priors.domain(dom)
+            c = rk.Candidate(cid=f"{rec.message_id}:{i}", message_id=rec.message_id, sender_name=rec.sender_name,
+                             sender_address=rec.sender_address, subject=rec.subject, email_ts=rec.timestamp,
+                             label=link.label, url=link.best_url, canonical=canonical, domain=dom,
+                             sender_weight=weight, sender_basis=basis, is_new_sender=is_new, domain_bonus=bonus,
+                             topic=priors.topic_prior(rec.sender_address, dom))
+            if link.resolved and canonical in notion_urls:
+                c.in_notion = True
+            elif link.label and _norm(link.label) in notion_titles:
+                c.in_notion = True
+            if not link.resolved:
+                c.reason = "redirect unresolved"
+            cands.append(c)
+            by_email[rec.message_id].append(c)
+    return cands, by_email
+
+
+# ---------------------------------------------------------------------------
+# one window
+
+
+def run_window(start: date, end: date, *, cfg: Dict[str, Any], criteria: Dict[str, Any], source: str,
+               use_llm: bool, use_fetch: bool, top_k: int, model: str, out_dir: Path,
+               edition_hint: str = "next free edition", backtest: Optional[Dict[str, Any]] = None,
+               limit_links: Optional[int] = None) -> Tuple[Path, rk.Selection, Dict[str, Any]]:
+    t0 = time.monotonic()
+    base_url = cfg.get("llm_hub_base_url") or load_full_config().get("newsletter_archive", {}).get("llm_hub_base_url", "http://127.0.0.1:8000")
+    priors = sc.Priors(criteria)
+    rules = criteria.get("rules", {})
+    records = emails_from_cache(start, end) if source == "cache" else emails_from_gmail(start, end, cfg=cfg)
+    notion_urls, notion_titles = load_notion_urls(created_before=start.isoformat() if backtest is not None else None)
+    cands, by_email = build_candidates(records, priors, notion_urls, notion_titles)
+    if limit_links:
+        cands = cands[:limit_links]
+    stats: Dict[str, Any] = {"emails": len(records), "links": len(cands),
+                             "duplicates_in_notion": sum(1 for c in cands if c.in_notion),
+                             "unresolved_links": sum(1 for c in cands if c.reason == "redirect unresolved")}
+    llm_calls = 0
+    llm_cache = sc.LLMCache()
+
+    # stage A — metadata, for everything that can still be selected
+    stage_a = [c for c in cands if not c.in_notion and c.sender_weight > 0]
+    if use_llm and stage_a:
+        if not llm.health_check(base_url=base_url, model=model):
+            logger.error("❌ LLM hub unreachable at %s — producing a rule-only report", base_url)
+            use_llm = False
+    if use_llm and stage_a:
+        items = [{"sender": c.sender_name, "label": c.label or c.url, "domain": c.domain,
+                  "path": urlsplit(c.url).path} for c in stage_a]
+        metas = sc.score_metadata(items, criteria, base_url=base_url, model=model,
+                                  workers=int(cfg.get("llm_workers", 3)) + 1, cache=llm_cache)
+        llm_calls += (llm_cache.misses + 24) // 25
+        for c, m in zip(stage_a, metas):
+            c.meta = m
+            c.score = sc.combine(sender_weight=c.sender_weight, domain_bonus=c.domain_bonus, meta=m, content=None)
+        stats["stage_a_scored"] = sum(1 for c in stage_a if c.meta and c.meta.ok)
+    else:
+        for c in stage_a:   # rule-only: sender weight + domain prior as a weak score
+            c.score = round(min(10.0, c.sender_weight * (1 + c.domain_bonus) * 4.0), 2) if len(c.label) >= 25 else None
+            c.reason = "rule-only score (no LLM)" if c.score is not None else "short anchor, no LLM"
+
+    # stage B — fetch + content for the top-K
+    ranked = sorted([c for c in stage_a if c.score is not None], key=lambda c: -(c.score or 0))
+    depth = max(top_k, len(stage_a) // 12)          # a 2-week backlog window gets proportionally more depth
+    stage_b = ranked[:depth]
+    fetched_ok = 0
+    if use_fetch and stage_b:
+        cache = fx.FetchCache()
+        fetched = fx.fetch_many([c.url for c in stage_b], cache, workers=int(cfg.get("fetch_workers", 8)),
+                                timeout=float(cfg.get("fetch_timeout_s", 15)))
+        for c in stage_b:
+            f = fetched.get(c.url)
+            if not f:
+                continue
+            c.fetched_ok, c.kind, c.paywalled = f.ok, f.kind, f.paywalled
+            if f.title:
+                c.title = f.title
+            if f.author:
+                c.author = f.author
+            if f.ok:
+                fetched_ok += 1
+            elif f.error:
+                c.reason = f"fetch: {f.error}"
+            if f.final_url:
+                canon = canonicalize_url(gm.canonical_substack(f.final_url))
+                if canon in notion_urls:
+                    c.in_notion = True
+                c.domain = fx.domain_of(f.final_url) or c.domain
+            if f.title and _norm(f.title) in notion_titles:
+                c.in_notion = True
+        stats["fetched"] = len(stage_b)
+        stats["fetched_ok"] = fetched_ok
+        stats["paywalled"] = sum(1 for c in stage_b if c.paywalled)
+        if use_llm:
+            todo = [c for c in stage_b if c.fetched_ok and not c.in_notion and not c.paywalled and c.kind == "article"]
+            def work(c: rk.Candidate) -> None:
+                f = cache.get(c.url)
+                c.content = sc.score_content(title=c.title or c.label, author=c.author or "", sender=c.sender_name,
+                                             domain=c.domain, excerpt=f.excerpt if f else "", criteria=criteria,
+                                             base_url=base_url, model=model, cache=llm_cache)
+            with ThreadPoolExecutor(max_workers=int(cfg.get("llm_workers", 3))) as pool:
+                list(pool.map(work, todo))
+            llm_cache.flush()
+            llm_calls += len(todo)
+            for c in todo:
+                c.score = sc.combine(sender_weight=c.sender_weight, domain_bonus=c.domain_bonus, meta=c.meta, content=c.content)
+                if c.content and c.content.ok:
+                    c.summary = c.content.summary
+            stats["stage_b_scored"] = sum(1 for c in todo if c.content and c.content.ok)
+    stats["scored"] = sum(1 for c in cands if c.score is not None)
+    stats["llm_calls"] = llm_calls
+
+    multi = {a for a in priors.ranked if priors.multi_pick(a)}
+    sel = rk.select(cands, rules, multi_pick_addrs=multi)
+    stats["selected"] = len(sel.all_picks())
+    stats["verdicts"] = dict(Counter(c.verdict for c in cands))
+    stats["elapsed_s"] = round(time.monotonic() - t0, 1)
+
+    # senders bookkeeping
+    new_senders: Dict[str, Tuple[str, str, int]] = {}
+    floor: Counter = Counter()
+    emails_view: List[Dict[str, Any]] = []
+    for rec in records:
+        w, basis, is_new = priors.sender(rec.sender_address)
+        if is_new:
+            name, addr, n = new_senders.get(rec.sender_address, (rec.sender_name, rec.sender_address, 0))
+            new_senders[rec.sender_address] = (name, addr, n + 1)
+        if basis.startswith("floor"):
+            floor[rec.sender_name] += 1
+        emails_view.append({"message_id": rec.message_id, "sender_name": rec.sender_name, "subject": rec.subject,
+                            "timestamp": rec.timestamp, "sender_basis": basis, "is_new": is_new})
+
+    if backtest is not None:
+        backtest.update(_backtest_metrics(sel, cands, backtest))
+
+    title = f"Newsletter triage — {start} → {end}" + (f" (backtest {backtest['edition']})" if backtest else "")
+    md = rp.render_report(title=title, window_start=start.isoformat(), window_end=end.isoformat(), edition_hint=edition_hint,
+                          sel=sel, emails=emails_view, cands_by_email=by_email, new_senders=list(new_senders.values()),
+                          floor_senders=floor.most_common(), stats=stats, backtest=backtest)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    name = f"triage-{start}_{end}" + (f"-backtest-{backtest['edition']}" if backtest else "") + ".md"
+    path = out_dir / name
+    path.write_text(md, encoding="utf-8")
+    logger.info("📝 report: %s — %d picks (%s) in %.0fs", path, stats["selected"],
+                ", ".join(f"{t[:6]} {len(sel.picks[t])}" for t in rk.TOPICS), stats["elapsed_s"])
+    return path, sel, stats
+
+
+# ---------------------------------------------------------------------------
+# backtest
+
+
+def _truth_sets() -> Tuple[set, Dict[str, str], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    positives = [json.loads(l) for l in (HISTORY_DIR / "positives.jsonl").open(encoding="utf-8") if l.strip()]
+    matches = [json.loads(l) for l in (HISTORY_DIR / "matches.jsonl").open(encoding="utf-8") if l.strip()]
+    canon = {p["canonical"] for p in positives if p.get("canonical")}
+    titles = {_norm(p["title"]): p["canonical"] for p in positives if p.get("title")}
+    return canon, titles, positives, matches
+
+
+def _is_truth(c: rk.Candidate, canon: set, titles: Dict[str, str]) -> bool:
+    if c.canonical in canon:
+        return True
+    for t in (c.title, c.label):
+        if t and _norm(t) in titles:
+            return True
+    return False
+
+
+def _backtest_metrics(sel: rk.Selection, cands: List[rk.Candidate], bt: Dict[str, Any]) -> Dict[str, Any]:
+    canon, titles = bt["_canon"], bt["_titles"]
+    picks = sel.all_picks()
+    runners = [c for t in rk.TOPICS for c in sel.runners[t]]
+    hits = sum(1 for c in picks if _is_truth(c, canon, titles))
+    truth_ids = bt["_truth_msg_canon"]          # {(message_id, canonical)} of edition picks sourced in window
+    truth_canon = {cn for _m, cn in truth_ids}
+    truth_titles = bt["_truth_titles"]
+    def recalled_by(group: List[rk.Candidate]) -> int:
+        got = set()
+        for c in group:
+            if c.canonical in truth_canon:
+                got.add(c.canonical)
+            else:
+                for t in (c.title, c.label):
+                    if t and _norm(t) in truth_titles:
+                        got.add(truth_titles[_norm(t)])
+        return len(got)
+    n_truth = len(truth_canon)
+    rec_p = recalled_by(picks)
+    rec_r = recalled_by(picks + runners)
+    missed = [bt["_truth_names"].get(cn, cn) for cn in truth_canon
+              if cn not in {c.canonical for c in picks + runners}][:8]
+    # per-truth diagnostics: where did each real pick end up?
+    by_canon: Dict[str, List[rk.Candidate]] = defaultdict(list)
+    by_title: Dict[str, List[rk.Candidate]] = defaultdict(list)
+    for c in cands:
+        by_canon[c.canonical].append(c)
+        for t in (c.title, c.label):
+            if t:
+                by_title[_norm(t)].append(c)
+    diag: List[str] = []
+    for cn in sorted(truth_canon, key=lambda x: bt["_truth_names"].get(x, x)):
+        name = bt["_truth_names"].get(cn, cn)
+        found = by_canon.get(cn) or by_title.get(_norm(name)) or []
+        if not found:
+            diag.append(f"❌ not a candidate · {name[:80]} · {cn[:70]}")
+            continue
+        c = max(found, key=lambda x: (x.score or -1))
+        diag.append(f"{'✅' if c.verdict == 'selected' else '🟡' if c.verdict == 'runner-up' else '⚪'} "
+                    f"{c.verdict:9} {c.score if c.score is not None else '–'} · {c.topic or '–'} · {name[:70]} · {c.reason[:60]}")
+    return {"shortlist": len(picks), "hits": hits, "precision": hits / max(1, len(picks)),
+            "truth": n_truth, "recalled": rec_p, "recall": rec_p / max(1, n_truth),
+            "recall_runners": rec_r / max(1, n_truth), "missed_preview": "; ".join(missed), "diag": diag}
+
+
+def backtest_edition(number: str, *, cfg: Dict[str, Any], criteria: Dict[str, Any], use_llm: bool, use_fetch: bool,
+                     top_k: int, model: str, out_dir: Path, window_days: int = 14, offset_days: int = 7) -> Dict[str, Any]:
+    editions = [json.loads(l) for l in (HISTORY_DIR / "editions.jsonl").open(encoding="utf-8") if l.strip()]
+    ed = next((e for e in editions if e["number"] == number), None)
+    if not ed or not ed.get("date"):
+        raise SystemExit(f"edition {number} not in history/editions.jsonl")
+    d = date.fromisoformat(ed["date"])
+    end = d - timedelta(days=offset_days)
+    start = end - timedelta(days=window_days)
+    canon, titles, positives, matches = _truth_sets()
+    truth_msg_canon = set()
+    truth_titles: Dict[str, str] = {}
+    names: Dict[str, str] = {}
+    pos_by_id = {p["article_id"]: p for p in positives}
+    for m in matches:
+        if m["edition"] != number or not m.get("email_date"):
+            continue
+        if start.isoformat() <= m["email_date"] < end.isoformat():
+            p = pos_by_id.get(m["article_id"])
+            if p and p.get("canonical"):
+                truth_msg_canon.add((m.get("message_id"), p["canonical"]))
+                truth_titles[_norm(p["title"])] = p["canonical"]
+                names[p["canonical"]] = p["title"]
+    bt = {"edition": number, "_canon": canon, "_titles": titles, "_truth_msg_canon": truth_msg_canon,
+          "_truth_titles": truth_titles, "_truth_names": names}
+    logger.info("🧪 backtest %s (%s): window %s → %s, %d truth picks sourced in window", number, ed["date"], start, end,
+                len({cn for _m, cn in truth_msg_canon}))
+    path, sel, stats = run_window(start, end, cfg=cfg, criteria=criteria, source="cache", use_llm=use_llm,
+                                  use_fetch=use_fetch, top_k=top_k, model=model, out_dir=out_dir,
+                                  edition_hint=number, backtest=bt)
+    return {k: v for k, v in bt.items() if not k.startswith("_")} | {"report": str(path), "stats": stats}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def _windows(start: date, end: date, days: int = 7) -> List[Tuple[date, date]]:
+    out: List[Tuple[date, date]] = []
+    cur = start
+    while cur < end:
+        nxt = min(cur + timedelta(days=days), end)
+        if (end - nxt).days < 2 and nxt != end:   # avoid a 1-day tail window
+            nxt = end
+        out.append((cur, nxt))
+        cur = nxt
+    return out
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    force_utf8_stdio()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--since", help="window start (YYYY-MM-DD); default = state.reviewed_until or today-7")
+    ap.add_argument("--until", help="window end, exclusive (YYYY-MM-DD); default = tomorrow")
+    ap.add_argument("--days", type=int, default=7, help="window length when splitting a backlog")
+    ap.add_argument("--source", choices=("gmail", "cache"), default="gmail")
+    ap.add_argument("--no-llm", action="store_true")
+    ap.add_argument("--no-fetch", action="store_true")
+    ap.add_argument("--top-k", type=int, default=None)
+    ap.add_argument("--model", default=None)
+    ap.add_argument("--limit-links", type=int, default=None)
+    ap.add_argument("--out", default=str(TRIAGE_DIR))
+    ap.add_argument("--backtest", help="comma-separated edition numbers, e.g. N226,N227")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s", stream=sys.stdout)
+    for noisy in ("httpx", "notion_client", "urllib3", "googleapiclient"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    cfg = load_block("newsletter_triage")
+    criteria = load_criteria()
+    model = args.model or cfg.get("llm_model", DEFAULT_MODEL)
+    top_k = args.top_k or int(cfg.get("stage_b_top_k", 90))
+    out_dir = Path(args.out)
+
+    if args.backtest:
+        results = []
+        for num in [n.strip() for n in args.backtest.split(",") if n.strip()]:
+            results.append(backtest_edition(num, cfg=cfg, criteria=criteria, use_llm=not args.no_llm,
+                                            use_fetch=not args.no_fetch, top_k=top_k, model=model, out_dir=out_dir))
+        print("\n=== backtest summary ===")
+        for r in results:
+            print(f"{r['edition']}: precision {r['precision']:.0%} ({r['hits']}/{r['shortlist']}) · "
+                  f"recall {r['recall']:.0%} ({r['recalled']}/{r['truth']}) · +runners {r['recall_runners']:.0%} · {r['report']}")
+        (out_dir / "backtest-summary.json").write_text(json.dumps(results, ensure_ascii=False, indent=1, default=str), encoding="utf-8")
+        return 0
+
+    state = load_state()
+    today = date.today()
+    if args.since:
+        start = date.fromisoformat(args.since)
+    elif state.get("reviewed_until"):
+        start = date.fromisoformat(state["reviewed_until"][:10])
+    else:
+        start = today - timedelta(days=7)
+    end = date.fromisoformat(args.until) if args.until else today + timedelta(days=1)
+    windows = _windows(start, end, args.days)
+    logger.info("🗓️ %d window(s): %s", len(windows), ", ".join(f"{a}→{b}" for a, b in windows))
+    reports = []
+    for a, b in windows:
+        path, sel, stats = run_window(a, b, cfg=cfg, criteria=criteria, source=args.source, use_llm=not args.no_llm,
+                                      use_fetch=not args.no_fetch, top_k=top_k, model=model, out_dir=out_dir,
+                                      limit_links=args.limit_links)
+        reports.append({"window": [a.isoformat(), b.isoformat()], "report": str(path), "selected": stats["selected"]})
+    state.setdefault("runs", []).append({"at": datetime.now(timezone.utc).isoformat(), "windows": reports})
+    state["last_window_end"] = end.isoformat()
+    save_state(state)
+    for r in reports:
+        print(f"{r['window'][0]} → {r['window'][1]}: {r['selected']} picks → {r['report']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/triage/score.py
+++ b/newsletter/triage/score.py
@@ -1,0 +1,346 @@
+"""Scoring: deterministic priors from ``criteria.json`` + two LLM stages via the hub.
+
+* ``sender_weight`` / ``domain_bonus`` — owner overrides first (tier), then the
+  data priors (hit-rate per email, domain picks); unknown senders get a neutral
+  weight and the ``new`` flag.
+* **Stage A** (``score_metadata``) — batched, cheap: sender + anchor/title +
+  domain for every candidate → topic, fit 0–5, news/promo flags. Ranks the
+  long tail without fetching anything.
+* **Stage B** (``score_content``) — per candidate, after the page fetch: topic,
+  relevance 0–5, star-worthiness, news/promo/paywall signals, one-line summary.
+
+Both stages go through ``newsletter.llm.call`` (hub ``/v1/messages``), the
+model alias comes from ``config.newsletter_triage.llm_model``; responses are
+JSON and parsed defensively — a bad answer is an ``unknown`` state, never a 0.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from newsletter import llm
+
+logger = logging.getLogger("newsletter_triage.score")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LLM_CACHE_PATH = REPO_ROOT / "results" / "newsletter" / "triage" / "llm_cache.json"
+
+
+class LLMCache:
+    """JSON cache for both stages, keyed by a hash of (model, prompt inputs).
+
+    Makes re-runs and backtest iterations free for unchanged items; entries carry
+    the model alias so a model switch invalidates naturally.
+    """
+
+    def __init__(self, path: Path = LLM_CACHE_PATH) -> None:
+        self.path = path
+        self._lock = threading.Lock()
+        self._data: Dict[str, Any] = {}
+        self.hits = self.misses = 0
+        if path.exists():
+            try:
+                self._data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("⚠️ llm cache unreadable (%s) — starting empty", exc)
+
+    @staticmethod
+    def key(model: str, *parts: str) -> str:
+        return hashlib.sha1(("\x1f".join([model, *parts])).encode("utf-8", "ignore")).hexdigest()
+
+    def get(self, k: str) -> Any:
+        v = self._data.get(k)
+        if v is None:
+            self.misses += 1
+        else:
+            self.hits += 1
+        return v
+
+    def put(self, k: str, v: Any) -> None:
+        with self._lock:
+            self._data[k] = v
+
+    def flush(self) -> None:
+        with self._lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self.path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(self.path)
+
+TOPICS = ("leadership and management", "personal development", "innovation")
+TIER_WEIGHT = {"never": 0.0, "rarely": 0.35, "review": 1.0, "usually": 1.25, "always": 1.5}
+NEW_SENDER_WEIGHT = 0.85
+FLOOR_WEIGHT = 0.25
+MULTI_PICK_SENDERS = ("readwise.io", "hbr.org")   # digests where >1 pick per email is normal
+
+
+# ---------------------------------------------------------------------------
+# priors
+
+
+class Priors:
+    def __init__(self, criteria: Dict[str, Any]) -> None:
+        self.criteria = criteria
+        self.overrides: Dict[str, Dict[str, Any]] = {k.lower(): v for k, v in criteria.get("sender_overrides", {}).items()}
+        self.ranked: Dict[str, Dict[str, Any]] = {r["address"].lower(): r for r in criteria.get("sender_priors", {}).get("ranked", [])}
+        self.floor: Dict[str, Dict[str, Any]] = {r["address"].lower(): r for r in criteria.get("sender_priors", {}).get("floor", [])}
+        self.domains: Dict[str, Dict[str, Any]] = {d["domain"]: d for d in criteria.get("domain_priors", [])}
+        self.max_domain_picks = max([d["picks"] for d in self.domains.values()] + [1])
+
+    def sender(self, address: str) -> Tuple[float, str, bool]:
+        """→ (weight, basis, is_new)."""
+        a = (address or "").lower()
+        ov = self.overrides.get(a)
+        if ov:
+            tier = ov.get("tier", "review")
+            return TIER_WEIGHT.get(tier, 1.0), f"override:{tier}", False
+        r = self.ranked.get(a)
+        if r:
+            hit = float(r.get("hit_rate_per_email", 0.0))
+            return round(0.6 + min(1.0, hit) * 0.9, 3), f"hit {hit:.2f}/email", False
+        if a in self.floor:
+            return FLOOR_WEIGHT, "floor (0 picks in 54 weeks)", False
+        return NEW_SENDER_WEIGHT, "new sender", True
+
+    def sender_topics(self, address: str) -> Dict[str, int]:
+        r = self.ranked.get((address or "").lower())
+        return dict(r.get("topics", {})) if r else {}
+
+    def domain(self, dom: str) -> Tuple[float, int]:
+        d = self.domains.get(dom)
+        if not d:
+            return 0.0, 0
+        return round(0.3 * min(1.0, d["picks"] / max(10, self.max_domain_picks * 0.2)), 3), int(d["picks"])
+
+    def topic_prior(self, address: str, dom: str) -> Optional[str]:
+        """Most frequent topic of this sender, else of the domain — a weak prior for rule-only mode."""
+        for mix in (self.sender_topics(address), (self.domains.get(dom) or {}).get("topics", {})):
+            mix = {k: v for k, v in mix.items() if k in TOPICS}
+            if mix:
+                return max(mix, key=mix.get)
+        return None
+
+    def multi_pick(self, address: str) -> bool:
+        return any(h in (address or "") for h in MULTI_PICK_SENDERS)
+
+
+# ---------------------------------------------------------------------------
+# prompts
+
+def _criteria_brief(criteria: Dict[str, Any]) -> str:
+    rules = criteria.get("rules", {})
+    parts = ["Newsletter selection criteria (owner-validated, measured on 54 weeks):"]
+    for t in TOPICS:
+        tr = rules.get("topics", {}).get(t, {})
+        parts.append(f"- {t}: themes = {', '.join(tr.get('themes', []))}. Avoid: {', '.join(tr.get('anti_themes', []))}.")
+    np_ = rules.get("news_policy", {})
+    parts.append(f"- News policy: {np_.get('rule', '')} Keep: {'; '.join(np_.get('keep_if', []))}. Drop: {'; '.join(np_.get('drop_if', []))}.")
+    parts.append(f"- Never: {'; '.join(rules.get('content_exclusions', {}).get('anchors', []))}; paywalled content.")
+    parts.append(f"- Style: {rules.get('title_style', {}).get('note', '')}")
+    return "\n".join(parts)
+
+
+_JSON_BLOCK = re.compile(r"\[.*\]|\{.*\}", re.DOTALL)
+
+
+def _parse_json(text: str) -> Any:
+    text = text.strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.DOTALL)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        m = _JSON_BLOCK.search(text)
+        if m:
+            try:
+                return json.loads(m.group(0))
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _clamp(v: Any, lo: int = 0, hi: int = 5) -> Optional[int]:
+    try:
+        return max(lo, min(hi, int(round(float(v)))))
+    except (TypeError, ValueError):
+        return None
+
+
+def _topic(v: Any) -> Optional[str]:
+    s = (str(v) if v is not None else "").strip().lower()
+    for t in TOPICS:
+        if s == t or s.startswith(t[:10]):
+            return t
+    aliases = {"leadership": TOPICS[0], "management": TOPICS[0], "personal": TOPICS[1], "innovation": TOPICS[2], "ai": TOPICS[2]}
+    for k, t in aliases.items():
+        if k in s:
+            return t
+    return None
+
+
+# ---------------------------------------------------------------------------
+# stage A — metadata, batched
+
+
+@dataclass
+class MetaScore:
+    topic: Optional[str] = None
+    fit: Optional[int] = None          # 0–5
+    news: bool = False
+    promo: bool = False
+    reason: str = ""
+    ok: bool = False
+
+
+def _meta_key(model: str, it: Dict[str, str]) -> str:
+    return LLMCache.key(model, "A", it.get("sender", ""), it.get("label", ""), it.get("domain", ""), it.get("path", ""))
+
+
+def score_metadata(items: Sequence[Dict[str, str]], criteria: Dict[str, Any], *, base_url: str, model: str,
+                   batch: int = 25, timeout: int = 180, workers: int = 4,
+                   cache: Optional["LLMCache"] = None) -> List[MetaScore]:
+    """``items``: dicts with sender, label, domain, path. Returns one MetaScore per item (same order).
+
+    Batches run concurrently (``workers``) — the hub's per-call overhead (~8 s
+    CLI start for the Claude aliases) dominates, not generation. Cached items
+    are not re-sent.
+    """
+    brief = _criteria_brief(criteria)
+    out: List[MetaScore] = [MetaScore() for _ in items]
+    todo_idx: List[int] = []
+    for i, it in enumerate(items):
+        hit = cache.get(_meta_key(model, it)) if cache is not None else None
+        if hit:
+            out[i] = MetaScore(**hit)
+        else:
+            todo_idx.append(i)
+    if cache is not None:
+        logger.info("  stage A cache: %d hits, %d to score", len(items) - len(todo_idx), len(todo_idx))
+    starts = list(range(0, len(todo_idx), batch))
+    t0 = time.monotonic()
+    done = 0
+
+    def one(start: int) -> None:
+        idxs = todo_idx[start:start + batch]
+        chunk = [items[i] for i in idxs]
+        lines = [f"{i + 1}. sender=\"{it['sender'][:40]}\" | anchor=\"{it['label'][:120]}\" | domain={it['domain']} | path={it['path'][:80]}"
+                 for i, it in enumerate(chunk)]
+        prompt = (f"{brief}\n\nYou triage links from newsletter emails for a weekly curated newsletter with three sections. "
+                  f"For EACH numbered link below, judge from the metadata only (no fetching): the best-fitting topic, how well it fits "
+                  f"the criteria (fit 0–5: 0 = promo/noise/irrelevant, 3 = plausible, 5 = textbook pick), whether it is a news/"
+                  f"release announcement, whether it is a promo (course, book, product, event, sponsor). Be strict: most links are 0–2.\n"
+                  f"Return ONLY a JSON array with one object per link, in order: "
+                  f"{{\"i\": <number>, \"topic\": \"leadership and management|personal development|innovation\", \"fit\": 0-5, "
+                  f"\"news\": true|false, \"promo\": true|false, \"reason\": \"<= 12 words\"}}\n\n" + "\n".join(lines))
+        try:
+            text = llm.call(base_url=base_url, model=model, prompt=prompt, max_tokens=70 * len(chunk) + 150, timeout=timeout)
+            data = _parse_json(text)
+        except Exception as exc:  # noqa: BLE001 — logged, stays unknown
+            logger.warning("⚠️ stage-A batch %d failed: %s", start // batch, type(exc).__name__)
+            data = None
+        if not isinstance(data, list):
+            return
+        for obj in data:
+            if not isinstance(obj, dict):
+                continue
+            idx = _clamp(obj.get("i"), 1, len(chunk))
+            if idx is None:
+                continue
+            gi = idxs[idx - 1]
+            ms = out[gi]
+            ms.topic, ms.fit = _topic(obj.get("topic")), _clamp(obj.get("fit"))
+            ms.news, ms.promo = bool(obj.get("news")), bool(obj.get("promo"))
+            ms.reason, ms.ok = str(obj.get("reason") or "")[:160], ms.fit is not None
+            if cache is not None and ms.ok:
+                cache.put(_meta_key(model, items[gi]), ms.__dict__)
+
+    if starts:
+        with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+            for _ in pool.map(one, starts):
+                done += 1
+                if done % 5 == 0 or done == len(starts):
+                    logger.info("  … stage A %d/%d batches (%.0fs)", done, len(starts), time.monotonic() - t0)
+    if cache is not None:
+        cache.flush()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# stage B — content, per candidate
+
+
+@dataclass
+class ContentScore:
+    topic: Optional[str] = None
+    relevance: Optional[int] = None    # 0–5
+    star: Optional[int] = None         # 0–5
+    news: bool = False
+    promo: bool = False
+    paywall: bool = False
+    summary: str = ""
+    reason: str = ""
+    ok: bool = False
+
+
+def score_content(*, title: str, author: str, sender: str, domain: str, excerpt: str, criteria: Dict[str, Any],
+                  base_url: str, model: str, timeout: int = 120, cache: Optional["LLMCache"] = None) -> ContentScore:
+    ck = LLMCache.key(model, "B", title, sender, domain, excerpt[:2500]) if cache is not None else ""
+    if cache is not None:
+        hit = cache.get(ck)
+        if hit:
+            return ContentScore(**hit)
+    brief = _criteria_brief(criteria)
+    prompt = (f"{brief}\n\nJudge this article for the newsletter. Title: {title[:200]}\nAuthor: {author or '?'}\nSent by: {sender[:60]}\n"
+              f"Domain: {domain}\nText (excerpt):\n\"\"\"\n{excerpt[:2500]}\n\"\"\"\n\n"
+              f"Return ONLY JSON: {{\"topic\": \"leadership and management|personal development|innovation\", \"relevance\": 0-5, "
+              f"\"star\": 0-5 (would this be the single best of its section?), \"news\": true|false (release/announcement), "
+              f"\"promo\": true|false, \"paywall\": true|false (text is cut off behind a subscription wall), "
+              f"\"summary\": \"one line, <= 25 words\", \"reason\": \"<= 15 words why it fits or not\"}}")
+    cs = ContentScore()
+    try:
+        text = llm.call(base_url=base_url, model=model, prompt=prompt, max_tokens=300, timeout=timeout)
+        data = _parse_json(text)
+    except Exception as exc:  # noqa: BLE001
+        cs.reason = f"llm-error:{type(exc).__name__}"
+        return cs
+    if not isinstance(data, dict):
+        cs.reason = "llm-unparseable"
+        return cs
+    cs.topic, cs.relevance, cs.star = _topic(data.get("topic")), _clamp(data.get("relevance")), _clamp(data.get("star"))
+    cs.news, cs.promo, cs.paywall = bool(data.get("news")), bool(data.get("promo")), bool(data.get("paywall"))
+    cs.summary, cs.reason = str(data.get("summary") or "")[:240], str(data.get("reason") or "")[:160]
+    cs.ok = cs.relevance is not None
+    if cache is not None and cs.ok:
+        cache.put(ck, cs.__dict__)
+    return cs
+
+
+# ---------------------------------------------------------------------------
+# combine
+
+
+def combine(*, sender_weight: float, domain_bonus: float, meta: Optional[MetaScore], content: Optional[ContentScore]) -> Optional[float]:
+    """Final 0–10-ish score; None when no LLM signal exists (unknown, not zero)."""
+    base: Optional[float] = None
+    if content is not None and content.ok and content.relevance is not None:
+        base = content.relevance / 5.0
+        if content.star:
+            base += 0.04 * content.star
+    elif meta is not None and meta.ok and meta.fit is not None:
+        base = meta.fit / 5.0 * 0.85          # metadata-only is less certain
+    if base is None:
+        return None
+    score = base * sender_weight * (1.0 + domain_bonus) * 10.0
+    news = (content.news if content and content.ok else False) or (meta.news if meta and meta.ok else False)
+    if news:
+        score *= 0.6
+    return round(score, 2)

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -1,0 +1,180 @@
+"""Pure tests for the triage engine: ranking rules, report ↔ feedback round-trip,
+priors, paywall detection, LLM JSON parsing. No network, no hub, no Gmail."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from newsletter.triage import feedback as fb  # noqa: E402
+from newsletter.triage import fetch as fx  # noqa: E402
+from newsletter.triage import rank as rk  # noqa: E402
+from newsletter.triage import report as rp  # noqa: E402
+from newsletter.triage import score as sc  # noqa: E402
+
+RULES = {"caps": {"hbr_per_edition": {"target": 3}, "same_author_per_edition": {"target": 2},
+                  "same_domain_per_edition": {"target": 3}},
+         "edition": {"must_read_topic_prior": {"personal development": 0.6, "leadership and management": 0.35, "innovation": 0.04}}}
+
+
+def _cand(i: int, *, topic: str, score: float, domain: str = "example.com", sender: str = "a@x.com",
+          author: str = "", msg: str = None, **kw) -> rk.Candidate:
+    c = rk.Candidate(cid=f"m{i}:0", message_id=msg or f"m{i}", sender_name=sender.split("@")[0], sender_address=sender,
+                     subject="s", email_ts=f"2026-08-{10 + (i % 10):02d}T10:00:00+00:00", label=f"Article {i}",
+                     url=f"https://{domain}/a{i}", canonical=f"https://{domain}/a{i}", domain=domain, author=author or None,
+                     score=score, topic=topic, **kw)
+    if score is not None:
+        c.content = sc.ContentScore(topic=topic, relevance=int(min(5, score / 2)), star=i % 6, ok=True, reason="fits")
+    return c
+
+
+class RankTests(unittest.TestCase):
+    def test_caps_and_fill(self) -> None:
+        cands = []
+        for i in range(6):   # 6 HBR leadership → only 3 allowed
+            cands.append(_cand(i, topic="leadership and management", score=9 - i * 0.1, domain="hbr.org", sender="hbr@x.com"))
+        for i in range(10, 20):  # 10 other leadership, 3 from the same author
+            cands.append(_cand(i, topic="leadership and management", score=8 - i * 0.1, domain=f"d{i}.com",
+                               sender=f"s{i}@x.com", author="Same Person" if i < 13 else ""))
+        for i in range(30, 40):
+            cands.append(_cand(i, topic="personal development", score=7 - i * 0.05, domain=f"p{i}.com", sender=f"p{i}@x.com"))
+        sel = rk.select(cands, RULES)
+        lead = sel.picks["leadership and management"]
+        self.assertEqual(len(lead), 8)
+        self.assertEqual(sum(1 for c in lead if c.domain == "hbr.org"), 3)
+        self.assertEqual(sum(1 for c in lead if c.author == "Same Person"), 2)
+        self.assertEqual(len(sel.picks["personal development"]), 8)
+        self.assertEqual(sel.short.get("innovation"), 8)
+        self.assertIsNotNone(sel.stars["leadership and management"])
+        self.assertIs(sel.must_read.topic, "personal development")  # prior 0.6 × 7 > 0.35 × 9
+
+    def test_vetoes_and_states(self) -> None:
+        pay = _cand(1, topic="innovation", score=9.0, paywalled=True)
+        never = _cand(2, topic="innovation", score=9.0, sender_weight=0.0, sender_basis="override:never")
+        dup = _cand(3, topic="innovation", score=9.0, in_notion=True)
+        unknown = _cand(4, topic="innovation", score=None)
+        low = _cand(5, topic="innovation", score=1.0)
+        promo = _cand(6, topic="innovation", score=8.0)
+        promo.content.promo = True
+        good = _cand(7, topic="innovation", score=6.0)
+        sel = rk.select([pay, never, dup, unknown, low, promo, good], RULES)
+        self.assertEqual([c.verdict for c in (pay, never, dup, unknown, low, promo, good)],
+                         ["vetoed", "vetoed", "duplicate", "unknown", "low", "vetoed", "selected"])
+        self.assertEqual(pay.reason, "paywalled")
+        self.assertEqual(sel.picks["innovation"], [good])
+
+    def test_one_pick_per_email_except_digests(self) -> None:
+        a = _cand(1, topic="innovation", score=9.0, msg="same", sender="x@y.com")
+        b = _cand(2, topic="innovation", score=8.0, msg="same", sender="x@y.com")
+        r1 = _cand(3, topic="innovation", score=9.0, msg="rw", sender="hello@readwise.io")
+        r2 = _cand(4, topic="innovation", score=8.0, msg="rw", sender="hello@readwise.io")
+        sel = rk.select([a, b, r1, r2], RULES)
+        self.assertEqual(a.verdict, "selected")
+        self.assertEqual(b.verdict, "runner-up")
+        self.assertEqual((r1.verdict, r2.verdict), ("selected", "selected"))
+
+
+class PriorsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pr = sc.Priors({
+            "sender_overrides": {"pay@wall.com": {"tier": "never"}, "fav@x.com": {"tier": "always"}},
+            "sender_priors": {"ranked": [{"address": "hit@x.com", "hit_rate_per_email": 0.9, "topics": {"innovation": 5}}],
+                              "floor": [{"address": "alumni@x.edu"}]},
+            "domain_priors": [{"domain": "hbr.org", "picks": 150, "topics": {"leadership and management": 120}}],
+        })
+
+    def test_weights(self) -> None:
+        self.assertEqual(self.pr.sender("pay@wall.com")[0], 0.0)
+        self.assertEqual(self.pr.sender("FAV@x.com")[0], 1.5)
+        w, basis, new = self.pr.sender("hit@x.com")
+        self.assertAlmostEqual(w, 1.41, places=2)
+        self.assertFalse(new)
+        self.assertEqual(self.pr.sender("alumni@x.edu")[0], sc.FLOOR_WEIGHT)
+        w, basis, new = self.pr.sender("someone@new.com")
+        self.assertTrue(new)
+        self.assertEqual(basis, "new sender")
+        self.assertGreater(self.pr.domain("hbr.org")[0], 0)
+        self.assertEqual(self.pr.topic_prior("hit@x.com", "hbr.org"), "innovation")
+        self.assertEqual(self.pr.topic_prior("nobody@x.com", "hbr.org"), "leadership and management")
+
+    def test_combine(self) -> None:
+        m = sc.MetaScore(topic="innovation", fit=4, ok=True)
+        self.assertAlmostEqual(sc.combine(sender_weight=1.0, domain_bonus=0.0, meta=m, content=None), 6.8, places=1)
+        c = sc.ContentScore(topic="innovation", relevance=5, star=0, news=True, ok=True)
+        self.assertAlmostEqual(sc.combine(sender_weight=1.0, domain_bonus=0.0, meta=m, content=c), 6.0, places=1)
+        self.assertIsNone(sc.combine(sender_weight=1.0, domain_bonus=0.0, meta=None, content=None))
+
+    def test_json_parsing(self) -> None:
+        self.assertEqual(sc._parse_json('```json\n[{"i": 1}]\n```'), [{"i": 1}])
+        self.assertEqual(sc._parse_json('Sure! {"topic": "innovation"} done'), {"topic": "innovation"})
+        self.assertIsNone(sc._parse_json("no json here"))
+        self.assertEqual(sc._topic("Leadership & Management"), "leadership and management")
+        self.assertEqual(sc._topic("Personal Development"), "personal development")
+
+
+class PaywallTests(unittest.TestCase):
+    def test_substack_hard_wall(self) -> None:
+        html = '<div class="paywall">This post is for paid subscribers</div>'
+        self.assertEqual(fx.detect_paywall(html, "short", "https://x.substack.com/p/y"), (True, "this post is for paid subscribers"))
+
+    def test_metered_domains_stay_eligible(self) -> None:
+        html = "You've hit the paywall. Subscribe to keep reading."
+        self.assertEqual(fx.detect_paywall(html, "x" * 2000, "https://hbr.org/2026/08/a"), (False, "metered-ok"))
+
+    def test_free_substack_with_subscribe_box(self) -> None:
+        html = '<p>Subscribe now</p>' + "<p>body</p>" * 300
+        self.assertEqual(fx.detect_paywall(html, "x" * 5000, "https://x.substack.com/p/free")[0], False)
+
+
+class ReportFeedbackTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        good = _cand(1, topic="innovation", score=8.0, sender="fav@x.com")
+        run = _cand(2, topic="innovation", score=5.0, sender="meh@x.com")
+        sel = rk.select([good, run], RULES, per_topic=1)
+        md = rp.render_report(title="t", window_start="2026-08-08", window_end="2026-08-15", edition_hint="N230", sel=sel,
+                              emails=[{"message_id": "m1", "sender_name": "fav", "subject": "s", "timestamp": "2026-08-10",
+                                       "sender_basis": "override:always", "is_new": False}],
+                              cands_by_email={"m1": [good, run]}, new_senders=[("New Guy", "new@x.com", 2)],
+                              floor_senders=[("Alumni", 3)], stats={"emails": 1, "links": 2, "scored": 2, "fetched": 0, "llm_calls": 0})
+        self.assertIn("- [x]", md)
+        self.assertIn("<!-- cand:m1:0 sender:fav@x.com -->", md)
+        self.assertIn("New senders", md)
+        decisions = fb.parse_report(md)
+        self.assertEqual([(d["cid"], d["yes"]) for d in decisions], [("m1:0", True), ("m2:0", False)])
+        # owner unticks the pick, ticks the runner-up
+        md2 = md.replace("- [x] ", "- [ ] ", 1).replace("- [ ] **5.0**", "- [x] **5.0**")
+        decisions = fb.parse_report(md2)
+        self.assertEqual([d["yes"] for d in decisions], [False, True])
+        with tempfile.TemporaryDirectory() as td:
+            ov = Path(td) / "overrides.json"
+            ov.write_text(json.dumps({"senders": {"pay@wall.com": {"tier": "never"}}}), encoding="utf-8")
+            log = Path(td) / "feedback.jsonl"
+            for k in range(3):   # three reports of yes for meh@x.com → usually
+                res = fb.apply([{"cid": f"r{k}:0", "sender": "meh@x.com", "yes": True, "title": "t", "url": "u"}],
+                               report_name=f"r{k}.md", overrides_path=ov, log_path=log)
+            data = json.loads(ov.read_text(encoding="utf-8"))
+            self.assertEqual(data["senders"]["meh@x.com"]["tier"], "usually")
+            self.assertEqual(data["senders"]["pay@wall.com"]["tier"], "never")
+            self.assertEqual(len(log.read_text(encoding="utf-8").splitlines()), 3)
+            # re-ingesting the same report replaces, never double-counts
+            fb.apply([{"cid": "r0:0", "sender": "meh@x.com", "yes": False, "title": "t", "url": "u"}],
+                     report_name="r0.md", overrides_path=ov, log_path=log)
+            self.assertEqual(len(log.read_text(encoding="utf-8").splitlines()), 3)
+
+    def test_tier_rules(self) -> None:
+        self.assertIsNone(fb.tier_for(2, 2))
+        self.assertEqual(fb.tier_for(3, 3), "usually")
+        self.assertEqual(fb.tier_for(6, 6), "always")
+        self.assertEqual(fb.tier_for(5, 0), "rarely")
+        self.assertIsNone(fb.tier_for(4, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Step 2/3 of the newsletter triage (series #210 → **#211** → #212): the weekly engine that turns one review window into one edition-sized shortlist, the markdown review surface, the feedback loop, the `/newsletter-triage` skill and an offline backtest.

| SHA | What | Why |
|---|---|---|
| `8d40c65` | `newsletter/triage/run.py` + `fetch.py` + `score.py` + `rank.py` + `report.py` + `feedback.py`, skill (`.claude` + `.agents`), tests, README, architecture.mmd | The engine: one window → one edition (owner cadence rule; backlog = N windows), stage-A batched metadata scoring + stage-B content scoring through the hub (cached per model+inputs), fetch-level paywall veto (metered walls stay eligible), caps (HBR ≤ 3, author ≤ 2 with multi-author publishers exempt, domain ≤ 3, one pick per email except digests), ⭐/🏆 suggestions, weak-fill flag, review surface with hidden cand ids, ticks → sender tiers. Also the anchor-text-is-URL decoder in `gmail.py` (history match 93.9 % → 94.7 %). |
| `e0ec288` | README | First backtest numbers recorded. |

**First dry run** (last four editions, 2-week windows ending 7 days before each edition, `claude_haiku`): N224 precision 54 % / recall 16 %, N225 54 % / 26 %, N226 62 % / 50 %, N227 42 % / 29 % (+runners-up 21–56 %). Precision = share of the 24 suggestions that were real picks in some edition; recall = share of the edition's picks sourced in the window that made the shortlist. Each backtest report carries a per-pick diagnostic ("where each real pick ended up") — misses are mostly the caps doing their job (HBR ≤ 3 where the edition had 4, author ≤ 2) and picks just below the fold.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 126 tests OK (new: `test_triage_engine` 11)
- [x] `py_compile` on all `newsletter/triage/*.py`
- [x] `python -m newsletter.triage.run --backtest N224,N225,N226,N227` end-to-end (numbers above, reports under `results/newsletter/triage/`)
- [x] `python -m newsletter.triage.run --backtest N227 --no-llm --no-fetch` produces a rule-only report (hub down ≠ no report)
- [x] live Gmail path: `--since 2026-08-20 --until 2026-08-21 --source gmail --no-llm --no-fetch` → 13 emails, report written
- [x] feedback round-trip covered by `tests/test_triage_engine.py::ReportFeedbackTests`
- [x] skill file present in `.claude/skills` and `.agents/skills`

## Closed in this PR

Closes #211

## Still open

#212 — `--open` into the `:9222` Chrome, `--mark-reviewed` watermark comment, Streamlit button, root README.
