### PR TITLE
fix: triage review picker selects by run id, not label (#225)

### DIFF
--- a/app/tab_triage.py
+++ b/app/tab_triage.py
@@ -343,11 +343,14 @@ def run() -> None:
         return
     if is_running(PIPELINE_NAME):
         st.info("a triage process is running — follow it in ▶ run; stored runs below refresh when it finishes")
-    options = {f"{r['window_start']} → {r['window_end']} · {r['kind']}"
-               + (f" {r.get('edition')}" if r.get("edition") else "")
-               + f" · {r['status']} · {r.get('picks') if r.get('picks') is not None else '?'} picks"
-               + (" · reviewed ✓" if r.get("reviewed") else ""): r["id"] for r in runs}
-    choice = st.selectbox("stored run", list(options.keys()), index=0, key="triage-run-pick")
-    run = _run(options[choice])
+    # options are run ids, not labels: a label changes after Apply (" · reviewed ✓") and a selectbox whose stored
+    # value vanished from its options silently resets to index 0 — the newest run (#225)
+    labels = {r["id"]: f"{r['window_start']} → {r['window_end']} · {r['kind']}"
+              + (f" {r.get('edition')}" if r.get("edition") else "")
+              + f" · {r['status']} · {r.get('picks') if r.get('picks') is not None else '?'} picks"
+              + (" · reviewed ✓" if r.get("reviewed") else "") for r in runs}
+    choice = st.selectbox("stored run", list(labels.keys()), index=0, key="triage-run-pick",
+                          format_func=lambda rid: labels.get(rid, f"run {rid}"))
+    run = _run(choice)
     if run:
         _render_review(run)


### PR DESCRIPTION
## Summary

In 🧭 triage → 📋 review, the stored-run selectbox was built over label strings. Apply invalidates the caches, `list_runs()` relabels the window with ` · reviewed ✓`, the widget's stored value no longer exists in its options and Streamlit resets it to index 0 — the newest run — so right after Apply the page showed another run's table with disabled Distil / 🌐 / 📝 buttons. Options are now run ids with a `format_func` label.

## Test plan

- [x] Playwright repro before: after Apply on N224 the header flipped to `2026-08-14 → 2026-08-22` and the buttons stayed disabled; after: header unchanged, Distil + 🌐 Open enable in the same render (📝 stays off for a backtest, as designed)
- [x] `python app/check_control_panel.py` — triage checks pass (one engagement sub-tab check was flaky on the cold restart, green on re-run)
- [x] `python -m unittest discover tests` → 147 OK

Closes #225

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
