### PR TITLE
feat: newsletter triage step 4 — Chrome hand-off + Notion watermark

### DIFF
--- a/.agents/skills/newsletter-triage/SKILL.md
+++ b/.agents/skills/newsletter-triage/SKILL.md
@@ -5,19 +5,21 @@ description: Triage the 'newsletters' Gmail label into an edition-sized shortlis
 
 # newsletter-triage
 
-**Goal:** replace the manual inbox review with a stored, reviewable shortlist. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. The interactive review (tick / untick / promote, Apply, distil lessons) is the control panel's **🧭 triage** tab — this skill never writes to Notion, Gmail or Chrome (that is `--open` / `--mark-reviewed`, issue #212).
+**Goal:** replace the manual inbox review with a stored, reviewable shortlist. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. The interactive review (tick / untick / promote, Apply, distil lessons) is the control panel's **🧭 triage** tab. The only external writes are the two explicit hand-off flags — `--open` (tabs in the `:9222` Chrome) and `--mark-reviewed` (one Notion comment) — never run without the owner asking for them in this conversation.
 
 This is a **public repo** — never put secrets, tokens or private identifiers in issues, PRs, commits or the report.
 
 ## Arguments
 
-`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--force] [--backtest N226[,N227]] [--feedback <report.md>] [--lessons <run-id>] [--no-llm] [--source cache]`
+`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--force] [--backtest N226[,N227]] [--feedback <report.md>] [--lessons <run-id>] [--open <run-id>] [--mark-reviewed <run-id>] [--no-llm] [--source cache]`
 
 - default = window from the last watermark (`results/newsletter/triage/state.json → reviewed_until`, else today−7) to today, split into 7-day windows oldest first — **one report per window, one edition per report** (owner rule: never drain the inbox into one edition).
 - a window already stored in Supabase is **refused** (exit 3) unless `--force` — say so and ask before forcing; the owner's decisions survive a re-run.
 - `--backtest` = replay past editions offline from the history cache (stored as `kind=backtest` with the real picks as decisions) and print precision/recall.
 - `--feedback <report>` = ingest the owner's ticks from a markdown report → `triage_decisions` + `newsletter/triage/overrides.json` sender tiers.
 - `--lessons <run-id>` = distil the applied review of a stored run into ≤ 3 proposed criteria notes (hub alias `claude_sonnet`); list them — the owner accepts them in the tab or with `-m newsletter.triage.lessons --accept <ids>`.
+- `--open <run-id>` = `-m newsletter.triage.handoff --run <id> --open`: ensure the newsletter Chrome, one tab per ticked URL of the applied review (already-open tabs skipped); the unchanged `newsletter_pipeline.py archive` then takes over. With no applied review it falls back to the engine's suggested picks and says so.
+- `--mark-reviewed <run-id>` = `-m newsletter.triage.handoff --run <id> --mark-reviewed`: exactly one `until <newest e-mail, Gmail style> > included` comment on the task page + `state.json → reviewed_until`. `-m newsletter.triage.handoff --run <id>` alone prints both (URLs + line) and writes nothing.
 
 ## Step 1 — pre-flight
 
@@ -45,7 +47,7 @@ Then point the owner to the **🧭 triage** tab to review + Apply (or, for a mar
 
 ## Guardrails (non-negotiable)
 
-- Read-only towards Notion / Gmail / Chrome; the only writes are the Supabase `triage_*` rows, the markdown report, `overrides.json` / `lessons.json` when the owner decides.
+- Read-only towards Notion / Gmail / Chrome unless the owner explicitly asks for `--open` / `--mark-reviewed` in this conversation (the only external writes: tabs in the `:9222` Chrome, one Notion comment); everything else writes only the Supabase `triage_*` rows, the markdown report, `overrides.json` / `lessons.json` when the owner decides.
 - Paywalled content is never a pick (criteria §8); `overrides.json` `tier: never` wins over every score.
 - One window → one edition. Do not merge windows. Never `--force` without saying which stored run gets replaced.
 - Lessons are proposed, never auto-accepted.

--- a/.claude/skills/newsletter-triage/SKILL.md
+++ b/.claude/skills/newsletter-triage/SKILL.md
@@ -5,19 +5,21 @@ description: Triage the 'newsletters' Gmail label into an edition-sized shortlis
 
 # newsletter-triage
 
-**Goal:** replace the manual inbox review with a stored, reviewable shortlist. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. The interactive review (tick / untick / promote, Apply, distil lessons) is the control panel's **🧭 triage** tab — this skill never writes to Notion, Gmail or Chrome (that is `--open` / `--mark-reviewed`, issue #212).
+**Goal:** replace the manual inbox review with a stored, reviewable shortlist. Run the deterministic engine once, synchronously, read the report it wrote, summarise the shortlist in chat, and stop. The interactive review (tick / untick / promote, Apply, distil lessons) is the control panel's **🧭 triage** tab. The only external writes are the two explicit hand-off flags — `--open` (tabs in the `:9222` Chrome) and `--mark-reviewed` (one Notion comment) — never run without the owner asking for them in this conversation.
 
 This is a **public repo** — never put secrets, tokens or private identifiers in issues, PRs, commits or the report.
 
 ## Arguments
 
-`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--force] [--backtest N226[,N227]] [--feedback <report.md>] [--lessons <run-id>] [--no-llm] [--source cache]`
+`[--days N] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--force] [--backtest N226[,N227]] [--feedback <report.md>] [--lessons <run-id>] [--open <run-id>] [--mark-reviewed <run-id>] [--no-llm] [--source cache]`
 
 - default = window from the last watermark (`results/newsletter/triage/state.json → reviewed_until`, else today−7) to today, split into 7-day windows oldest first — **one report per window, one edition per report** (owner rule: never drain the inbox into one edition).
 - a window already stored in Supabase is **refused** (exit 3) unless `--force` — say so and ask before forcing; the owner's decisions survive a re-run.
 - `--backtest` = replay past editions offline from the history cache (stored as `kind=backtest` with the real picks as decisions) and print precision/recall.
 - `--feedback <report>` = ingest the owner's ticks from a markdown report → `triage_decisions` + `newsletter/triage/overrides.json` sender tiers.
 - `--lessons <run-id>` = distil the applied review of a stored run into ≤ 3 proposed criteria notes (hub alias `claude_sonnet`); list them — the owner accepts them in the tab or with `-m newsletter.triage.lessons --accept <ids>`.
+- `--open <run-id>` = `-m newsletter.triage.handoff --run <id> --open`: ensure the newsletter Chrome, one tab per ticked URL of the applied review (already-open tabs skipped); the unchanged `newsletter_pipeline.py archive` then takes over. With no applied review it falls back to the engine's suggested picks and says so.
+- `--mark-reviewed <run-id>` = `-m newsletter.triage.handoff --run <id> --mark-reviewed`: exactly one `until <newest e-mail, Gmail style> > included` comment on the task page + `state.json → reviewed_until`. `-m newsletter.triage.handoff --run <id>` alone prints both (URLs + line) and writes nothing.
 
 ## Step 1 — pre-flight
 
@@ -45,7 +47,7 @@ Then point the owner to the **🧭 triage** tab to review + Apply (or, for a mar
 
 ## Guardrails (non-negotiable)
 
-- Read-only towards Notion / Gmail / Chrome; the only writes are the Supabase `triage_*` rows, the markdown report, `overrides.json` / `lessons.json` when the owner decides.
+- Read-only towards Notion / Gmail / Chrome unless the owner explicitly asks for `--open` / `--mark-reviewed` in this conversation (the only external writes: tabs in the `:9222` Chrome, one Notion comment); everything else writes only the Supabase `triage_*` rows, the markdown report, `overrides.json` / `lessons.json` when the owner decides.
 - Paywalled content is never a pick (criteria §8); `overrides.json` `tier: never` wins over every score.
 - One window → one edition. Do not merge windows. Never `--force` without saying which stored run gets replaced.
 - Lessons are proposed, never auto-accepted.

--- a/app/tab_triage.py
+++ b/app/tab_triage.py
@@ -260,8 +260,10 @@ def _render_review(run: dict) -> None:
                   on_click=_launch, args=(handoff + ["--mark-reviewed"],),
                   help="Writes exactly one 'until <newest e-mail> > included' comment on the newsletters task page "
                        "and advances the local watermark. Without clicking, the run only prints the line.")
-        st.button("👀 Preview hand-off", key=f"triage-preview-{run_id}", disabled=running,
-                  on_click=_launch, args=(handoff,), help="Print the URLs and the watermark line — no writes.")
+        st.button("👀 Dry run (Chrome plan)", key=f"triage-preview-{run_id}", disabled=running,
+                  on_click=_launch, args=(handoff + ["--open", "--dry-run"],),
+                  help="Ensure Chrome, connect, list its tabs and print what would open / is already open, plus the "
+                       "watermark line — opens nothing, writes nothing. Follow it in ▶ run.")
     _render_lessons(run_id, start, end)
     _render_new_senders(run_id)
     report_path = run.get("report_path")
@@ -325,12 +327,22 @@ def run() -> None:
         st.error(f"triage store unavailable: {str(err)[:300]}")
         st.caption("Apply `newsletter/triage/schema.sql` once in the Supabase SQL editor if the tables are missing.")
         runs = []
-    _render_run_controls(runs)
-    st.divider()
+
+    # Two sub-sections (owner request): the run side and the review side stay separate. segmented_control
+    # rather than st.tabs() — same fix as app.py's top-level routing (issue #157).
+    SUB_SECTIONS = ["▶ run", "📋 review"]
+    sub = st.segmented_control("triage sub-section", options=SUB_SECTIONS, default=SUB_SECTIONS[0],
+                               key="triage-sub-section", label_visibility="collapsed")
+    sub = sub or SUB_SECTIONS[0]
+    if sub == "▶ run":
+        _render_run_controls(runs)
+        return
     if not runs:
-        st.info("no stored runs yet — run a week above, or import history: "
+        st.info("no stored runs yet — run a week in ▶ run, or import history: "
                 "`python -m newsletter.triage.db import-history` then `python -m newsletter.triage.run --backtest N224,N225,N226,N227`")
         return
+    if is_running(PIPELINE_NAME):
+        st.info("a triage process is running — follow it in ▶ run; stored runs below refresh when it finishes")
     options = {f"{r['window_start']} → {r['window_end']} · {r['kind']}"
                + (f" {r.get('edition')}" if r.get("edition") else "")
                + f" · {r['status']} · {r.get('picks') if r.get('picks') is not None else '?'} picks"

--- a/app/tab_triage.py
+++ b/app/tab_triage.py
@@ -246,6 +246,22 @@ def _render_review(run: dict) -> None:
     if prior:
         st.caption(f"last applied {str(prior.get('reviewed_at', ''))[:16]} · {prior.get('n_pick')} picks · "
                    + (f"{len(prior.get('tier_changes') or [])} tier change(s)"))
+    # hand-off (issue #212): the two external writes, each an explicit click, streamed into the log panel
+    # like every other pipeline step (Playwright + Notion run in the subprocess, never in the Streamlit thread)
+    handoff = [str(VENV_PY), "-m", "newsletter.triage.handoff", "--run", str(run_id)]
+    running = is_running(PIPELINE_NAME)
+    with st.container(horizontal=True, gap="small"):
+        st.button("🌐 Open ticked in Chrome (:9222)", key=f"triage-open-{run_id}", disabled=running or prior is None,
+                  on_click=_launch, args=(handoff + ["--open"],),
+                  help="ensure_chrome() then one tab per ticked URL (already-open tabs skipped) — then run "
+                       "② Archive → Notion in the newsletter tab as usual.")
+        st.button("📝 Mark reviewed in Notion", key=f"triage-mark-{run_id}", disabled=running or prior is None
+                  or run.get("kind") != "live",
+                  on_click=_launch, args=(handoff + ["--mark-reviewed"],),
+                  help="Writes exactly one 'until <newest e-mail> > included' comment on the newsletters task page "
+                       "and advances the local watermark. Without clicking, the run only prints the line.")
+        st.button("👀 Preview hand-off", key=f"triage-preview-{run_id}", disabled=running,
+                  on_click=_launch, args=(handoff,), help="Print the URLs and the watermark line — no writes.")
     _render_lessons(run_id, start, end)
     _render_new_senders(run_id)
     report_path = run.get("report_path")

--- a/config/config_example.json
+++ b/config/config_example.json
@@ -301,7 +301,8 @@
         "fetch_workers": 8,
         "fetch_timeout_s": 15,
         "llm_workers": 3,
-        "lessons_model": "claude_sonnet"
+        "lessons_model": "claude_sonnet",
+        "notion_task_page_id": "your_notion_task_page_id_here"
     },
     "engagement": {
         "default_days": 5,

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -90,6 +90,8 @@ flowchart TB
   NTRIAGEREVIEW -->|"triage_decisions / reviews /\nlessons / editions / picks"| SUPA
   NTRIAGEREVIEW -->|"distil review comment\n(claude_sonnet alias)"| LLMHUB
   APP -->|"🧭 triage tab: run (slot 'triage'),\neditable table → Apply, distil, tiers"| NTRIAGEREVIEW
+  NTRIAGEREVIEW -->|"handoff.py --open: ticked URLs\nas tabs (then archive, unchanged)"| NBOOT
+  NTRIAGEREVIEW -->|"handoff.py --mark-reviewed:\none 'until … > included' comment"| NOTION
   TRIAGESKILL["newsletter-triage skill\n(.claude/skills/, .agents/skills/)"] --> NTRIAGERUN
   NARCHIVE -->|"readability-lxml extraction"| NOTION
   NARCHIVE --> LLMHUB[("local LLM hub\n127.0.0.1:8000\ntopic + 3-line summary")]

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -344,6 +344,13 @@ markdown report renders in an expander (one source, no second copy).
 | `python -m newsletter.triage.db import-history` | Load `triage_editions` + `triage_picks` from `results/newsletter/triage/history/`. |
 | `python -m newsletter.triage.run --backtest N224,N225,N226,N227 --force` | Store the four backtests with the real picks as decisions (the first knowledge base). |
 | `python -m newsletter.triage.lessons --run <id>` / `--accept 1,2` / `--list` | Distil / accept / list lessons from the CLI. |
+| `python -m newsletter.triage.handoff --run <id>` | Hand-off preview (issue #212): the ticked URLs + the `until <newest e-mail> > included` watermark line — no writes. |
+| `python -m newsletter.triage.handoff --run <id> --open` | `ensure_chrome()` then one tab per ticked URL in the `:9222` Chrome (already-open tabs skipped) → run ② Archive as usual. |
+| `python -m newsletter.triage.handoff --run <id> --mark-reviewed` | Exactly one watermark comment on the `newsletters processing` task page (`notion_task_page_id`) + `state.json → reviewed_until`. |
+
+The tab's **🌐 Open ticked in Chrome** / **📝 Mark reviewed in Notion** /
+**👀 Preview hand-off** buttons run the same commands in the `triage` log
+panel (enabled once a review is applied; mark-reviewed only for live runs).
 
 ### Gmail one-time setup
 

--- a/newsletter/triage/handoff.py
+++ b/newsletter/triage/handoff.py
@@ -1,0 +1,229 @@
+"""Hand-off after a review — the two writes the triage never does on its own (issue #212).
+
+    python -m newsletter.triage.handoff --run 6 --open              # ticked URLs → tabs in the :9222 Chrome
+    python -m newsletter.triage.handoff --run 6 --mark-reviewed     # "until … > included" comment on the Notion task page
+    python -m newsletter.triage.handoff --run 6                     # neither: print what both would do
+
+``--open``: ``bootstrap_chrome.ensure_chrome()`` (targeted, idempotent) then one new tab per ticked URL
+of the run's window (from ``triage_decisions``; falls back to the engine's suggested picks only when
+the owner has not applied a review, and says so). Idempotent against tabs already open. The unchanged
+``newsletter_pipeline.py archive`` step then takes over.
+
+``--mark-reviewed``: exactly one comment on the configured task page (``config.newsletter_triage.
+notion_task_page_id``) in the owner's own style — ``until Fri 07/08 3:17 PM > included`` — where the
+timestamp is the newest e-mail of the window in local time, then ``state.json → reviewed_until``.
+Without the flag the line is only printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from config.console import force_utf8_stdio  # noqa: E402
+from config.loader import load_block, load_full_config  # noqa: E402
+from newsletter.cache import TRACKING_PARAM_EXACT, TRACKING_PARAM_PREFIXES, canonicalize_url  # noqa: E402
+from newsletter.triage import db  # noqa: E402
+from newsletter.triage.state import load_state, save_state  # noqa: E402
+
+logger = logging.getLogger("newsletter_triage.handoff")
+
+
+# ---------------------------------------------------------------------------
+# what to open
+
+
+def ticked_urls(run_id: int) -> Tuple[List[str], str]:
+    """URLs to hand off for a stored run: the owner's ticks (``pick=True``) for the run's window, else
+    the engine's suggested picks. Returns ``(urls, source)`` with source ``decisions`` | ``suggestions``."""
+    run = db.get_run(run_id)
+    if not run:
+        raise ValueError(f"run {run_id} not found")
+    decisions = db.load_decisions(run["window_start"], run["window_end"])
+    if decisions:
+        urls = [open_url(d.get("url"), d.get("canonical")) for d in decisions if d.get("pick")]
+        return _dedupe([u for u in urls if u]), "decisions"
+    cands = db.candidates(run_id)
+    urls = [open_url(c.get("url"), c.get("canonical"))
+            for c in sorted(cands, key=lambda c: (c.get("topic") or "", c.get("suggested_rank") or 99))
+            if c.get("suggested") == "pick"]
+    return _dedupe([u for u in urls if u]), "suggestions"
+
+
+_APP_LINK_HOSTS = ("open.substack.com", "substack.com")
+
+
+def open_url(url: Optional[str], canonical: Optional[str]) -> str:
+    """The URL to put in a tab: the original href with tracking params stripped (host kept as-is — the
+    canonical form drops ``www.`` and reorders the query, fine for a dedupe key, not always loadable);
+    Substack app-links / redirects use the canonical post URL instead."""
+    if not url:
+        return canonical or ""
+    parts = urlsplit(url.strip())
+    if canonical and parts.netloc.lower() in _APP_LINK_HOSTS:
+        return canonical
+    kept = [(k, v) for k, v in parse_qsl(parts.query, keep_blank_values=True)
+            if not k.lower().startswith(TRACKING_PARAM_PREFIXES) and k.lower() not in TRACKING_PARAM_EXACT]
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(kept), ""))
+
+
+def _dedupe(urls: Sequence[str]) -> List[str]:
+    seen, out = set(), []
+    for u in urls:
+        k = canonicalize_url(u)
+        if k not in seen:
+            seen.add(k)
+            out.append(u)
+    return out
+
+
+def plan_open(urls: Sequence[str], already_open: Sequence[str]) -> Tuple[List[str], List[str]]:
+    """Split ``urls`` into (to_open, skipped) against the tabs already open — canonical match."""
+    open_keys = {canonicalize_url(u) for u in already_open if u}
+    to_open, skipped = [], []
+    for u in urls:
+        (skipped if canonicalize_url(u) in open_keys else to_open).append(u)
+    return to_open, skipped
+
+
+def open_in_chrome(urls: Sequence[str], *, debug_port: int = 9222) -> Dict[str, Any]:
+    """Ensure the newsletter Chrome, open one tab per URL not already open. Returns counts + the skipped list."""
+    from newsletter import chrome_tabs  # noqa: PLC0415 — Playwright, imported only when opening
+    from newsletter.bootstrap_chrome import ensure_chrome  # noqa: PLC0415
+
+    rc = ensure_chrome()
+    if rc != 0:
+        raise RuntimeError(f"Chrome on :{debug_port} not reachable (bootstrap exit {rc})")
+    browser = chrome_tabs.connect(debug_port)
+    try:
+        open_urls = [t.url for t in chrome_tabs.list_tabs(browser)]
+        to_open, skipped = plan_open(urls, open_urls)
+        context = browser.contexts[0] if browser.contexts else browser.new_context()
+        opened = 0
+        for u in to_open:
+            page = context.new_page()
+            try:
+                page.goto(u, wait_until="domcontentloaded", timeout=30_000)
+            except Exception as err:  # noqa: BLE001 — a slow page is still an open tab; archive handles it
+                logger.warning("⚠️ %s — %s (tab left open)", u[:80], str(err)[:80])
+            opened += 1
+            logger.info("🌐 opened %d/%d · %s", opened, len(to_open), u[:100])
+    finally:
+        chrome_tabs.close_browser(browser)
+    return {"opened": opened, "skipped_open": len(skipped), "skipped": skipped, "total": len(urls)}
+
+
+# ---------------------------------------------------------------------------
+# watermark
+
+
+def window_until(run_id: int) -> Optional[datetime]:
+    """Newest e-mail timestamp of the run (UTC-aware), or None when the run has no emails."""
+    emails = db.emails(run_id)
+    stamps = []
+    for e in emails:
+        ts = e.get("ts")
+        if not ts:
+            continue
+        try:
+            d = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        stamps.append(d if d.tzinfo else d.replace(tzinfo=timezone.utc))
+    return max(stamps) if stamps else None
+
+
+def watermark_line(until: datetime, *, window: Optional[Tuple[str, str]] = None) -> str:
+    """``until Fri 07/08 3:17 PM > included`` in local time — the owner's own Gmail-style comment."""
+    local = until.astimezone()
+    hour = local.strftime("%I").lstrip("0") or "12"
+    stamp = f"{local.strftime('%a')} {local.strftime('%d/%m')} {hour}:{local.strftime('%M %p')}"
+    line = f"until {stamp} > included"
+    if window:
+        line += f" (triage {window[0]} → {window[1]})"
+    return line
+
+
+def mark_reviewed(run_id: int, *, line: str, page_id: Optional[str] = None, client: Any = None) -> Dict[str, Any]:
+    """Create exactly one comment on the task page and advance the local watermark. Returns the comment id."""
+    page_id = page_id or load_block("newsletter_triage").get("notion_task_page_id")
+    if not page_id:
+        raise RuntimeError("config.newsletter_triage.notion_task_page_id is not set")
+    if client is None:
+        from newsletter import notion_io  # noqa: PLC0415
+        client = notion_io.init_client(load_full_config()["notion"]["api_token"])
+    res = client.comments.create(parent={"page_id": page_id}, rich_text=[{"type": "text", "text": {"content": line}}])
+    run = db.get_run(run_id) or {}
+    state = load_state()
+    end = str(run.get("window_end") or "")[:10]
+    if end and end > (state.get("reviewed_until") or "")[:10]:
+        state["reviewed_until"] = end
+    state.setdefault("watermarks", []).append({"run_id": run_id, "line": line, "comment_id": res.get("id"),
+                                               "at": datetime.now(timezone.utc).isoformat()})
+    save_state(state)
+    logger.info("📝 Notion comment created (%s): %s", res.get("id"), line)
+    return {"comment_id": res.get("id"), "line": line, "reviewed_until": state.get("reviewed_until")}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    force_utf8_stdio()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run", type=int, required=True, help="stored run id (control panel → stored run)")
+    ap.add_argument("--open", action="store_true", help="open the ticked URLs as tabs in the :9222 Chrome")
+    ap.add_argument("--mark-reviewed", action="store_true", help="write the watermark comment on the Notion task page")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s", stream=sys.stdout)
+    for noisy in ("httpx", "httpcore", "hpack", "notion_client"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+    try:
+        db.ensure_schema()
+    except db.SchemaMissing as err:
+        print(f"❌ {err}")
+        return 2
+    run = db.get_run(args.run)
+    if not run:
+        print(f"❌ run {args.run} not found")
+        return 2
+    window = (str(run["window_start"]), str(run["window_end"]))
+    urls, source = ticked_urls(args.run)
+    if source == "suggestions":
+        logger.warning("⚠️ no applied review for %s → %s — using the engine's %d suggested picks", *window, len(urls))
+    else:
+        logger.info("✅ %d ticked URL(s) from the applied review (%s → %s)", len(urls), *window)
+    until = window_until(args.run)
+    line = watermark_line(until, window=window) if until else None
+
+    if args.open:
+        res = open_in_chrome(urls)
+        print(f"🌐 opened {res['opened']} tab(s), {res['skipped_open']} already open — now run `newsletter_pipeline.py archive`")
+    else:
+        print(f"🌐 would open {len(urls)} tab(s) in the :9222 Chrome (--open):")
+        for u in urls:
+            print("   ", u)
+    if line is None:
+        print("📝 no e-mails in this run — no watermark line")
+    elif args.mark_reviewed:
+        res = mark_reviewed(args.run, line=line)
+        print(f"📝 comment {res['comment_id']} written · reviewed_until = {res['reviewed_until']}")
+    else:
+        print(f"📝 watermark line (paste on the task page, or re-run with --mark-reviewed): {line}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/newsletter/triage/handoff.py
+++ b/newsletter/triage/handoff.py
@@ -122,7 +122,9 @@ def open_in_chrome(urls: Sequence[str], *, debug_port: int = 9222, dry_run: bool
         for u in to_open:
             page = context.new_page()
             try:
-                page.goto(u, wait_until="domcontentloaded", timeout=30_000)
+                # "commit" = the navigation started; the page keeps loading in its tab while we move on
+                # (domcontentloaded waited up to 30 s on ad-heavy sites — 24 tabs took 12 min).
+                page.goto(u, wait_until="commit", timeout=15_000)
             except Exception as err:  # noqa: BLE001 — a slow page is still an open tab; archive handles it
                 logger.warning("⚠️ %s — %s (tab left open)", u[:80], str(err)[:80])
             opened += 1

--- a/newsletter/triage/handoff.py
+++ b/newsletter/triage/handoff.py
@@ -95,8 +95,9 @@ def plan_open(urls: Sequence[str], already_open: Sequence[str]) -> Tuple[List[st
     return to_open, skipped
 
 
-def open_in_chrome(urls: Sequence[str], *, debug_port: int = 9222) -> Dict[str, Any]:
-    """Ensure the newsletter Chrome, open one tab per URL not already open. Returns counts + the skipped list."""
+def open_in_chrome(urls: Sequence[str], *, debug_port: int = 9222, dry_run: bool = False) -> Dict[str, Any]:
+    """Ensure the newsletter Chrome, open one tab per URL not already open. Returns counts + the skipped list.
+    ``dry_run`` does everything except opening: ensure Chrome, connect, list tabs, print the plan."""
     from newsletter import chrome_tabs  # noqa: PLC0415 — Playwright, imported only when opening
     from newsletter.bootstrap_chrome import ensure_chrome  # noqa: PLC0415
 
@@ -107,6 +108,15 @@ def open_in_chrome(urls: Sequence[str], *, debug_port: int = 9222) -> Dict[str, 
     try:
         open_urls = [t.url for t in chrome_tabs.list_tabs(browser)]
         to_open, skipped = plan_open(urls, open_urls)
+        logger.info("🔎 Chrome :%d has %d tab(s) open · %d to open · %d already open", debug_port, len(open_urls),
+                    len(to_open), len(skipped))
+        if dry_run:
+            for u in to_open:
+                logger.info("   would open · %s", u[:110])
+            for u in skipped:
+                logger.info("   already open · %s", u[:110])
+            return {"opened": 0, "would_open": len(to_open), "skipped_open": len(skipped), "skipped": skipped,
+                    "total": len(urls), "dry_run": True}
         context = browser.contexts[0] if browser.contexts else browser.new_context()
         opened = 0
         for u in to_open:
@@ -184,6 +194,8 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--run", type=int, required=True, help="stored run id (control panel → stored run)")
     ap.add_argument("--open", action="store_true", help="open the ticked URLs as tabs in the :9222 Chrome")
     ap.add_argument("--mark-reviewed", action="store_true", help="write the watermark comment on the Notion task page")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="with --open: ensure Chrome, connect, list tabs and print the plan — open nothing")
     ap.add_argument("--debug", action="store_true")
     args = ap.parse_args(argv)
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
@@ -208,7 +220,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     until = window_until(args.run)
     line = watermark_line(until, window=window) if until else None
 
-    if args.open:
+    if args.open and args.dry_run:
+        res = open_in_chrome(urls, dry_run=True)
+        print(f"🌐 dry run: would open {res['would_open']} tab(s), {res['skipped_open']} already open — nothing opened")
+    elif args.open:
         res = open_in_chrome(urls)
         print(f"🌐 opened {res['opened']} tab(s), {res['skipped_open']} already open — now run `newsletter_pipeline.py archive`")
     else:

--- a/tests/test_triage_handoff.py
+++ b/tests/test_triage_handoff.py
@@ -1,0 +1,94 @@
+"""Hand-off (issue #212): which URLs to open, idempotence against open tabs, the watermark line, the
+Notion comment write (client mocked) and the local watermark advance. No network, no Chrome."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+import unittest.mock
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from newsletter.triage import db  # noqa: E402
+from newsletter.triage import handoff as ho  # noqa: E402
+from tests.test_triage_db import FakeSupabase  # noqa: E402
+
+
+class HandoffTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fake = FakeSupabase()
+        db.set_client(self.fake)
+        self.run_id = db.register_run("2026-08-14", "2026-08-22", source="cache", model="m", criteria_version="1")
+        cands = [{"cid": "m1:0", "message_id": "m1", "url": "https://a.com/x?utm_source=nl", "canonical": "https://a.com/x",
+                  "topic": "innovation", "suggested": "pick", "suggested_rank": 1},
+                 {"cid": "m2:0", "message_id": "m2", "url": "https://b.com/y", "canonical": "https://b.com/y",
+                  "topic": "innovation", "suggested": "runner", "suggested_rank": 1}]
+        emails = [{"message_id": "m1", "timestamp": "2026-08-20T09:05:00+00:00"},
+                  {"message_id": "m2", "timestamp": "2026-08-21T13:17:00+00:00"}]
+        db.store_run_results(self.run_id, emails, cands)
+
+    def tearDown(self) -> None:
+        db.set_client(None)
+
+    def test_urls_from_suggestions_then_decisions(self) -> None:
+        urls, source = ho.ticked_urls(self.run_id)
+        self.assertEqual((urls, source), (["https://a.com/x"], "suggestions"))      # canonical, not the tracking href
+        db.save_decisions("2026-08-14", "2026-08-22", [
+            {"canonical": "https://a.com/x", "url": "https://a.com/x?utm_source=nl", "pick": False},
+            {"canonical": "https://b.com/y", "url": "https://b.com/y", "pick": True},
+            {"canonical": "https://b.com/y", "url": "https://b.com/y", "pick": True},     # upsert → one row
+        ])
+        urls, source = ho.ticked_urls(self.run_id)
+        self.assertEqual((urls, source), (["https://b.com/y"], "decisions"))
+
+    def test_open_url_keeps_host_strips_tracking_uses_post_url_for_app_links(self) -> None:
+        self.assertEqual(ho.open_url("https://www.Site.com/A/b?utm_source=x&id=7&deliveryName=NL", "https://site.com/A/b?id=7"),
+                         "https://www.Site.com/A/b?id=7")
+        self.assertEqual(ho.open_url("https://open.substack.com/pub/x/p/slug?utm_source=a&r=1", "https://x.substack.com/p/slug"),
+                         "https://x.substack.com/p/slug")
+        self.assertEqual(ho.open_url(None, "https://c.com/z"), "https://c.com/z")
+
+    def test_plan_open_is_idempotent_on_canonical(self) -> None:
+        to_open, skipped = ho.plan_open(["https://a.com/x?utm_source=nl", "https://b.com/y"],
+                                        ["https://a.com/x", "chrome://newtab/"])
+        self.assertEqual(to_open, ["https://b.com/y"])
+        self.assertEqual(skipped, ["https://a.com/x?utm_source=nl"])
+
+    def test_watermark_line(self) -> None:
+        until = ho.window_until(self.run_id)
+        self.assertEqual(until, datetime(2026, 8, 21, 13, 17, tzinfo=timezone.utc))
+        line = ho.watermark_line(until, window=("2026-08-14", "2026-08-22"))
+        self.assertTrue(line.startswith("until "))
+        self.assertIn(" > included (triage 2026-08-14 → 2026-08-22)", line)
+        local = until.astimezone()
+        self.assertIn(local.strftime("%d/%m"), line)
+        self.assertIn(local.strftime("%p"), line)
+        self.assertNotIn(" 0", line.split(local.strftime("%d/%m"))[1][:3])      # no zero-padded hour
+
+    def test_mark_reviewed_writes_one_comment_and_advances_state(self) -> None:
+        client = unittest.mock.MagicMock()
+        client.comments.create.return_value = {"id": "c-1"}
+        with unittest.mock.patch.object(ho, "load_state", return_value={"reviewed_until": "2026-08-14"}), \
+                unittest.mock.patch.object(ho, "save_state") as saved:
+            res = ho.mark_reviewed(self.run_id, line="until Fri 21/08 3:17 PM > included", page_id="p1", client=client)
+        self.assertEqual(client.comments.create.call_count, 1)
+        kwargs = client.comments.create.call_args.kwargs
+        self.assertEqual(kwargs["parent"], {"page_id": "p1"})
+        self.assertEqual(kwargs["rich_text"][0]["text"]["content"], "until Fri 21/08 3:17 PM > included")
+        self.assertEqual(res["comment_id"], "c-1")
+        state = saved.call_args[0][0]
+        self.assertEqual(state["reviewed_until"], "2026-08-22")
+        self.assertEqual(state["watermarks"][0]["comment_id"], "c-1")
+
+    def test_mark_reviewed_needs_page_id(self) -> None:
+        with unittest.mock.patch.object(ho, "load_block", return_value={}):
+            with self.assertRaises(RuntimeError):
+                ho.mark_reviewed(self.run_id, line="x", client=unittest.mock.MagicMock())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_triage_handoff.py
+++ b/tests/test_triage_handoff.py
@@ -84,6 +84,28 @@ class HandoffTests(unittest.TestCase):
         self.assertEqual(state["reviewed_until"], "2026-08-22")
         self.assertEqual(state["watermarks"][0]["comment_id"], "c-1")
 
+    def test_open_in_chrome_dry_run_opens_nothing(self) -> None:
+        import types
+        page = unittest.mock.MagicMock()
+        tab = types.SimpleNamespace(url="https://b.com/y", title="t", page=page)
+        browser = unittest.mock.MagicMock()
+        ctx = unittest.mock.MagicMock()
+        browser.contexts = [ctx]
+        fake_tabs = types.SimpleNamespace(connect=lambda port: browser, list_tabs=lambda b: [tab],
+                                          close_browser=lambda b: None)
+        fake_boot = types.SimpleNamespace(ensure_chrome=lambda: 0)
+        with unittest.mock.patch.dict(sys.modules, {"newsletter.chrome_tabs": fake_tabs,
+                                                    "newsletter.bootstrap_chrome": fake_boot}):
+            res = ho.open_in_chrome(["https://a.com/x", "https://b.com/y?utm_source=z"], dry_run=True)
+            self.assertEqual((res["would_open"], res["skipped_open"], res["opened"]), (1, 1, 0))
+            ctx.new_page.assert_not_called()
+            res = ho.open_in_chrome(["https://a.com/x", "https://b.com/y?utm_source=z"])
+            self.assertEqual((res["opened"], res["skipped_open"]), (1, 1))
+            ctx.new_page.assert_called_once()
+            fake_boot.ensure_chrome = lambda: 3
+            with self.assertRaises(RuntimeError):
+                ho.open_in_chrome(["https://a.com/x"])
+
     def test_mark_reviewed_needs_page_id(self) -> None:
         with unittest.mock.patch.object(ho, "load_block", return_value={}):
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
## Summary

Step 4/4 of the newsletter-triage series — the two external writes the triage never does on its own, each an explicit action on a stored, reviewed run:

- `newsletter/triage/handoff.py --run <id> --open`: `ensure_chrome()` then one tab per ticked URL of the applied review (tracking params stripped, Substack app-links → post URL, tabs already open are skipped), so the unchanged `newsletter_pipeline.py archive` step takes over. No applied review → falls back to the engine's suggested picks and says so.
- `--mark-reviewed`: exactly one `until <newest e-mail, Gmail style> > included (triage start → end)` comment on the `newsletters processing` task page (`config.newsletter_triage.notion_task_page_id`) + `state.json → reviewed_until`. Without a flag the command prints the URLs and the line and writes nothing.
- 🧭 triage tab: **🌐 Open ticked in Chrome** / **📝 Mark reviewed in Notion** (live runs only) / **👀 Preview hand-off** buttons after Apply, streamed into the `triage` log panel as subprocesses.
- skill args `--open` / `--mark-reviewed` with the guardrail "only when the owner asks in this conversation"; README rows, architecture edges, config example.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 143 tests OK (6 new, Notion client mocked)
- [x] `python -m newsletter.triage.handoff --run 6` (no flags) prints 24 cleaned URLs + `until Fri 21/08 9:54 AM > included (triage 2026-08-14 → 2026-08-22)` and writes nothing
- [x] `app/check_control_panel.py` all checks pass; 📋 review sub-section renders table + Apply + hand-off buttons (Playwright check, no exception)
- [x] `--open --dry-run` on run 6: Chrome launched on :9222, plan printed (24 to open, 0 already open), nothing opened; then `--open` live: 24 tabs open in the newsletter Chrome, archive deliberately **not** run (owner checks the tabs on the PC first)
- [ ] `--mark-reviewed` — left for the owner's first real review (📝 button in the tab; client mocked in tests, one `comments.create` call asserted)

Closes #212

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
