### PR TITLE
feat: triage lessons editable in place with an explicit save (#231)

### DIFF
--- a/app/tab_triage.py
+++ b/app/tab_triage.py
@@ -102,8 +102,16 @@ def _distil(run_id: int) -> None:
     _invalidate()
 
 
-def _accept_lessons(ids: list[int], accepted: bool) -> None:
-    lessons.accept(ids, accepted=accepted)
+def _save_lessons(editor_key: str) -> None:
+    base: list[dict] = st.session_state[f"{editor_key}-base"]
+    edits = (st.session_state.get(editor_key) or {}).get("edited_rows", {})
+    rows = [dict(r) for r in base]
+    for idx, patch in edits.items():
+        rows[int(idx)].update(patch)
+    try:
+        st.session_state["triage-last-lessons"] = {"n": lessons.save(rows)}
+    except Exception as err:  # noqa: BLE001 — surfaced as st.error below
+        st.session_state["triage-last-lessons"] = {"error": str(err)}
     _invalidate()
 
 
@@ -284,11 +292,30 @@ def _render_lessons(run_id: int, start: str, end: str) -> None:
     rows = _lessons(start, end)
     if not rows:
         return
-    st.markdown("**lessons from this review** — tick to accept into the engine's criteria brief")
-    for r in rows:
-        key = f"triage-lesson-{r['id']}"
-        st.checkbox(r["text"], value=bool(r.get("accepted")), key=key,
-                    on_change=lambda rid=r["id"], k=key: _accept_lessons([rid], st.session_state[k]))
+    st.markdown("**lessons from this review** — edit the wording, tick to accept into the engine's criteria brief, "
+                "then 💾 Save (nothing is written before)")
+    key = f"triage-lessons-{run_id}"
+    base = [{"id": r["id"], "accepted": bool(r.get("accepted")), "text": r["text"]} for r in rows]
+    st.session_state[f"{key}-base"] = base
+    st.data_editor(
+        pd.DataFrame(base, columns=["id", "accepted", "text"]),
+        key=key, hide_index=True, num_rows="fixed", width="stretch", disabled=["id"],
+        column_order=["accepted", "text"],
+        # pixel widths on purpose: Streamlit spreads any leftover width evenly over *all* columns, so a
+        # "small" tick column balloons next to a "large" text one; 45 + 1050 keeps the tick narrow and the
+        # sentence readable on a ~1100 px content pane (verified against the owner's manual resize)
+        column_config={"accepted": st.column_config.CheckboxColumn("✅", width=45),
+                       "text": st.column_config.TextColumn("lesson", width=1050)},
+    )
+    last = st.session_state.pop("triage-last-lessons", None)
+    st.button("💾 Save lessons", key=f"{key}-save", on_click=_save_lessons, args=(key,),
+              help="Writes text + accept flag to the store and re-exports the tracked lessons.json "
+                   "(commit it when you are happy with the wording).")
+    if last:
+        if "error" in last:
+            st.error(f"save failed: {last['error']}")
+        else:
+            st.success(f"saved {last['n']} lesson(s) · lessons.json re-exported")
 
 
 def _render_new_senders(run_id: int) -> None:

--- a/newsletter/triage/db.py
+++ b/newsletter/triage/db.py
@@ -337,6 +337,19 @@ def lessons(*, accepted: Optional[bool] = None, start: Any = None, end: Any = No
     return _fetch_all("triage_lessons", filters=filters, order=("id", False))
 
 
+def update_lesson(lesson_id: int, *, text: Optional[str] = None, accepted: Optional[bool] = None) -> None:
+    """Edit one lesson in place — the owner's wording and/or the accept flag (#231). ``accepted_at`` is set
+    when the flag turns on and cleared when it turns off; unchanged when only the text changes."""
+    patch: Dict[str, Any] = {}
+    if text is not None:
+        patch["text"] = text.strip()
+    if accepted is not None:
+        patch["accepted"] = bool(accepted)
+        patch["accepted_at"] = _now() if accepted else None
+    if patch:
+        _t("triage_lessons").update(patch).eq("id", int(lesson_id)).execute()
+
+
 def accept_lessons(ids: Sequence[int], *, accepted: bool = True) -> int:
     if not ids:
         return 0

--- a/newsletter/triage/lessons.py
+++ b/newsletter/triage/lessons.py
@@ -140,6 +140,26 @@ def accept(ids: Sequence[int], *, accepted: bool = True) -> int:
     return n
 
 
+def save(rows: Sequence[Dict[str, Any]]) -> int:
+    """Control-panel editor → store: each row ``{id, text, accepted}`` is written as-is (text edited by the owner,
+    accept flag ticked or not); rows whose text is blank are left untouched. Then ``lessons.json`` is re-exported."""
+    current = {r["id"]: r for r in db.lessons()}
+    n = 0
+    for row in rows:
+        cur = current.get(row.get("id"))
+        if cur is None:
+            continue
+        text = (row.get("text") or "").strip()
+        accepted = bool(row.get("accepted"))
+        changed_text = text and text != (cur.get("text") or "")
+        changed_flag = accepted != bool(cur.get("accepted"))
+        if changed_text or changed_flag:
+            db.update_lesson(cur["id"], text=text if changed_text else None, accepted=accepted if changed_flag else None)
+            n += 1
+    export()
+    return n
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     force_utf8_stdio()
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/tests/test_triage_db.py
+++ b/tests/test_triage_db.py
@@ -315,6 +315,17 @@ class StoreTests(unittest.TestCase):
             self.assertEqual(sc.load_lessons(out), ["Prefer first-person stories over listicles"])
             with unittest.mock.patch.object(sc, "LESSONS_PATH", out):
                 self.assertIn("Prefer first-person stories", sc._criteria_brief({"rules": {}}))
+            # control-panel editor path (#231): owner rewording + un-accept, one Save
+            ls.save([{"id": rows[0]["id"], "text": "Prefer first-person stories over listicles and roundups",
+                      "accepted": True}])
+            self.assertEqual(db.lessons()[0]["text"], "Prefer first-person stories over listicles and roundups")
+            self.assertTrue(db.lessons()[0]["accepted"])
+            with unittest.mock.patch.object(ls, "LESSONS_PATH", out):
+                ls.save([{"id": rows[0]["id"], "text": "", "accepted": False}])   # blank text ignored, flag off
+            self.assertEqual(db.lessons()[0]["text"], "Prefer first-person stories over listicles and roundups")
+            self.assertEqual(json.loads(out.read_text(encoding="utf-8"))["lessons"], [])
+            with unittest.mock.patch.object(ls, "LESSONS_PATH", out):
+                ls.accept([rows[0]["id"]])
         # run replaced → lesson survives with run_id = null
         self._store()
         self.assertIsNone(self.fake.tables["triage_lessons"][0]["run_id"])


### PR DESCRIPTION
## Summary

The lessons block was a list of checkboxes whose `on_change` accepted/rejected immediately — it worked, but there was no visible save and the model's wording could not be edited. Now a `st.data_editor` (✅ tick + editable text) with **💾 Save lessons**: the callback merges `edited_rows`, `lessons.save(rows)` writes text / accept flag per id (`db.update_lesson`; `accepted_at` set/cleared with the flag, untouched on a pure reword; blank text ignored), then re-exports the tracked `lessons.json`. Column widths are pixel values (45 / 1050) because Streamlit distributes leftover width evenly across all columns, which ballooned the tick column.

## Test plan

- [x] `python -m unittest discover tests` → 149 OK (save path: reword + flag toggle + export, blank text ignored)
- [x] Live: editor renders for 08-14 → 08-22 with the 3 accepted lessons, 💾 Save → `saved 0 lesson(s) · lessons.json re-exported`, no exception; widths verified by screenshot at 1150/1500 px
- [x] `python app/check_control_panel.py` → all green (warm run)

Closes #231

https://claude.ai/code/session_01NWz9aYMUJqB6nAjxcbiaUm
