### PR TITLE
fix: triage domain cap per Substack publication

### DIFF
--- a/newsletter/triage/gmail.py
+++ b/newsletter/triage/gmail.py
@@ -473,6 +473,29 @@ def canonical_substack(url: str) -> str:
     return url
 
 
+_SUBSTACK_SHARED_HOSTS = {"substack.com", "open.substack.com"}
+_OPEN_SUBSTACK_PUB = re.compile(r"^/pub/([^/?#]+)")
+
+
+def publication_domain(url: str, sender_address: str = "") -> str:
+    """The source a link belongs to, for caps / priors / display — every Substack publication is its own
+    domain (issue #220): ``open.substack.com/pub/<pub>/…`` → ``<pub>.substack.com``; bare ``substack.com``
+    app-links / unresolved redirects → the sender's ``<pub>@substack.com`` → ``<pub>.substack.com``; any
+    other host → host without ``www.``."""
+    parts = urlsplit(url or "")
+    host = parts.netloc.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    if host in _SUBSTACK_SHARED_HOSTS:
+        m = _OPEN_SUBSTACK_PUB.match(parts.path or "")
+        if m:
+            return f"{m.group(1).lower()}.substack.com"
+        local, _, sdom = (sender_address or "").lower().rpartition("@")
+        if sdom == "substack.com" and local:
+            return f"{local.split('+')[0]}.substack.com"
+    return host
+
+
 # ---------------------------------------------------------------------------
 # redirect resolution — HTTP, cached, bounded
 

--- a/newsletter/triage/run.py
+++ b/newsletter/triage/run.py
@@ -193,7 +193,7 @@ def build_candidates(records: Sequence[gm.EmailRecord], priors: sc.Priors, notio
                 if canonical in seen_in_email:
                     continue          # same article via two anchors (resolved after extraction-time dedupe)
                 seen_in_email.add(canonical)
-            dom = fx.domain_of(link.best_url)
+            dom = gm.publication_domain(link.best_url, rec.sender_address)   # each Substack publication = own domain (#220)
             bonus, _ = priors.domain(dom)
             c = rk.Candidate(cid=f"{rec.message_id}:{i}", message_id=rec.message_id, sender_name=rec.sender_name,
                              sender_address=rec.sender_address, subject=rec.subject, email_ts=rec.timestamp,
@@ -343,7 +343,7 @@ def _run_window_body(start: date, end: date, *, cfg: Dict[str, Any], criteria: D
                 canon = canonicalize_url(gm.canonical_substack(f.final_url))
                 if canon in notion_urls:
                     c.in_notion = True
-                c.domain = fx.domain_of(f.final_url) or c.domain
+                c.domain = gm.publication_domain(f.final_url, c.sender_address) or c.domain
             if f.title and _norm(f.title) in notion_titles:
                 c.in_notion = True
         stats["fetched"] = len(stage_b)

--- a/tests/test_triage_links.py
+++ b/tests/test_triage_links.py
@@ -103,6 +103,20 @@ class ExtractionTests(unittest.TestCase):
         self.assertTrue(gm.is_redirector(link.href))
 
 
+class PublicationDomainTests(unittest.TestCase):
+    def test_every_substack_publication_is_its_own_domain(self) -> None:
+        self.assertEqual(gm.publication_domain("https://open.substack.com/pub/adamgrant/p/the-truth?utm_source=x"), "adamgrant.substack.com")
+        self.assertEqual(gm.publication_domain("https://open.substack.com/pub/TheGoodBusy/p/slug"), "thegoodbusy.substack.com")
+        # unresolved redirect / app-link → the sender's publication
+        self.assertEqual(gm.publication_domain("https://substack.com/redirect/abc?j=x", "mikefisher@substack.com"), "mikefisher.substack.com")
+        self.assertEqual(gm.publication_domain("https://substack.com/app-link/post?publication_id=1", "rishad+tag@substack.com"), "rishad.substack.com")
+        # nothing to derive from → the shared host stays (still one bucket, but only for truly unknown links)
+        self.assertEqual(gm.publication_domain("https://substack.com/redirect/abc", "someone@gmail.com"), "substack.com")
+        # everything else: host without www.
+        self.assertEqual(gm.publication_domain("https://www.hbr.org/2026/08/x?deliveryName=y", "x@hbr.org"), "hbr.org")
+        self.assertEqual(gm.publication_domain("https://thegoodbusy.substack.com/p/x"), "thegoodbusy.substack.com")
+
+
 class RuleTests(unittest.TestCase):
     def test_is_redirector_labels(self) -> None:
         self.assertTrue(gm.is_redirector("https://link.mail.beehiiv.com/v2/c/x"))


### PR DESCRIPTION
## Summary

Every Substack publication is now its own domain for the triage caps / priors / display. `open.substack.com/pub/<pub>/…` links and bare `substack.com` app-links / unresolved redirects all collapsed to one domain, so three different newsletters (Adam Grant, The Good Busy, Mike Fisher in the 2026-08-07 → 08-14 run) were pushed out with `domain cap 3` as if they were one source. `gmail.publication_domain(url, sender)` keys on `<pub>.substack.com` — from the path, or from the sender's `<pub>@substack.com` when the link is an unresolved redirect.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests -v` — 145 tests OK (helper covered incl. redirect → sender publication, `www.` strip)
- [x] both August windows re-stored with `--force` (runs 7 and 8): no `domain cap` reason at all; 22 distinct Substack publications keyed separately (e.g. `dwarkesh.substack.com` ×2, `lenny.substack.com` ×2 as picks)

Closes #220

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
