### PR TITLE
fix: triage schema.sql carries RLS + anon policies for all 8 tables (#222)

### DIFF
--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -312,8 +312,9 @@ low / vetoed / duplicate / unknown`) — an unfetchable or unscorable link is
 Every run and every owner decision lives in Supabase — the repo's store, same
 project DB as reporting + engagement — in `triage_*` tables
 (`newsletter/triage/schema.sql`, applied **once** in the Supabase SQL editor,
-idempotent; `python -m newsletter.triage.db ensure-schema` probes and prints the
-recipe if missing). `db.py` owns every query (supabase-py from
+idempotent, and carrying the RLS + `anon_*` policy stanza every public table needs
+for the daily drift check; `python -m newsletter.triage.db ensure-schema` probes and
+prints the recipe if missing). `db.py` owns every query (supabase-py from
 `config.supabase`, key fallback service_role → key → anon like engagement).
 Markdown reports and caches stay in gitignored `results/newsletter/triage/`.
 

--- a/newsletter/triage/schema.sql
+++ b/newsletter/triage/schema.sql
@@ -3,7 +3,9 @@
 -- Idempotent: safe to re-run. `newsletter/triage/db.py::ensure_schema()` probes triage_runs
 -- and fails loud with a pointer to this file when the tables are missing.
 --
--- Access is through the service_role key (RLS bypass), like the engagement tables.
+-- Every table carries RLS + the four permissive anon_* policies (stanza at the bottom) — the
+-- project-wide convention that reporting_pipeline.py step 7 (supabase_policy_script --check)
+-- enforces fail-closed on the whole public schema. A table without it fails the daily job (#222).
 
 -- one engine run = one window (closed Saturday→Saturday week) of one kind.
 -- Re-running a stored window deletes the row (children cascade) and inserts a fresh one.
@@ -140,3 +142,90 @@ create table if not exists triage_picks (
     summary             text
 );
 create index if not exists triage_picks_edition_idx on triage_picks (edition);
+
+-- ---------------------------------------------------------------------------
+-- RLS + anon_* policies — one block per table, identical to what
+-- reporting/process/supabase_policy_script.py::apply_table_policies emits. Idempotent
+-- (drop policy if exists before create). ADD A BLOCK HERE FOR EVERY NEW triage_* TABLE —
+-- otherwise the daily drift check (step 7 of the reporting pipeline) fails until someone
+-- runs `python -m reporting.process.supabase_policy_script` by hand.
+
+alter table triage_runs enable row level security;
+drop policy if exists anon_select_all on triage_runs;
+create policy anon_select_all on triage_runs for select to anon using (true);
+drop policy if exists anon_insert_all on triage_runs;
+create policy anon_insert_all on triage_runs for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_runs;
+create policy anon_update_all on triage_runs for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_runs;
+create policy anon_delete_all on triage_runs for delete to anon using (true);
+
+alter table triage_emails enable row level security;
+drop policy if exists anon_select_all on triage_emails;
+create policy anon_select_all on triage_emails for select to anon using (true);
+drop policy if exists anon_insert_all on triage_emails;
+create policy anon_insert_all on triage_emails for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_emails;
+create policy anon_update_all on triage_emails for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_emails;
+create policy anon_delete_all on triage_emails for delete to anon using (true);
+
+alter table triage_candidates enable row level security;
+drop policy if exists anon_select_all on triage_candidates;
+create policy anon_select_all on triage_candidates for select to anon using (true);
+drop policy if exists anon_insert_all on triage_candidates;
+create policy anon_insert_all on triage_candidates for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_candidates;
+create policy anon_update_all on triage_candidates for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_candidates;
+create policy anon_delete_all on triage_candidates for delete to anon using (true);
+
+alter table triage_decisions enable row level security;
+drop policy if exists anon_select_all on triage_decisions;
+create policy anon_select_all on triage_decisions for select to anon using (true);
+drop policy if exists anon_insert_all on triage_decisions;
+create policy anon_insert_all on triage_decisions for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_decisions;
+create policy anon_update_all on triage_decisions for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_decisions;
+create policy anon_delete_all on triage_decisions for delete to anon using (true);
+
+alter table triage_reviews enable row level security;
+drop policy if exists anon_select_all on triage_reviews;
+create policy anon_select_all on triage_reviews for select to anon using (true);
+drop policy if exists anon_insert_all on triage_reviews;
+create policy anon_insert_all on triage_reviews for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_reviews;
+create policy anon_update_all on triage_reviews for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_reviews;
+create policy anon_delete_all on triage_reviews for delete to anon using (true);
+
+alter table triage_lessons enable row level security;
+drop policy if exists anon_select_all on triage_lessons;
+create policy anon_select_all on triage_lessons for select to anon using (true);
+drop policy if exists anon_insert_all on triage_lessons;
+create policy anon_insert_all on triage_lessons for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_lessons;
+create policy anon_update_all on triage_lessons for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_lessons;
+create policy anon_delete_all on triage_lessons for delete to anon using (true);
+
+alter table triage_editions enable row level security;
+drop policy if exists anon_select_all on triage_editions;
+create policy anon_select_all on triage_editions for select to anon using (true);
+drop policy if exists anon_insert_all on triage_editions;
+create policy anon_insert_all on triage_editions for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_editions;
+create policy anon_update_all on triage_editions for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_editions;
+create policy anon_delete_all on triage_editions for delete to anon using (true);
+
+alter table triage_picks enable row level security;
+drop policy if exists anon_select_all on triage_picks;
+create policy anon_select_all on triage_picks for select to anon using (true);
+drop policy if exists anon_insert_all on triage_picks;
+create policy anon_insert_all on triage_picks for insert to anon with check (true);
+drop policy if exists anon_update_all on triage_picks;
+create policy anon_update_all on triage_picks for update to anon using (true) with check (true);
+drop policy if exists anon_delete_all on triage_picks;
+create policy anon_delete_all on triage_picks for delete to anon using (true);


### PR DESCRIPTION
## Summary

`newsletter/triage/schema.sql` created the 8 `triage_*` tables without RLS or the four `anon_*` policies that `reporting/process/supabase_policy_script.py --check` (step 7 of the daily reporting pipeline) requires, fail-closed, on every public table — so applying the file by hand put the DB into permanent drift and failed the daily job. The header comment justified the omission with a claim about the engagement tables that isn't true.

- Appended one idempotent stanza per table (`alter table … enable row level security` + `drop policy if exists` / `create policy` × 4), byte-equivalent to what `apply_table_policies` emits, with a note to add a block for every future table.
- Replaced the wrong header comment with the actual rule; one-line README touch.

## Test plan

- [x] `schema.sql` re-applied against the live (already-remediated) DB through the reporting psycopg2 connection — idempotent, all 8 tables `rowsecurity=true`, 4 policies each
- [x] `python -m reporting.process.supabase_policy_script --check` → `✅ No RLS/policy/view drift — 42 table(s) and 117 view(s) all conform`, exit 0
- [x] `python -m unittest discover tests` → 145 OK (1 skipped)

Closes #222

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
