### PR TITLE
fix: triage normalises YouTube links before the oembed lookup (#224)

### DIFF
--- a/newsletter/triage/fetch.py
+++ b/newsletter/triage/fetch.py
@@ -22,7 +22,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, urlsplit
 
 import requests
 from lxml import html as lxml_html
@@ -94,10 +94,33 @@ def detect_paywall(html: str, body_text: str, url: str) -> tuple[Optional[bool],
     return False, ""
 
 
+_YT_ID_PATH = re.compile(r"^/(?:shorts|embed|live|v)/([A-Za-z0-9_-]{6,})")
+
+
+def youtube_watch_url(url: str) -> Optional[str]:
+    """Canonical ``https://www.youtube.com/watch?v=<id>`` for any video link (``watch/?v=``, ``youtu.be/<id>``,
+    ``/shorts/<id>``, ``/embed/<id>``, ``/live/<id>``); None when there is no video id (playlists, channels).
+    The oembed endpoint answers 404 for the ``youtube.com/watch/?v=`` form some newsletters emit (#224)."""
+    parts = urlsplit(url or "")
+    host = parts.netloc.lower()
+    host = host[4:] if host.startswith("www.") else host
+    vid = ""
+    if host == "youtu.be":
+        vid = parts.path.strip("/").split("/")[0]
+    elif host in ("youtube.com", "m.youtube.com", "music.youtube.com"):
+        vid = dict(parse_qsl(parts.query)).get("v", "")
+        if not vid:
+            m = _YT_ID_PATH.match(parts.path)
+            vid = m.group(1) if m else ""
+    return f"https://www.youtube.com/watch?v={vid}" if vid else None
+
+
 def _youtube_oembed(session: requests.Session, url: str, timeout: float) -> Fetched:
-    f = Fetched(url=url, kind="video", final_url=url)
+    watch = youtube_watch_url(url)
+    f = Fetched(url=url, kind="video", final_url=watch or url)
     try:
-        r = session.get("https://www.youtube.com/oembed", params={"url": url, "format": "json"}, timeout=timeout)
+        r = session.get("https://www.youtube.com/oembed", params={"url": watch or url, "format": "json"},
+                        timeout=timeout)
         f.status = r.status_code
         if r.ok:
             data = r.json()

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -190,6 +190,38 @@ class ReportFeedbackTests(unittest.TestCase):
         self.assertEqual(fb.tier_for(5, 0), "rarely")
         self.assertIsNone(fb.tier_for(4, 1))
 
+class YouTubeUrlTests(unittest.TestCase):
+    def test_watch_slash_form_normalises(self) -> None:  # issue #224 — oembed 404s on youtube.com/watch/?v=
+        self.assertEqual(fx.youtube_watch_url("https://youtube.com/watch/?v=oCVq-wAPqSs"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+        self.assertEqual(fx.youtube_watch_url("https://www.youtube.com/watch?t=266&v=TmNARZonhvY&feature=youtu.be"),
+                         "https://www.youtube.com/watch?v=TmNARZonhvY")
+        self.assertEqual(fx.youtube_watch_url("https://youtu.be/oCVq-wAPqSs?si=abc"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+        self.assertEqual(fx.youtube_watch_url("https://www.youtube.com/shorts/oCVq-wAPqSs"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+
+    def test_no_video_id_passes_through(self) -> None:
+        self.assertIsNone(fx.youtube_watch_url("https://www.youtube.com/playlist?list=PLbN57C5Zdl6j"))
+        self.assertIsNone(fx.youtube_watch_url("https://www.youtube.com/@JasonHeadley/videos"))
+        self.assertIsNone(fx.youtube_watch_url("https://example.com/watch?v=abc"))
+
 
 if __name__ == "__main__":
     unittest.main()
+
+class YouTubeUrlTests(unittest.TestCase):
+    def test_watch_slash_form_normalises(self) -> None:  # issue #224 — oembed 404s on youtube.com/watch/?v=
+        self.assertEqual(fx.youtube_watch_url("https://youtube.com/watch/?v=oCVq-wAPqSs"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+        self.assertEqual(fx.youtube_watch_url("https://www.youtube.com/watch?t=266&v=TmNARZonhvY&feature=youtu.be"),
+                         "https://www.youtube.com/watch?v=TmNARZonhvY")
+        self.assertEqual(fx.youtube_watch_url("https://youtu.be/oCVq-wAPqSs?si=abc"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+        self.assertEqual(fx.youtube_watch_url("https://www.youtube.com/shorts/oCVq-wAPqSs"),
+                         "https://www.youtube.com/watch?v=oCVq-wAPqSs")
+
+    def test_no_video_id_passes_through(self) -> None:
+        self.assertIsNone(fx.youtube_watch_url("https://www.youtube.com/playlist?list=PLbN57C5Zdl6j"))
+        self.assertIsNone(fx.youtube_watch_url("https://www.youtube.com/@JasonHeadley/videos"))
+        self.assertIsNone(fx.youtube_watch_url("https://example.com/watch?v=abc"))


### PR DESCRIPTION
## Summary

`fetch.py::_youtube_oembed` forwarded the e-mail href verbatim; the oembed endpoint 404s on the `youtube.com/watch/?v=<id>` form some newsletters emit, so those videos scored on title alone with an empty summary — and the failure was cached for good. New `youtube_watch_url()` extracts the video id (`v=` on any path, `youtu.be`, `/shorts/`, `/embed/`, `/live/`) and queries the canonical watch URL; playlists/channels pass through as before.

## Test plan

- [x] `python -m unittest discover tests` → 147 OK (2 new cases: normaliser forms + pass-through)
- [x] `fetch_one` live on both previously failing URLs → `ok=True` with title/author; a playlist still resolves via the original URL
- [x] Evicted the 4 cached `watch/` failures, re-stored both August windows `--source cache --force` (runs 9 and 10): the two videos now `fetched_ok` with a summary; the applied review for 08-07 → 08-14 (42 decisions, review row) survived the re-run

Closes #224

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
