### PR TITLE
fix: triage dedupes against picks applied in earlier windows (#228)

### DIFF
--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -322,7 +322,7 @@ Markdown reports and caches stay in gitignored `results/newsletter/triage/`.
 |---|---|
 | `triage_runs` | one row per (window, kind live/backtest) — status, model, stats, report path; re-running a stored window **replaces** it (needs `--force`) |
 | `triage_emails`, `triage_candidates` | the run's inbox + every link with scores, verdict, stage-A/B JSON and the engine's suggestion (pick / runner, rank, ⭐, 🏆) |
-| `triage_decisions` | the owner's ticks, keyed by **window + canonical URL** — they survive a re-run and pre-fill the new table; single source for the sender-tier tally (`feedback.jsonl` retired) |
+| `triage_decisions` | the owner's ticks, keyed by **window + canonical URL** — they survive a re-run and pre-fill the new table; single source for the sender-tier tally (`feedback.jsonl` retired); picks from earlier windows are a dedupe set for the next run (`already picked <window>`, before the archive step puts them in Notion) |
 | `triage_reviews` | the per-window review comment ("why these choices") |
 | `triage_lessons` | criteria notes proposed by the hub (`lessons_model`, `claude_sonnet`) from comment + disagreements; accepted ones are exported to the tracked `newsletter/triage/lessons.json` and appended to the scoring prompt brief |
 | `triage_editions`, `triage_picks` | the 54-week knowledge base from the history files (`python -m newsletter.triage.db import-history`) |

--- a/newsletter/triage/db.py
+++ b/newsletter/triage/db.py
@@ -116,7 +116,8 @@ def ensure_schema() -> None:
 
 
 def _fetch_all(name: str, select: str = "*", *, filters: Optional[Dict[str, Any]] = None,
-               order: Optional[Tuple[str, bool]] = None, in_: Optional[Tuple[str, Sequence[Any]]] = None) -> List[Dict[str, Any]]:
+               order: Optional[Tuple[str, bool]] = None, in_: Optional[Tuple[str, Sequence[Any]]] = None,
+               lte: Optional[Tuple[str, Any]] = None) -> List[Dict[str, Any]]:
     """Page through every matching row (PostgREST caps a request at ``PAGE`` rows)."""
     out: List[Dict[str, Any]] = []
     start = 0
@@ -126,6 +127,8 @@ def _fetch_all(name: str, select: str = "*", *, filters: Optional[Dict[str, Any]
             q = q.eq(col, val)
         if in_:
             q = q.in_(in_[0], list(in_[1]))
+        if lte:
+            q = q.lte(lte[0], lte[1])
         if order:
             q = q.order(order[0], desc=order[1])
         rows = q.range(start, start + PAGE - 1).execute().data or []
@@ -254,6 +257,15 @@ def emails(run_id: int) -> List[Dict[str, Any]]:
 
 def load_decisions(start: Any, end: Any) -> List[Dict[str, Any]]:
     return _fetch_all("triage_decisions", filters={"window_start": _d(start), "window_end": _d(end)})
+
+
+def picked_before(start: Any) -> Dict[str, str]:
+    """``{canonical: "window_start → window_end"}`` of every article the owner picked in a window that closed
+    on or before ``start`` — the cross-window dedupe set (#228). Overlapping windows (backtests) and the
+    run's own window are excluded by construction (``window_end <= start``)."""
+    rows = _fetch_all("triage_decisions", "canonical,window_start,window_end", filters={"pick": True},
+                      lte=("window_end", _d(start)), order=("window_end", False))
+    return {r["canonical"]: f"{r['window_start']} → {r['window_end']}" for r in rows if r.get("canonical")}
 
 
 def save_decisions(start: Any, end: Any, rows: Sequence[Dict[str, Any]]) -> int:

--- a/newsletter/triage/rank.py
+++ b/newsletter/triage/rank.py
@@ -59,6 +59,7 @@ class Candidate:
     fetched_ok: Optional[bool] = None
     paywalled: Optional[bool] = None
     in_notion: bool = False
+    picked_earlier: str = ""    # "2026-08-07 → 2026-08-14": picked in that earlier window (#228); implies in_notion
     sender_weight: float = 1.0
     sender_basis: str = ""
     is_new_sender: bool = False
@@ -118,7 +119,7 @@ def resolve_topic(c: Candidate) -> Optional[str]:
 def apply_vetoes(c: Candidate) -> None:
     """Set verdict for anything that can never be selected; leave others ``pending``."""
     if c.in_notion:
-        c.verdict, c.reason = "duplicate", "already in Notion"
+        c.verdict, c.reason = "duplicate", (f"already picked {c.picked_earlier}" if c.picked_earlier else "already in Notion")
     elif c.sender_weight <= 0.0:
         c.verdict, c.reason = "vetoed", f"sender {c.sender_basis}"
     elif c.paywalled is True:

--- a/newsletter/triage/run.py
+++ b/newsletter/triage/run.py
@@ -179,7 +179,11 @@ def emails_from_gmail(start: date, end: date, *, cfg: Dict[str, Any], budget: Op
 
 
 def build_candidates(records: Sequence[gm.EmailRecord], priors: sc.Priors, notion_urls: set,
-                     notion_titles: Dict[str, str]) -> Tuple[List[rk.Candidate], Dict[str, List[rk.Candidate]]]:
+                     notion_titles: Dict[str, str],
+                     picked_before: Optional[Dict[str, str]] = None) -> Tuple[List[rk.Candidate], Dict[str, List[rk.Candidate]]]:
+    """``picked_before`` = ``db.picked_before(start)``: articles ticked in an earlier window are duplicates even
+    before the archive step puts them in Notion (#228 — HBR re-links the same piece from a later digest)."""
+    picked_before = picked_before or {}
     cands: List[rk.Candidate] = []
     by_email: Dict[str, List[rk.Candidate]] = defaultdict(list)
     for rec in records:
@@ -200,7 +204,9 @@ def build_candidates(records: Sequence[gm.EmailRecord], priors: sc.Priors, notio
                              label=link.label, url=link.best_url, canonical=canonical, domain=dom,
                              sender_weight=weight, sender_basis=basis, is_new_sender=is_new, domain_bonus=bonus,
                              topic=priors.topic_prior(rec.sender_address, dom))
-            if link.resolved and canonical in notion_urls:
+            if link.resolved and canonical in picked_before:
+                c.in_notion, c.picked_earlier = True, picked_before[canonical]
+            elif link.resolved and canonical in notion_urls:
                 c.in_notion = True
             elif link.label and _norm(link.label) in notion_titles:
                 c.in_notion = True
@@ -287,11 +293,13 @@ def _run_window_body(start: date, end: date, *, cfg: Dict[str, Any], criteria: D
     rules = criteria.get("rules", {})
     records = emails_from_cache(start, end) if source == "cache" else emails_from_gmail(start, end, cfg=cfg)
     notion_urls, notion_titles = load_notion_urls(created_before=start.isoformat() if backtest is not None else None)
-    cands, by_email = build_candidates(records, priors, notion_urls, notion_titles)
+    picked_before = db.picked_before(start) if store_ok() else {}
+    cands, by_email = build_candidates(records, priors, notion_urls, notion_titles, picked_before)
     if limit_links:
         cands = cands[:limit_links]
     stats: Dict[str, Any] = {"emails": len(records), "links": len(cands),
-                             "duplicates_in_notion": sum(1 for c in cands if c.in_notion),
+                             "duplicates_in_notion": sum(1 for c in cands if c.in_notion and not c.picked_earlier),
+                             "duplicates_picked_earlier": sum(1 for c in cands if c.picked_earlier),
                              "unresolved_links": sum(1 for c in cands if c.reason == "redirect unresolved")}
     llm_calls = 0
     llm_cache = sc.LLMCache()
@@ -341,7 +349,9 @@ def _run_window_body(start: date, end: date, *, cfg: Dict[str, Any], criteria: D
                 c.reason = f"fetch: {f.error}"
             if f.final_url:
                 canon = canonicalize_url(gm.canonical_substack(f.final_url))
-                if canon in notion_urls:
+                if canon in picked_before:
+                    c.in_notion, c.picked_earlier = True, picked_before[canon]
+                elif canon in notion_urls:
                     c.in_notion = True
                 c.domain = gm.publication_domain(f.final_url, c.sender_address) or c.domain
             if f.title and _norm(f.title) in notion_titles:

--- a/tests/test_triage_db.py
+++ b/tests/test_triage_db.py
@@ -79,6 +79,10 @@ class _Query:
         self.filters.append(("in", col, list(vals)))
         return self
 
+    def lte(self, col: str, val: Any) -> "_Query":
+        self.filters.append(("lte", col, val))
+        return self
+
     def order(self, col: str, desc: bool = False) -> "_Query":
         self.orders.append((col, desc))
         return self
@@ -97,6 +101,8 @@ class _Query:
             if kind == "eq" and str(row.get(col)) != str(val):
                 return False
             if kind == "in" and row.get(col) not in val:
+                return False
+            if kind == "lte" and not (row.get(col) is not None and str(row.get(col)) <= str(val)):
                 return False
         return True
 
@@ -346,6 +352,15 @@ class StoreTests(unittest.TestCase):
             self.assertNotIn("meh@x.com", json.loads(ov.read_text(encoding="utf-8"))["senders"])
             with self.assertRaises(ValueError):
                 rv.set_sender_tier("a@b.c", "sometimes", overrides_path=ov)
+
+    def test_picked_before_is_strictly_earlier_windows(self) -> None:  # issue #228
+        db.save_decisions("2026-08-07", "2026-08-14", [
+            {"canonical": "https://hbr.org/leadership-drift", "pick": True, "title": "Drift"},
+            {"canonical": "https://hbr.org/passed", "pick": False, "title": "Passed"}])
+        db.save_decisions("2026-08-14", "2026-08-22", [{"canonical": "https://x.com/later", "pick": True}])
+        picked = db.picked_before("2026-08-14")
+        self.assertEqual(picked, {"https://hbr.org/leadership-drift": "2026-08-07 → 2026-08-14"})
+        self.assertEqual(db.picked_before("2026-08-07"), {})          # nothing closed before the window opens
 
     def test_saturday_weeks(self) -> None:
         weeks = rv.saturday_weeks(3, today=date(2026, 8, 21))       # a Friday

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -55,6 +55,15 @@ class RankTests(unittest.TestCase):
         self.assertIsNotNone(sel.stars["leadership and management"])
         self.assertIs(sel.must_read.topic, "personal development")  # prior 0.6 × 7 > 0.35 × 9
 
+    def test_picked_earlier_is_a_duplicate(self) -> None:  # issue #228
+        c = _cand(1, topic="leadership and management", score=12.4, in_notion=True,
+                  picked_earlier="2026-08-07 → 2026-08-14")
+        rk.apply_vetoes(c)
+        self.assertEqual((c.verdict, c.reason), ("duplicate", "already picked 2026-08-07 → 2026-08-14"))
+        d = _cand(2, topic="innovation", score=9.0, in_notion=True)
+        rk.apply_vetoes(d)
+        self.assertEqual(d.reason, "already in Notion")
+
     def test_vetoes_and_states(self) -> None:
         pay = _cand(1, topic="innovation", score=9.0, paywalled=True)
         never = _cand(2, topic="innovation", score=9.0, sender_weight=0.0, sender_basis="override:never")


### PR DESCRIPTION
## Summary

The engine deduped within one e-mail and against the Notion archive only. A pick ticked in the control panel lives in `triage_decisions` but reaches Notion only after the archive step, and HBR re-links the same piece from a later digest — so *“Leadership Drift” Is Stalling Your AI Strategy* was suggested in both August windows. `db.picked_before(start)` returns the picks of every window closed on/before `start` (the run's own window and overlapping backtest windows are excluded by construction); `build_candidates` and the post-fetch `final_url` check mark them like a Notion duplicate with reason `already picked <window>`, counted as `duplicates_picked_earlier`. Store unreachable → empty set, same report-only degrade as today.

## Test plan

- [x] `python -m unittest discover tests` → 149 OK (new: `picked_before` strictly-earlier semantics; `apply_vetoes` reason)
- [x] Live: `picked_before('2026-08-14')` → 172 canonicals incl. the HBR piece; re-stored 08-14 → 08-22 `--source cache --force` (run 11): the HBR row is `duplicate · already picked 2026-08-07 → 2026-08-14`, not suggested; stats `duplicates_picked_earlier: 2`

Closes #228

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
