### PR TITLE
fix: bounded waits + row retry for the Twitter/Threads composer races

### DIFF
--- a/planning/_failure.py
+++ b/planning/_failure.py
@@ -16,13 +16,24 @@ decide whether it is safe to touch:
 
 The classification lives here so the pipeline (which writes ``failure_kind`` into
 the machine-readable result JSON) and the skill (which reads it) can never drift
-apart. Pure function, no side effects — trivially unit-testable.
+apart.
+
+This module also owns the **retry-safety contract** (issue #235):
+``PostMayBeLiveError`` marks a failure that must never be retried, and
+``attempt_row`` is the single enforcement of that rule. Both live here, next to
+each other and to the classifier, precisely because a driver that re-implemented
+either one slightly differently would double-post to a live social account.
 """
 
 from __future__ import annotations
 
+import logging
 import re
-from typing import Literal
+from typing import Callable, Literal, Optional, TypeVar
+
+logger = logging.getLogger("planning_failure")
+
+T = TypeVar("T")
 
 FailureKind = Literal["ui-drift", "login-required", "data-error", "other", "none"]
 
@@ -63,6 +74,78 @@ def classify(status: str, detail: str) -> FailureKind:
     if _DATA_ERROR_RE.search(text):
         return "data-error"
     return "other"
+
+
+class PostMayBeLiveError(RuntimeError):
+    """A row failed at or after the point of no return — never retry it.
+
+    The per-row retry added in issue #235 exists to absorb races *before* a
+    post is committed (composer not open yet, caption box not rendered). Once
+    the driver has clicked the platform's final Schedule action, a failure no
+    longer means "nothing happened": the post may well be scheduled and the
+    driver simply lost sight of it. Retrying there would double-post, which is
+    strictly worse than the transient failure the retry was added to fix.
+
+    So drivers raise this — instead of a plain ``RuntimeError`` — for anything
+    from the final-action click onward, and the row loop treats it as terminal.
+    The boundary is deliberately drawn *before* that click rather than after:
+    a click that never landed is safe to retry, but proving it never landed is
+    harder than accepting one lost row.
+    """
+
+
+ROW_ATTEMPTS = 2
+
+
+def attempt_row(
+    run: Callable[[], T],
+    *,
+    label: str,
+    attempts: int = ROW_ATTEMPTS,
+    reset: Optional[Callable[[], None]] = None,
+) -> T:
+    """Run one scheduler row, retrying only failures that are safe to retry.
+
+    ``run`` is re-invoked at most ``attempts`` times. Between attempts ``reset``
+    (when given) returns the browser to a clean state — the composer from the
+    failed attempt has to be dismissed or the retry types into a half-filled
+    one.
+
+    Two failures are never retried:
+
+    * ``PostMayBeLiveError`` — raised at or past the platform's final Schedule
+      click, where a retry risks a duplicate post (see the class docstring).
+    * anything on the final attempt, which is simply re-raised.
+
+    Everything else — a composer that never opened, a caption box that had not
+    rendered — is exactly the transient class issue #235 was filed for, and is
+    retried against a settled DOM.
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+    last_err: Exception
+    for attempt in range(1, attempts + 1):
+        try:
+            return run()
+        except PostMayBeLiveError:
+            # Terminal by construction: the post may already be live.
+            raise
+        except Exception as err:
+            last_err = err
+            if attempt >= attempts:
+                break
+            logger.warning(
+                "↻ %s: attempt %d/%d failed (%s) — retrying.",
+                label, attempt, attempts, err,
+            )
+            if reset is not None:
+                try:
+                    reset()
+                except Exception as reset_err:
+                    logger.warning(
+                        "⚠️ %s: could not reset between attempts: %s", label, reset_err
+                    )
+    raise last_err
 
 
 _SCREENSHOT_RE = re.compile(r"\(screenshot\s+([^)]+)\)")

--- a/planning/_waits.py
+++ b/planning/_waits.py
@@ -1,0 +1,187 @@
+"""Bounded readiness waits shared by the planning schedulers.
+
+``Locator.count()`` returns *immediately* — it is a query, not a wait. Using it
+as a readiness test ("is the composer there yet?") therefore only ever asks
+"was it there at this instant", and a driver built on it fails the moment the
+page is slower than whatever fixed ``page.wait_for_timeout(...)`` happened to
+precede the probe. Issue #235: an X row failed in ~10 s (its six siblings took
+~14 s) because the app shell had not hydrated, and a Threads row failed because
+the composer modal's shell had mounted while its ``contenteditable`` had not —
+two probes racing each other inside the same driver.
+
+The helpers here replace that pattern with a deadline + re-resolve loop, the
+same shape ``linkedin_composer.click_feed_entry`` already uses: every attempt
+re-resolves the locator against the live DOM, so a not-yet-mounted element on
+attempt 1 is simply found on attempt 3 instead of raising. A warm page still
+returns on the first attempt in well under a second — the budget is a ceiling,
+not a cost.
+
+Two rules the callers depend on:
+
+* **Deadlines come off the page clock** (``Date.now()`` in the page context),
+  not ``time.monotonic()``, so the fake-page harness in ``tests/`` can drive a
+  full timeout in zero real seconds — the same trick
+  ``_wait_composer_clears`` and ``_wait_for_pdf_upload`` already rely on.
+* **Failures are self-describing.** Every raise ends with a live probe of each
+  candidate's ``count()``, so the log alone says whether the selector matched
+  nothing (drift) or matched something that never became visible (a race) —
+  without needing the failure screenshot.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence, Tuple
+
+logger = logging.getLogger("planning_waits")
+
+# Ceiling for a readiness wait. Generous on purpose: it is only ever paid in
+# full on a genuine failure, and a cold app shell (X's splash screen) can take
+# several seconds to hydrate on a slow morning.
+READY_TIMEOUT_MS = 20000
+
+# Per-attempt budget for a single candidate. Short so the loop cycles through
+# every candidate quickly rather than spending the whole budget on the first.
+ATTEMPT_TIMEOUT_MS = 800
+
+# Budget for a click to produce its observable effect (a modal opening).
+EFFECT_TIMEOUT_MS = 4000
+
+CLICK_TIMEOUT_MS = 4000
+
+# Settle pause between rounds, letting a churning SPA re-render before we
+# re-resolve against it.
+POLL_INTERVAL_MS = 400
+
+# (label, locator) pairs — the label is what shows up in the log/diagnostic.
+Candidates = Sequence[Tuple[str, object]]
+
+
+def _now(page) -> float:
+    """Milliseconds from the *page's* clock (see module docstring)."""
+    return page.evaluate("() => Date.now()")
+
+
+def describe(candidates: Candidates) -> str:
+    """Live ``count()`` probe of every candidate, for a failure message.
+
+    Deliberately called only on the failure path: it distinguishes "matched
+    nothing" (the platform renamed something — UI drift) from "matched but
+    never became visible" (a race, or an element behind an overlay), which is
+    the first question anyone debugging one of these asks.
+    """
+    parts = []
+    for name, loc in candidates:
+        try:
+            parts.append(f"{name}: count={loc.count()}")
+        except Exception as err:  # a detached frame can make even count() throw
+            parts.append(f"{name}: probe-error({type(err).__name__})")
+    return "; ".join(parts)
+
+
+def wait_for_first_ready(
+    page,
+    candidates: Candidates,
+    *,
+    label: str,
+    timeout_ms: int = READY_TIMEOUT_MS,
+    state: str = "visible",
+):
+    """Return the first candidate that reaches ``state`` before the deadline.
+
+    Candidates are tried in order on every round, so preference order is
+    honoured while a later-appearing preferred candidate can still win a
+    subsequent round. Playwright locators are lazy, so the caller may build
+    them once and they still re-resolve on each attempt.
+
+    Raises ``RuntimeError`` naming ``label`` and describing what each candidate
+    could actually see at the deadline.
+    """
+    deadline = _now(page) + timeout_ms
+    attempts = 0
+    while True:
+        attempts += 1
+        for name, loc in candidates:
+            try:
+                target = loc.first
+                target.wait_for(state=state, timeout=ATTEMPT_TIMEOUT_MS)
+            except Exception:
+                continue
+            if attempts > 1:
+                logger.info(
+                    "✅ %s: ready via %s after %d attempt(s).", label, name, attempts
+                )
+            return target
+        if _now(page) >= deadline:
+            break
+        page.wait_for_timeout(POLL_INTERVAL_MS)
+    raise RuntimeError(
+        f"{label}: no candidate became {state} within {timeout_ms}ms "
+        f"({attempts} attempt(s)) [{describe(candidates)}]"
+    )
+
+
+def click_until_effect(
+    page,
+    candidates: Candidates,
+    *,
+    effect,
+    label: str,
+    timeout_ms: int = READY_TIMEOUT_MS,
+) -> None:
+    """Click the first ready candidate; accept only once ``effect`` is visible.
+
+    Guards the failure mode a bare click cannot see: the click is delivered to
+    a mounted-but-not-yet-hydrated node and silently swallowed, so ``.click()``
+    reports success while nothing happens. A click is only accepted once its
+    observable consequence — the modal it was supposed to open — is actually
+    on screen; otherwise it is retried like any other failed attempt.
+
+    ``effect`` is re-checked at the top of every round *before* clicking again,
+    so a click whose effect merely arrived late is never followed by a second,
+    redundant click into an already-open composer.
+    """
+    deadline = _now(page) + timeout_ms
+    attempts = 0
+    last_err = "no attempt made"
+    while True:
+        attempts += 1
+
+        # Effect already satisfied (warm composer, or a previous round's click
+        # landing late) — nothing to do.
+        try:
+            effect.first.wait_for(state="visible", timeout=ATTEMPT_TIMEOUT_MS)
+            if attempts > 1:
+                logger.info("✅ %s: effect present after %d attempt(s).", label, attempts)
+            return
+        except Exception:
+            pass
+
+        for name, loc in candidates:
+            try:
+                target = loc.first
+                target.wait_for(state="visible", timeout=ATTEMPT_TIMEOUT_MS)
+                target.click(timeout=CLICK_TIMEOUT_MS)
+            except Exception as err:
+                last_err = f"{name}: {type(err).__name__}"
+                continue
+            try:
+                effect.first.wait_for(state="visible", timeout=EFFECT_TIMEOUT_MS)
+            except Exception:
+                # Click landed but had no visible effect — inert click, or the
+                # platform is still hydrating. Retry rather than proceed into a
+                # composer that isn't there.
+                last_err = f"{name}: clicked, but the effect never became visible"
+                logger.info("↻ %s: %s — retrying.", label, last_err)
+                continue
+            logger.debug("📝 %s: opened via %s (attempt %d).", label, name, attempts)
+            return
+
+        if _now(page) >= deadline:
+            break
+        page.wait_for_timeout(POLL_INTERVAL_MS)
+    raise RuntimeError(
+        f"{label}: could not reach the expected state within {timeout_ms}ms "
+        f"({attempts} attempt(s); last: {last_err}) "
+        f"[{describe(candidates)}; {describe([('effect', effect)])}]"
+    )

--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -814,18 +814,52 @@ def _wait_for_pdf_upload(page: Page, *, timeout_ms: int = 180000) -> None:
     title as well as on PDF processing, so polling it first deadlocks until
     the timeout. Called in the right order it is the single accurate signal
     that both the upload and the title are satisfied.
+
+    **Leaves breadcrumbs (issue #235).** This wait timed out once with the
+    failure screenshot showing a dialog that looked entirely ready — preview
+    rendered, title filled, Done in its enabled style — and because the loop
+    logged nothing across its ~180 polls, the log could not settle whether
+    LinkedIn was genuinely slow or the readiness predicate had gone blind. So
+    the observed state is now sampled into the log periodically and folded into
+    the raised error: ``present=0`` means the button selector stopped matching
+    (drift), while ``present=1 disabled=…`` means it matched and stayed
+    disabled (genuinely still processing). One line in the log now answers the
+    question the screenshot could not.
     """
     deadline = page.evaluate("() => Date.now()") + timeout_ms
+    polls = 0
+    observed = "not yet observed"
     while page.evaluate("() => Date.now()") < deadline:
+        polls += 1
         done_btn = _dialog_button(page, DONE_BTN_RE).first
         try:
-            ready = done_btn.count() and _button_is_enabled(done_btn)
-        except Exception:
+            present = done_btn.count()
+            observed = f"present={present}"
+            if present:
+                disabled = done_btn.get_attribute("disabled")
+                aria_dis = done_btn.get_attribute("aria-disabled")
+                observed = (
+                    f"present=1 disabled={disabled!r} aria-disabled={aria_dis!r}"
+                )
+            ready = present and _button_is_enabled(done_btn)
+        except Exception as err:
+            observed = f"probe-error({type(err).__name__}: {err})"
             ready = False
         if ready:
+            if polls > 1:
+                logger.info(
+                    "📄 PDF ready for 'Done' after %d poll(s) (~%ds).", polls, polls
+                )
             return
+        # Every 15th poll ≈ every 15s: enough of a trace to reconstruct the
+        # whole wait afterwards, far too little to drown the log.
+        if polls == 1 or polls % 15 == 0:
+            logger.info("⏳ Waiting on PDF processing (poll %d): %s", polls, observed)
         page.wait_for_timeout(1000)
-    raise RuntimeError("PDF processing did not finish within the timeout window.")
+    raise RuntimeError(
+        f"PDF processing did not finish within the timeout window "
+        f"({timeout_ms}ms, {polls} polls; last observed Done button: {observed})."
+    )
 
 
 def _fill_document_title(page: Page, doc_title: str) -> None:

--- a/planning/threads/README.md
+++ b/planning/threads/README.md
@@ -134,6 +134,22 @@ from the IG side of the editorial DB. The scheduler only **reads** these
    The scheduler's primary idempotency marker is
    `work in progress TH` — unticked on a fully-successful LIVE run.
 
+9. **The modal shell and its caption box mount separately** (issue #235).
+   Treating `[role="dialog"]` as "composer open" is a race: the shell appears
+   while the modal is still spinning, so `_type_caption` then probes for a
+   `contenteditable` that has not rendered and fails — which is exactly how the
+   *first* row of a batch failed while the six after it succeeded.
+   `_open_composer` now holds until the **caption box itself** is visible, and
+   `_type_caption` keeps a bounded wait as a second line of defence (the box is
+   also re-created when Threads swaps the composer between reply/thread modes).
+   Never use `count()` as a readiness test — it does not wait.
+
+10. **Row retry stops at the final Schedule click.** `planning._failure.attempt_row`
+    re-attempts a row that failed *before* the post was committed, but
+    `schedule_post` raises `PostMayBeLiveError` from `_click_final_schedule_action`
+    onward — past that point a failure no longer proves nothing happened, and a
+    retry would double-post. Losing one row to a manual re-run beats a duplicate.
+
 ---
 
 ## Files

--- a/planning/threads/schedule_threads_posts.py
+++ b/planning/threads/schedule_threads_posts.py
@@ -74,6 +74,12 @@ from planning._wip_rows import (  # noqa: E402
     fetch_wip_rows as _fetch_wip_rows,
     resolve_payload as _resolve_payload,
 )
+from planning._failure import PostMayBeLiveError, attempt_row  # noqa: E402
+from planning._waits import (  # noqa: E402
+    CLICK_TIMEOUT_MS,
+    click_until_effect,
+    wait_for_first_ready,
+)
 
 
 def fetch_wip_th_rows(notion, db_id: str, ed_cols: dict, days: Optional[list[date]]) -> list[ScheduleRow]:
@@ -90,31 +96,29 @@ def _open_composer(page: Page) -> None:
     """Click the inline 'What's new?' on the profile to open the New thread
     modal. The same placeholder text exists inside the modal, so disambiguate
     by checking the modal's heading after opening.
+
+    The modal is only accepted once its **caption box** is on screen, not
+    merely its ``[role="dialog"]`` shell. Those two mount separately, and
+    treating the shell as "open" is what let ``_type_caption`` run against a
+    still-spinning modal and fail the first row of a batch while the six after
+    it succeeded (issue #235).
     """
-    candidates = [
-        # Profile-row click target. Several variants observed across Threads
-        # builds — try in order.
-        'text="What\'s new?"',
-        '[aria-label="Create new thread" i]',
-        'div[role="button"]:has-text("What\'s new?")',
-    ]
-    opened = False
-    for sel in candidates:
-        try:
-            loc = page.locator(sel).first
-            if loc.count():
-                loc.click(timeout=4000)
-                page.wait_for_timeout(800)
-                if page.locator('[role="dialog"]').count() or page.locator(
-                    'text="New thread"'
-                ).count():
-                    logger.debug("📝 Opened composer via %s", sel)
-                    opened = True
-                    break
-        except Exception:
-            continue
-    if not opened:
-        raise RuntimeError("Could not open the Threads composer modal.")
+    click_until_effect(
+        page,
+        [
+            # Profile-row click target. Several variants observed across
+            # Threads builds — tried in order on every round.
+            ("placeholder text", page.locator('text="What\'s new?"')),
+            ("aria create-thread", page.locator('[aria-label="Create new thread" i]')),
+            ("role=button placeholder",
+             page.locator('div[role="button"]:has-text("What\'s new?")')),
+        ],
+        effect=page.locator(
+            '[role="dialog"] div[contenteditable="true"], '
+            '[role="dialog"] [role="textbox"]'
+        ),
+        label="Threads composer modal",
+    )
 
 
 def _type_caption(page: Page, caption: str) -> None:
@@ -124,23 +128,26 @@ def _type_caption(page: Page, caption: str) -> None:
     dialog = page.locator('[role="dialog"]').last
     # The textarea inside the dialog is a contenteditable, anchored by the
     # same "What's new?" placeholder. Anchor by role.
-    ta_candidates = [
-        dialog.get_by_role("textbox", name=WHATS_NEW_TEXTBOX_RE).first,
-        dialog.locator('div[contenteditable="true"]').first,
-        dialog.locator('[role="textbox"]').first,
-    ]
-    for ta in ta_candidates:
-        try:
-            if ta.count():
-                ta.click(timeout=4000)
-                page.wait_for_timeout(150)
-                page.keyboard.type(caption, delay=4)
-                page.wait_for_timeout(400)
-                logger.debug("📝 Caption typed (%d chars).", len(caption))
-                return
-        except Exception:
-            continue
-    raise RuntimeError("Could not find the Threads caption textbox.")
+    #
+    # Bounded wait rather than a bare count(): _open_composer now holds until
+    # this box exists, so reaching here and finding nothing should be rare —
+    # but the contenteditable is also re-created when Threads swaps the
+    # composer between reply/thread modes, so the wait stays as the second
+    # line of defence (issue #235).
+    ta = wait_for_first_ready(
+        page,
+        [
+            ("placeholder textbox", dialog.get_by_role("textbox", name=WHATS_NEW_TEXTBOX_RE)),
+            ("contenteditable", dialog.locator('div[contenteditable="true"]')),
+            ("role=textbox", dialog.locator('[role="textbox"]')),
+        ],
+        label="Threads caption textbox",
+    )
+    ta.click(timeout=CLICK_TIMEOUT_MS)
+    page.wait_for_timeout(150)
+    page.keyboard.type(caption, delay=4)
+    page.wait_for_timeout(400)
+    logger.debug("📝 Caption typed (%d chars).", len(caption))
 
 
 def _upload_image(page: Page, path: Path) -> None:
@@ -529,11 +536,19 @@ def schedule_post(
         return "post:DRY-OK"
 
     _click_calendar_done(page)
-    _click_final_schedule_action(page)
-    if not _wait_composer_closes(page, timeout_ms=25000):
-        shot = out_dir / f"{label}-post-FAIL.png"
-        page.screenshot(path=str(shot), full_page=False)
-        raise RuntimeError(f"Composer did not close — see {shot}")
+
+    # ---- point of no return (issue #235) ----
+    # Past the final Schedule click a failure no longer proves the post was not
+    # scheduled, so these raise PostMayBeLiveError and the row loop refuses to
+    # retry them. See planning/_failure.py for the contract.
+    try:
+        _click_final_schedule_action(page)
+        if not _wait_composer_closes(page, timeout_ms=25000):
+            shot = out_dir / f"{label}-post-FAIL.png"
+            page.screenshot(path=str(shot), full_page=False)
+            raise RuntimeError(f"Composer did not close — see {shot}")
+    except Exception as err:
+        raise PostMayBeLiveError(str(err)) from err
     page.wait_for_timeout(1500)
     logger.info("✅ LIVE %s post scheduled on Threads", label)
     return "post:LIVE"
@@ -647,8 +662,19 @@ def main() -> tuple[int, list[dict]]:
 
         for row, payload in plans:
             return_to_profile(session.page, cfg["feed_url"])
+
+            def _reset() -> None:
+                """Clean slate between attempts — a half-filled composer left
+                by the failed attempt would otherwise capture the retry."""
+                _cancel_composer(session.page)
+                return_to_profile(session.page, cfg["feed_url"])
+
             try:
-                status = schedule_post(session, cfg, row, payload, dry_run=dry_run)
+                status = attempt_row(
+                    lambda: schedule_post(session, cfg, row, payload, dry_run=dry_run),
+                    label=row.day_title,
+                    reset=_reset,
+                )
             except (RuntimeError, PWTimeoutError) as err:
                 shot = session.screenshot_failure(f"{row.day_title}-error")
                 logger.error("❌ %s post failed: %s (screenshot %s)", row.day_title, err, shot)

--- a/planning/twitter/README.md
+++ b/planning/twitter/README.md
@@ -123,6 +123,24 @@ successful live run).
    label. Use `.last` to avoid ambiguity with the inline composer's button
    on the underlying feed.
 
+9. **Never use `count()` as a readiness test** (issue #235). `Locator.count()`
+   returns immediately — it asks "is it there *right now*", not "wait for it".
+   A row that arrives while X is still showing its black splash screen finds
+   nothing mounted, burns through every candidate selector in milliseconds and
+   fails, while its siblings on the same warm page all succeed. Use
+   `planning._waits.click_until_effect` / `wait_for_first_ready`, which
+   re-resolve against the live DOM until a deadline. The effect for the
+   composer must be `[role="dialog"] [data-testid="tweetTextarea_0"]` — the
+   bare testid also matches the **inline** composer that is always present on
+   `/home`, so a looser effect is satisfied on arrival and the modal never
+   opens at all.
+
+10. **Row retry stops at the final Schedule click.** `planning._failure.attempt_row`
+    re-attempts a row that failed *before* the post was committed, but
+    `schedule_post` raises `PostMayBeLiveError` from `_click_final_schedule_action`
+    onward — past that point a failure no longer proves nothing happened, and a
+    retry would double-post. Losing one row to a manual re-run beats a duplicate.
+
 ---
 
 ## Files

--- a/planning/twitter/schedule_twitter_posts.py
+++ b/planning/twitter/schedule_twitter_posts.py
@@ -54,6 +54,12 @@ from reporting.notion.editorial import (  # noqa: E402
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
 from planning._dates import parse_single_date, parse_week_start  # noqa: E402
+from planning._failure import PostMayBeLiveError, attempt_row  # noqa: E402
+from planning._waits import (  # noqa: E402
+    CLICK_TIMEOUT_MS,
+    click_until_effect,
+    wait_for_first_ready,
+)
 
 logger = logging.getLogger("twitter_schedule")
 
@@ -115,41 +121,47 @@ def _click_compose_area(page: Page) -> None:
     ``[data-testid="tweetTextarea_0"]`` inside ``[role="dialog"]``. Preferred
     over the inline composer because the inline one can carry stale draft
     state between sessions.
-    """
-    candidates = [
-        '[data-testid="SideNav_NewTweet_Button"]',
-        'a[data-testid="SideNav_NewTweet_Button"]',
-        '[aria-label="Post" i][role="button"]',
-    ]
-    for sel in candidates:
-        try:
-            loc = page.locator(sel).first
-            if loc.count():
-                loc.click(timeout=5000)
-                page.wait_for_timeout(900)
-                # Confirm a dialog opened with a textarea inside.
-                ta_in_dialog = page.locator(
-                    '[role="dialog"] [data-testid="tweetTextarea_0"]'
-                ).count()
-                if ta_in_dialog:
-                    logger.debug("📝 Opened composer modal via %s", sel)
-                    return
-        except Exception:
-            continue
 
-    # Fallback: try the inline textarea directly.
+    Every candidate used to be probed with a bare ``count()``, which does not
+    wait — so a row that arrived while X was still showing its splash screen
+    found nothing mounted, exhausted all four probes in milliseconds and
+    raised, while its siblings on the same warm page all succeeded (#235).
+    ``click_until_effect`` re-resolves until the composer is genuinely on
+    screen, so a cold app shell costs a few extra seconds instead of the row.
+    """
+    # The effect must be the textarea *inside the dialog*, never a bare
+    # ``tweetTextarea_0``: X renders an inline composer on the home timeline,
+    # so the looser selector is already satisfied on arrival and the modal
+    # would never be opened at all.
     try:
-        ta = page.locator('[data-testid="tweetTextarea_0"]').first
-        if ta.count():
-            ta.scroll_into_view_if_needed(timeout=2000)
-            ta.click(timeout=4000)
-            page.wait_for_timeout(500)
-            logger.debug("📝 Clicked inline composer area (fallback).")
-            return
+        click_until_effect(
+            page,
+            [
+                ("side-rail testid", page.locator('[data-testid="SideNav_NewTweet_Button"]')),
+                ("side-rail anchor", page.locator('a[data-testid="SideNav_NewTweet_Button"]')),
+                ("aria Post button", page.locator('[aria-label="Post" i][role="button"]')),
+            ],
+            effect=page.locator('[role="dialog"] [data-testid="tweetTextarea_0"]'),
+            label="X compose modal",
+        )
+        return
+    except RuntimeError as err:
+        logger.warning("⚠️ Compose modal did not open (%s) — trying the inline composer.", err)
+
+    # Fallback: the inline composer. Kept strictly behind the modal routes
+    # because it can carry stale draft state between sessions.
+    ta = wait_for_first_ready(
+        page,
+        [("inline textarea", page.locator('[data-testid="tweetTextarea_0"]'))],
+        label="X inline composer",
+        timeout_ms=4000,
+    )
+    try:
+        ta.scroll_into_view_if_needed(timeout=2000)
     except Exception:
         pass
-
-    raise RuntimeError("Could not open the X compose area.")
+    ta.click(timeout=CLICK_TIMEOUT_MS)
+    logger.debug("📝 Clicked inline composer area (fallback).")
 
 
 def _type_caption(page: Page, caption: str) -> None:
@@ -537,11 +549,20 @@ def schedule_post(
         return "post:DRY-OK"
 
     _click_confirm_in_modal(page)
-    _click_final_schedule_action(page)
-    if not _wait_composer_clears(page, timeout_ms=25000):
-        shot = out_dir / f"{label}-post-FAIL.png"
-        page.screenshot(path=str(shot), full_page=False)
-        raise RuntimeError(f"Composer did not clear — see {shot}")
+
+    # ---- point of no return (issue #235) ----
+    # From the final Schedule click onward a failure no longer means "nothing
+    # happened" — the post may be scheduled and we merely lost sight of it. So
+    # everything below raises PostMayBeLiveError, which the row loop refuses to
+    # retry. Losing one row to a manual re-run beats double-posting it.
+    try:
+        _click_final_schedule_action(page)
+        if not _wait_composer_clears(page, timeout_ms=25000):
+            shot = out_dir / f"{label}-post-FAIL.png"
+            page.screenshot(path=str(shot), full_page=False)
+            raise RuntimeError(f"Composer did not clear — see {shot}")
+    except Exception as err:
+        raise PostMayBeLiveError(str(err)) from err
     page.wait_for_timeout(1200)
     logger.info("✅ LIVE %s post scheduled on X", label)
     return "post:LIVE"
@@ -658,8 +679,19 @@ def main() -> tuple[int, list[dict]]:
 
         for row, payload in plans:
             return_to_home(session.page, cfg["feed_url"])
+
+            def _reset() -> None:
+                """Clean slate between attempts — a half-filled composer left
+                by the failed attempt would otherwise capture the retry."""
+                _cancel_composer(session.page)
+                return_to_home(session.page, cfg["feed_url"])
+
             try:
-                status = schedule_post(session, cfg, row, payload, dry_run=dry_run)
+                status = attempt_row(
+                    lambda: schedule_post(session, cfg, row, payload, dry_run=dry_run),
+                    label=row.day_title,
+                    reset=_reset,
+                )
             except (RuntimeError, PWTimeoutError) as err:
                 shot = session.screenshot_failure(f"{row.day_title}-error")
                 logger.error("❌ %s post failed: %s (screenshot %s)", row.day_title, err, shot)

--- a/planning/videos/videos_linkedin.py
+++ b/planning/videos/videos_linkedin.py
@@ -44,8 +44,14 @@ from planning.linkedin.schedule_linkedin_posts import (  # noqa: E402
     _set_schedule_datetime,
 )
 from planning.videos.videos_session import VideoRow  # noqa: E402
+from planning._waits import wait_for_first_ready  # noqa: E402
 
 logger = logging.getLogger("videos_linkedin")
+
+# Budget for LinkedIn's video Editor dialog to mount its (hidden) file input.
+# Generous because it is only ever paid in full on a genuine failure, and the
+# old 15 s lost a leg to a slow LinkedIn morning (issue #235).
+VIDEO_INPUT_TIMEOUT_MS = 45000
 
 
 # Re-exported for backward compatibility with any caller that imported these
@@ -101,9 +107,26 @@ def _upload_video(page: Page, video_path: Path) -> None:
     # with ``accept="...video/mp4..."`` and a visually-hidden wrapper. Push the file
     # straight at that input — the visible "Upload from computer" button is purely
     # decorative and is intercepted by a styled <div> overlay (clicking it errors out).
-    inp = page.locator('input#media-editor-file-selector__file-input, input[type="file"]').first
+    #
+    # The 15 s budget this used to carry was not enough on a slow LinkedIn
+    # morning — the Editor dialog simply had not mounted yet and the leg failed
+    # with a bare Playwright timeout (issue #235). ``wait_for_first_ready``
+    # re-resolves until a far more generous deadline and, on a real failure,
+    # reports what each selector could actually see instead of just the elapsed
+    # time. ``state="attached"``, not visible: the input is deliberately
+    # visually hidden behind the decorative "Upload from computer" button.
     try:
-        inp.wait_for(state="attached", timeout=15000)
+        inp = wait_for_first_ready(
+            page,
+            [
+                ("media-editor input",
+                 page.locator('input#media-editor-file-selector__file-input')),
+                ("any file input", page.locator('input[type="file"]')),
+            ],
+            label="LinkedIn video editor file input",
+            timeout_ms=VIDEO_INPUT_TIMEOUT_MS,
+            state="attached",
+        )
         inp.set_input_files(str(video_path))
     except Exception as err:
         raise RuntimeError(f"Could not upload video to LinkedIn editor: {err}")

--- a/tests/test_planning_waits_and_retry.py
+++ b/tests/test_planning_waits_and_retry.py
@@ -1,0 +1,291 @@
+"""Behavioural tests for the bounded readiness waits + row retry (issue #235).
+
+The 2026-08-22 planning run lost 3 rows to the same mechanism: a readiness test
+built on ``Locator.count()``, which returns *immediately* and never waits. An X
+row failed in ~10 s (its six siblings took ~14 s) because the app shell had not
+hydrated yet, and a Threads row failed because the composer modal's shell had
+mounted while its ``contenteditable`` had not.
+
+The fakes below model exactly that: an element that becomes ready at a chosen
+point on a virtual clock. ``test_waits_for_a_late_element`` is the regression
+proof — its element is absent at t=0, so the old ``if loc.count():`` probe would
+have seen 0 and raised, while the replacement finds it on a later round.
+
+The clock only advances inside the fakes' own waits, so a full 20 s timeout
+costs no real time — the same trick ``test_schedule_confirmation.py`` uses.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from planning._failure import PostMayBeLiveError, attempt_row, classify
+from planning._waits import (
+    READY_TIMEOUT_MS,
+    click_until_effect,
+    wait_for_first_ready,
+)
+
+
+class _FakeTimeout(Exception):
+    """Stand-in for Playwright's TimeoutError."""
+
+
+class _FakePage:
+    """Minimal Playwright ``Page`` with a virtual clock in milliseconds."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def evaluate(self, _expr: str) -> float:
+        return self.now
+
+    def wait_for_timeout(self, ms: float) -> None:
+        self.now += ms
+
+    def advance(self, ms: float) -> None:
+        self.now += ms
+
+
+class _FakeLocator:
+    """Element that becomes ready at ``ready_at`` on the page's virtual clock.
+
+    ``ready_at=None`` means "never appears" — the UI-drift case.
+    """
+
+    def __init__(self, page: _FakePage, ready_at: float | None = 0.0) -> None:
+        self._page = page
+        self._ready_at = ready_at
+        self.clicks = 0
+
+    # Playwright locators are lazy; ``.first`` re-resolves rather than snapshots.
+    @property
+    def first(self) -> "_FakeLocator":
+        return self
+
+    def _ready(self) -> bool:
+        return self._ready_at is not None and self._ready_at <= self._page.now
+
+    def count(self) -> int:
+        return 1 if self._ready() else 0
+
+    def wait_for(self, *, state: str = "visible", timeout: float = 0) -> None:
+        if self._ready():
+            return
+        if self._ready_at is not None and self._ready_at <= self._page.now + timeout:
+            self._page.advance(self._ready_at - self._page.now)
+            return
+        self._page.advance(timeout)
+        raise _FakeTimeout(f"not {state} within {timeout}ms")
+
+    def click(self, timeout: float = 0) -> None:
+        if not self._ready():
+            raise _FakeTimeout("not clickable")
+        self.clicks += 1
+        self._page.advance(50)
+
+
+class _FakeButton(_FakeLocator):
+    """A button whose click arms an effect locator after ``delay`` ms.
+
+    ``delay=None`` models the inert click: the click lands and reports success,
+    but nothing ever happens — the failure mode a bare ``.click()`` cannot see.
+    """
+
+    def __init__(self, page, effect: _FakeLocator, *, delay: float | None = 0.0,
+                 ready_at: float = 0.0) -> None:
+        super().__init__(page, ready_at)
+        self._effect = effect
+        self._delay = delay
+
+    def click(self, timeout: float = 0) -> None:
+        super().click(timeout)
+        if self._delay is not None:
+            self._effect._ready_at = self._page.now + self._delay
+
+
+class WaitForFirstReadyTests(unittest.TestCase):
+
+    def test_waits_for_a_late_element(self):
+        """Regression for #235: absent at t=0, present shortly after.
+
+        A bare ``count()`` probe — the pre-fix readiness test — returns 0 here
+        and the driver raises. The bounded wait must find it instead.
+        """
+        page = _FakePage()
+        late = _FakeLocator(page, ready_at=5000)
+        self.assertEqual(late.count(), 0, "precondition: absent at t=0")
+
+        got = wait_for_first_ready(
+            page, [("late", late)], label="composer",
+        )
+        self.assertIs(got, late)
+        self.assertLessEqual(page.now, READY_TIMEOUT_MS)
+
+    def test_honours_candidate_order(self):
+        page = _FakePage()
+        preferred = _FakeLocator(page, ready_at=0)
+        fallback = _FakeLocator(page, ready_at=0)
+        got = wait_for_first_ready(
+            page,
+            [("preferred", preferred), ("fallback", fallback)],
+            label="composer",
+        )
+        self.assertIs(got, preferred)
+
+    def test_falls_through_to_a_later_candidate(self):
+        page = _FakePage()
+        never = _FakeLocator(page, ready_at=None)
+        works = _FakeLocator(page, ready_at=0)
+        got = wait_for_first_ready(
+            page, [("never", never), ("works", works)], label="composer",
+        )
+        self.assertIs(got, works)
+
+    def test_timeout_message_reports_what_it_saw(self):
+        """The failure must distinguish drift from a race without a screenshot."""
+        page = _FakePage()
+        missing = _FakeLocator(page, ready_at=None)
+        with self.assertRaises(RuntimeError) as ctx:
+            wait_for_first_ready(
+                page, [("side-rail", missing)], label="X compose area",
+                timeout_ms=3000,
+            )
+        msg = str(ctx.exception)
+        self.assertIn("X compose area", msg)
+        self.assertIn("side-rail", msg)
+        self.assertIn("count=0", msg)
+
+    def test_timeout_is_bounded(self):
+        page = _FakePage()
+        missing = _FakeLocator(page, ready_at=None)
+        with self.assertRaises(RuntimeError):
+            wait_for_first_ready(
+                page, [("missing", missing)], label="x", timeout_ms=3000,
+            )
+        # Generous ceiling: the loop may overshoot by one attempt + settle.
+        self.assertLess(page.now, 3000 * 3)
+
+
+class ClickUntilEffectTests(unittest.TestCase):
+
+    def test_clicks_once_when_the_effect_follows(self):
+        page = _FakePage()
+        effect = _FakeLocator(page, ready_at=None)
+        button = _FakeButton(page, effect, delay=200)
+        click_until_effect(
+            page, [("side-rail", button)], effect=effect, label="X compose modal",
+        )
+        self.assertEqual(button.clicks, 1)
+
+    def test_does_not_click_when_the_effect_is_already_present(self):
+        """Guards against a second, redundant click into an open composer."""
+        page = _FakePage()
+        effect = _FakeLocator(page, ready_at=0)
+        button = _FakeButton(page, effect, delay=0)
+        click_until_effect(
+            page, [("side-rail", button)], effect=effect, label="X compose modal",
+        )
+        self.assertEqual(button.clicks, 0)
+
+    def test_retries_an_inert_click(self):
+        """Click lands and reports success, but nothing happens — must retry."""
+        page = _FakePage()
+        effect = _FakeLocator(page, ready_at=None)
+        inert = _FakeButton(page, effect, delay=None)
+        with self.assertRaises(RuntimeError) as ctx:
+            click_until_effect(
+                page, [("inert", inert)], effect=effect,
+                label="X compose modal", timeout_ms=6000,
+            )
+        self.assertGreater(inert.clicks, 1, "an inert click must be retried")
+        self.assertIn("effect never became visible", str(ctx.exception))
+
+    def test_waits_for_a_button_that_mounts_late(self):
+        """The X-splash-screen case: nothing is mounted on the first round."""
+        page = _FakePage()
+        effect = _FakeLocator(page, ready_at=None)
+        button = _FakeButton(page, effect, delay=200, ready_at=4000)
+        click_until_effect(
+            page, [("side-rail", button)], effect=effect, label="X compose modal",
+        )
+        self.assertEqual(button.clicks, 1)
+
+
+class AttemptRowTests(unittest.TestCase):
+
+    def test_retries_a_transient_failure(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("Could not open the X compose area.")
+            return "post:LIVE"
+
+        self.assertEqual(attempt_row(run, label="20260830"), "post:LIVE")
+        self.assertEqual(len(calls), 2)
+
+    def test_never_retries_a_committed_post(self):
+        """The double-post guard — the one regression that must never happen."""
+        calls = []
+
+        def run():
+            calls.append(1)
+            raise PostMayBeLiveError("Composer did not clear")
+
+        with self.assertRaises(PostMayBeLiveError):
+            attempt_row(run, label="20260830")
+        self.assertEqual(calls, [1], "a committed post must never be re-attempted")
+
+    def test_reraises_after_the_final_attempt(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            raise RuntimeError("still broken")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            attempt_row(run, label="20260830", attempts=3)
+        self.assertEqual(len(calls), 3)
+        self.assertIn("still broken", str(ctx.exception))
+
+    def test_resets_between_attempts(self):
+        """A half-filled composer must be cleared or the retry inherits it."""
+        order = []
+
+        def run():
+            order.append("run")
+            if order.count("run") == 1:
+                raise RuntimeError("transient")
+            return "ok"
+
+        attempt_row(run, label="20260830", reset=lambda: order.append("reset"))
+        self.assertEqual(order, ["run", "reset", "run"])
+
+    def test_reset_failure_does_not_mask_the_retry(self):
+        calls = []
+
+        def run():
+            calls.append(1)
+            if len(calls) == 1:
+                raise RuntimeError("transient")
+            return "ok"
+
+        def boom():
+            raise RuntimeError("cancel failed")
+
+        self.assertEqual(attempt_row(run, label="x", reset=boom), "ok")
+
+    def test_committed_failure_still_classifies(self):
+        """The heal loop reads failure_kind — a committed row must not become
+        auto-heal-eligible just because it now carries a different type."""
+        self.assertEqual(
+            classify("FAIL", "Composer did not clear — see shot.png"), "other"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The 2026-08-22 planning run finished `Mixed result` — 4 failures out of 22 items. Three of them share one mechanism: **`Locator.count()` used as a readiness test**. It returns immediately and never waits, so whenever the page or modal is slower than the preceding hardcoded `wait_for_timeout`, every candidate reports `0` and the driver raises instead of waiting for the element that is about to appear.

The tell: the X row failed in ~10s where its six successful siblings each took ~14s, and the Threads failure was the *first* row of the batch with all six after it green.

- **`planning/_waits.py`** (new) — `wait_for_first_ready` / `click_until_effect`: deadline + re-resolve loops driven off the page clock, mirroring the shape `linkedin_composer.click_feed_entry` already uses. Both probe every candidate on failure so the log alone separates drift (`count=0`) from a race.
- **Twitter** — composer opened via `click_until_effect`. The effect had to be the textarea *inside the dialog*: the bare `tweetTextarea_0` testid also matches the always-present inline composer on `/home`, so a looser effect is already satisfied on arrival and the modal would never open.
- **Threads** — the composer is accepted only once its **caption box** is visible, not its `[role="dialog"]` shell. Those mount separately, and racing them is exactly what failed the first row.
- **`attempt_row` + `PostMayBeLiveError`** — row-level retry for Twitter/Threads, which had none. Retries a row that failed *before* the post was committed; never one that failed at or past the final Schedule click.
- **LinkedIn** — `_wait_for_pdf_upload` now leaves breadcrumbs (see below).
- **Videos** — the LinkedIn editor file-input wait was 15s with no retry.

## The double-post guard

The one failure mode strictly worse than the bug being fixed. The retry boundary is drawn *before* the final Schedule click rather than after: a click that never landed is safe to retry, but proving it never landed is harder than accepting one lost row. `test_never_retries_a_committed_post` pins it.

## Test plan

- [x] `& .\.venv\Scripts\python.exe -m unittest discover tests` — 186 tests, OK (skipped=1)
- [x] 15 new tests in `tests/test_planning_waits_and_retry.py`, on the existing virtual-clock fake-page harness so a full 20s timeout costs no real time
- [x] Regression proof: `test_waits_for_a_late_element` asserts `count() == 0` at t=0 as a precondition — the exact predicate the pre-fix code used — then shows the bounded wait finds the element anyway
- [x] Live dry-run, Twitter, the row that failed: `--all-wip --dry-run` → `20260830: post:DRY-OK`
- [x] Live dry-run, Threads, the row that failed: `--all-wip --dry-run` → `20260824: post:DRY-OK`

## Note

The LinkedIn breadcrumbs added here immediately paid for themselves: a dry-run of the carousel row logged `present=0` on all 177 polls, proving the Done-button selector matches **nothing** — UI drift, not the slow PDF processing the error message claimed. That is a separate, independently-revertable bug and is filed on its own.

Closes #235