### PR TITLE
fix: triage dedupe across digests and slug-derived titles

### DIFF
--- a/newsletter/cache.py
+++ b/newsletter/cache.py
@@ -22,6 +22,7 @@ TRACKING_PARAM_PREFIXES = ("utm_", "mc_", "_hsenc", "_hsmi")
 TRACKING_PARAM_EXACT = {
     "ref", "gclid", "fbclid", "yclid", "msclkid",
     "ref_src", "ref_url", "triedredirect", "source",
+    "deliveryname", "ab", "_bhlid", "vgo_ee", "stcr", "__hscid__", "__hrlid__", "rw_tt_thread",
 }
 
 

--- a/newsletter/triage/rank.py
+++ b/newsletter/triage/rank.py
@@ -11,7 +11,20 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from urllib.parse import urlsplit
+
 from newsletter.triage.score import ContentScore, MetaScore
+
+
+def slug_title(url: str) -> str:
+    """``…/p/from-caterpillar-to-butterfly`` → ``From caterpillar to butterfly`` (display only)."""
+    path = urlsplit(url or "").path.rstrip("/")
+    seg = path.rsplit("/", 1)[-1] if path else ""
+    seg = seg.rsplit(".", 1)[0] if "." in seg else seg
+    words = [w for w in seg.replace("_", "-").split("-") if w and not w.isdigit()]
+    if len(words) < 2:
+        return (url or "")[:160]
+    return " ".join(words).capitalize()[:160]
 
 TOPICS = ("leadership and management", "personal development", "innovation")
 MIN_SCORE = 3.0          # below this a link is a "candidate", never auto-selected
@@ -60,7 +73,17 @@ class Candidate:
 
     @property
     def display_title(self) -> str:
-        return (self.title or self.label or self.url)[:160]
+        for t in (self.title, self.label):
+            t = (t or "").strip()
+            if t and not t.lower().startswith(("http://", "https://")):
+                return t[:160]
+        return slug_title(self.url)
+
+    @property
+    def path_key(self) -> str:
+        """host + path — the dedupe key that survives per-list tracking params."""
+        parts = urlsplit(self.canonical or self.url)
+        return f"{parts.netloc}{parts.path}".lower()
 
     @property
     def author_key(self) -> str:
@@ -136,7 +159,7 @@ def select(cands: List[Candidate], rules: Dict[str, Any], *, per_topic: int = 8,
     seen_canon: set = set()
     for c in eligible:
         t = c.topic
-        if c.canonical in seen_canon:
+        if c.canonical in seen_canon or c.path_key in seen_canon:
             c.verdict, c.reason = "duplicate", "same article already picked"
             continue
         if len(sel.picks[t]) >= per_topic:
@@ -157,6 +180,7 @@ def select(cands: List[Candidate], rules: Dict[str, Any], *, per_topic: int = 8,
         sel.picks[t].append(c)
         c.verdict = "selected"
         seen_canon.add(c.canonical)
+        seen_canon.add(c.path_key)
         if c.domain == "hbr.org":
             hbr_n += 1
         author_n[c.author_key] += 1
@@ -167,10 +191,11 @@ def select(cands: List[Candidate], rules: Dict[str, Any], *, per_topic: int = 8,
         if c.verdict != "pending":
             continue
         t = c.topic
-        if c.canonical in seen_canon:
+        if c.canonical in seen_canon or c.path_key in seen_canon:
             c.verdict, c.reason = "duplicate", "same article already listed"
             continue
         seen_canon.add(c.canonical)
+        seen_canon.add(c.path_key)
         if len(sel.runners[t]) < runners_n:
             sel.runners[t].append(c)
             c.verdict = "runner-up"

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -70,6 +70,21 @@ class RankTests(unittest.TestCase):
         self.assertEqual(pay.reason, "paywalled")
         self.assertEqual(sel.picks["innovation"], [good])
 
+    def test_same_article_different_tracking_params_dedupes(self) -> None:
+        a = _cand(1, topic="innovation", score=9.0, domain="hbr.org", sender="a@x.com")
+        b = _cand(2, topic="innovation", score=8.0, domain="hbr.org", sender="b@x.com")
+        a.url = a.canonical = "https://hbr.org/2026/08/article?deliveryName=NL_1"
+        b.url = b.canonical = "https://hbr.org/2026/08/article?deliveryName=NL_2"
+        sel = rk.select([a, b], RULES)
+        self.assertEqual((a.verdict, b.verdict), ("selected", "duplicate"))
+
+    def test_slug_title_when_label_is_a_url(self) -> None:
+        c = _cand(1, topic="innovation", score=9.0)
+        c.title, c.label = "", "https://rishad.substack.com/p/from-caterpillar-to-butterfly?utm_source=x"
+        c.url = c.label
+        self.assertEqual(c.display_title, "From caterpillar to butterfly")
+        self.assertEqual(rk.slug_title("https://x.com/abc"), "https://x.com/abc")
+
     def test_one_pick_per_email_except_digests(self) -> None:
         a = _cand(1, topic="innovation", score=9.0, msg="same", sender="x@y.com")
         b = _cand(2, topic="innovation", score=8.0, msg="same", sender="x@y.com")


### PR DESCRIPTION
## Summary

- the same HBR article arrived via the daily alert and the weekly hotlist with different `deliveryName` params and was shortlisted twice — strip the common per-list tracking params and dedupe picks/runners-up on host+path too
- when the page fetch fails and the anchor text is the URL itself, show a slug-derived title instead of the raw URL

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 128 tests OK
- [x] regenerated the two live reports: the duplicate HBR entry collapsed to one; raw-URL titles replaced by slug titles

Closes #215

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
