### PR TITLE
videos: give the Threads leg an idempotency marker for recovery runs

### DIFF
--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -64,6 +64,7 @@ flowchart TB
   TW --> CHROME
   TH --> CHROME
   VIDEOS --> CHROME
+  VIDEOS <-->|"TH 'already scheduled'\n(no link TH(v) column)"| VIDLEDGER[["results/videos/\ntag_along_scheduled.json"]]
   PPIPE --> RESULTSPLAN[["results/planning/\nsummary.md + result.json"]]
   RESULTSPLAN -.->|"selector-drift failure"| AUTOHEALSKILL
 

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -34,7 +34,7 @@ flowchart TD
 | `python -m planning.videos.schedule_videos_posts --all-wip --live` | Schedule on every WIP-Video row across LI / IG / TW / TH. |
 | `python -m planning.videos.schedule_videos_posts --date 20260512 --live` | Single-day mode (only that row's video). |
 | `python -m planning.videos.schedule_videos_posts --all-wip --live --skip-li --skip-th` | Schedule only the platforms not flagged with `--skip-*`. |
-| `python -m planning.videos.schedule_videos_posts --all-wip --live --force` | Schedule even if `link <P>(v)` is already populated. |
+| `python -m planning.videos.schedule_videos_posts --all-wip --live --force` | Schedule even if already marked scheduled (`link <P>(v)` populated, or a tag-along ledger entry). |
 | `python -m planning.substack.post_substack_video_note --date 20260512 --live --force` | Standalone Substack video-note publish (also invoked automatically by the daily pipeline on video days). |
 | `python planning_pipeline.py --live` | Full planning orchestrator: LI → IG → TW → TH → **Videos** (Videos runs last). |
 
@@ -153,20 +153,39 @@ attach helper. See:
   SKIP-out-of-scope (clip relation deliberately empty → untick OK).
   Re-running with `--skip-li` will leave WIP-Vd checked so you can come
   back to LI later.
-- **Threads has no `link TH(v)` column → no link-based idempotency.**
-  TH is included via the `PLATFORMS_TAG_ALONG` set: in scope whenever
-  any other clip relation is populated. The orchestrator can't write a
-  sentinel for TH (no column), so re-runs with WIP-Vd still True would
-  attempt to re-schedule TH. The orchestrator unticks WIP-Vd as soon as
-  TH (and the other platforms) succeed once, which prevents accidental
-  double-scheduling in practice — but if you re-tick WIP-Vd later
-  without first deleting the existing scheduled Threads post, you'll
-  get a duplicate. The post-LIVE sentinel-write loop in
-  `schedule_videos_posts.py` explicitly skips platforms in
-  `PLATFORMS_TAG_ALONG` (see issue #29) so successful TH runs don't
-  log a misleading `"Role 'post_url_th' not present"` warning — that
-  warning is reserved for *real* `editorial_columns` regressions
-  (e.g. a `post_url_li` entry accidentally deleted from `config.json`).
+- **Threads has no `link TH(v)` column → its idempotency marker lives
+  off-column, in a ledger.** TH is included via the
+  `PLATFORMS_TAG_ALONG` set: in scope whenever any other clip relation
+  is populated. There is no column to hold the sentinel every other
+  platform uses, so the post-LIVE sentinel-write loop in
+  `schedule_videos_posts.py` skips tag-along platforms (issue #29 — the
+  write would log a misleading `"Role 'post_url_th' not present"`
+  warning, and that warning is reserved for *real* `editorial_columns`
+  regressions such as a `post_url_li` entry deleted from `config.json`).
+  Instead a successful TH run is recorded in
+  `results/videos/tag_along_scheduled.json` by
+  `planning/videos/videos_ledger.py` (gitignored, keyed by platform and
+  day title), and both `_rows_for_platform` and the WIP-Vd untick
+  decision consult it.
+
+  This is what makes a **recovery run** possible (issue #239). Before the
+  ledger, a row whose LI leg failed while IG/TW/TH went live had no good
+  re-run: plain re-run re-posted the Threads video, and `--skip-th`
+  avoided that only by leaving WIP-Vd checked forever, since a flag-skip
+  is deliberately not accepted as success. Now the untick decision
+  consults the ledger rather than the SKIP *reason*, so `--skip-th`
+  unticks when a prior run genuinely scheduled TH and still keeps WIP-Vd
+  checked when it did not. `--force` bypasses the ledger, which is the
+  deliberate way to re-post.
+
+  The ledger is a cache of what we already did, never a source of truth
+  about Notion, and its failure directions are asymmetric on purpose: a
+  missing or corrupt file reads as "nothing scheduled" (so the platform
+  runs — exactly the pre-ledger behaviour), while a failed write is
+  logged loudly but never raises, because the post is already live by
+  then. Deleting the file is therefore safe but costs you the recovery
+  path; if you re-tick WIP-Vd for a day whose ledger entry you removed,
+  you will get a duplicate.
 - **The LI composer does not reliably close within 20 s of `Schedule`.** The
   wait that confirms a scheduled post is shared with the photo/carousel
   driver — `linkedin_composer.wait_for_schedule_confirmation`, one copy so the
@@ -278,6 +297,10 @@ attach helper. See:
 - `schedule_videos_posts.py` — orchestrator entry point. Implements the
   `main() -> tuple[int, list[dict]]` contract consumed by
   `planning_pipeline.py`.
+- `videos_ledger.py` — `TagAlongLedger`, the off-column "already scheduled"
+  marker for platforms with no `link <P>(v)` column (currently TH only).
+  Backed by `results/videos/tag_along_scheduled.json`; see the tag-along
+  gotcha above for why it exists and how it fails.
 - `videos_linkedin.py` / `videos_instagram.py` / `videos_twitter.py` /
   `videos_threads.py` — per-platform drivers, each exposing
   `run(rows, video_cfg, *, dry_run) -> list[dict]`.

--- a/planning/videos/schedule_videos_posts.py
+++ b/planning/videos/schedule_videos_posts.py
@@ -15,7 +15,8 @@ The ``Work in Progress Video`` checkbox is unticked **only** when all four
 scheduled platforms succeed AND ``link SB(v)`` is populated by the daily
 Substack pipeline. Re-runnable: a second invocation after Substack posts
 will skip the already-scheduled four (idempotent via ``link <P>(v)``
-presence) and just untick.
+presence, or via the tag-along ledger for platforms that have no such
+column — see ``planning.videos.videos_ledger``) and just untick.
 
 CLI:
     python -m planning.videos.schedule_videos_posts \\
@@ -23,7 +24,7 @@ CLI:
         [--date YYYYMMDD]
         [--all-wip]             # every WIP-Video row, no date filter
         [--dry-run | --live]
-        [--force]               # schedule even if link <P>(v) is set
+        [--force]               # schedule even if already marked scheduled
         [--debug]
         [--skip-li] [--skip-ig] [--skip-tw] [--skip-th]
 """
@@ -38,6 +39,7 @@ from pathlib import Path
 from typing import Optional
 
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from planning.videos.videos_ledger import TagAlongLedger  # noqa: E402
 from planning.videos.videos_session import (  # noqa: E402
     ClipPayload,
     VideoRow,
@@ -68,6 +70,9 @@ PLATFORMS_SCHEDULED = ("li", "ig", "tw", "th")  # SB is owned by the daily Subst
 # They are in scope whenever ANY of the other platforms' clip relations is
 # populated (i.e. the row has a video planned at all). The shared clip page
 # resolves identically regardless of which relation it was followed through.
+# Having no column of their own also means no ``link <P>(v)`` to hold the
+# idempotency sentinel, so their "already scheduled" marker lives off-column in
+# ``planning.videos.videos_ledger`` instead (issue #239).
 PLATFORMS_TAG_ALONG = frozenset({"th"})
 
 
@@ -220,12 +225,14 @@ def fetch_wip_video_rows(notion, db_id: str, video_cols: dict,
     return rows
 
 
-def _rows_for_platform(rows: list[_RowState], platform: str, force: bool) -> list:
+def _rows_for_platform(rows: list[_RowState], platform: str, force: bool,
+                       ledger: TagAlongLedger) -> list:
     """Filter rows to those eligible for the given platform.
 
-    Eligible = clip relation populated for that platform AND
-    (link <P>(v) is empty OR --force). Already-failed (payload-failed)
-    rows are excluded since they have nothing to schedule.
+    Eligible = clip relation populated for that platform AND not already
+    scheduled (per ``link <P>(v)``, or per the tag-along ledger for platforms
+    that have no such column) — unless ``--force``. Already-failed
+    (payload-failed) rows are excluded since they have nothing to schedule.
     """
     eligible = []
     for row in rows:
@@ -238,6 +245,19 @@ def _rows_for_platform(rows: list[_RowState], platform: str, force: bool) -> lis
         if row.link_status.get(platform) and not force:
             row.driver_status[platform] = "SKIP"
             row.driver_detail[platform] = f"link {platform.upper()}(v) already populated"
+            continue
+        if (platform in PLATFORMS_TAG_ALONG and not force
+                and ledger.is_scheduled(platform, row.day_title)):
+            at = ledger.recorded_at(platform, row.day_title) or "an earlier run"
+            row.driver_status[platform] = "SKIP"
+            row.driver_detail[platform] = (
+                f"{platform.upper()} already scheduled in a prior run "
+                f"(tag-along ledger, {at})"
+            )
+            logger.info(
+                "⏭️  %s: %s already scheduled on %s (tag-along ledger) — not re-posting.",
+                row.day_title, platform.upper(), at,
+            )
             continue
         eligible.append(VideoRow(
             page_id=row.page_id,
@@ -290,22 +310,27 @@ def _aggregate_row_status(state: _RowState, dry_run: bool) -> tuple[str, str]:
     return "FAIL", ", ".join(parts)
 
 
-def _maybe_untick_wip(notion, video_cols: dict, state: _RowState, dry_run: bool) -> tuple[str, str]:
+def _maybe_untick_wip(notion, video_cols: dict, state: _RowState, dry_run: bool,
+                      ledger: TagAlongLedger) -> tuple[str, str]:
     """Untick Work-in-Progress-Video iff every scheduled platform is OK AND
     link SB is populated.
 
     "OK" per platform is one of:
       * LIVE                          (just scheduled this run)
       * SKIP with link populated      (idempotent skip — already scheduled in a prior run)
+      * SKIP with a tag-along ledger entry (same, for platforms with no link column)
       * SKIP with platform out-of-scope (clip relation deliberately empty)
 
     SKIP via a ``--skip-<P>`` flag does NOT count — the platform genuinely
     hasn't been scheduled and WIP-Vd must stay checked so the user can
     re-run later. FAIL / LOGIN-REQUIRED also block the untick.
 
-    Note: tag-along platforms (no ``post_url_<P>`` column on the editorial
-    DB — currently TH) have no link-based idempotency marker. They are
-    only considered OK if the driver returned LIVE this run.
+    Tag-along platforms (no ``post_url_<P>`` column on the editorial DB —
+    currently TH) carry their idempotency marker off-column in the ledger
+    (issue #239). The ledger is consulted rather than the SKIP *reason*, so a
+    recovery run passing ``--skip-th`` to avoid re-posting still unticks when
+    a prior run genuinely scheduled TH — and still keeps WIP-Vd checked when
+    it did not.
 
     Returns ``(action, reason)`` so the end-of-run summary can name the
     WIP-Vd outcome per row (issue #37 AC). Actions:
@@ -323,6 +348,15 @@ def _maybe_untick_wip(notion, video_cols: dict, state: _RowState, dry_run: bool)
             continue
         if s == "SKIP" and state.link_status.get(p):
             continue  # idempotent skip
+        if (s == "SKIP" and p in PLATFORMS_TAG_ALONG
+                and ledger.is_scheduled(p, state.day_title)):
+            logger.info(
+                "🧾 %s: %s has no link column but the tag-along ledger records it "
+                "as scheduled on %s — counting it as done.",
+                state.day_title, p.upper(),
+                ledger.recorded_at(p, state.day_title) or "an earlier run",
+            )
+            continue  # idempotent skip, ledger-backed
         if s == "SKIP" and not state.in_scope.get(p):
             continue  # out of scope, user opted out
         logger.info(
@@ -395,7 +429,8 @@ def parse_args() -> argparse.Namespace:
     mode.add_argument("--live", action="store_true",
                       help="Actually schedule on every platform.")
     p.add_argument("--force", action="store_true",
-                   help="Schedule even if link <P>(v) is already populated.")
+                   help="Schedule even if already marked scheduled (link <P>(v) "
+                        "populated, or a tag-along ledger entry).")
     p.add_argument("--debug", action="store_true", help="Enable debug logging.")
     p.add_argument("--skip-li", action="store_true")
     p.add_argument("--skip-ig", action="store_true")
@@ -479,6 +514,9 @@ def main() -> tuple[int, list[dict]]:
     # Pre-compute eligibility per platform (so we don't waste a session if 0 rows).
     skip = {"li": args.skip_li, "ig": args.skip_ig, "tw": args.skip_tw, "th": args.skip_th}
 
+    # Off-column idempotency for platforms with no ``link <P>(v)`` column.
+    ledger = TagAlongLedger()
+
     # Dispatch per platform. Each driver opens its own browser session.
     for platform in PLATFORMS_SCHEDULED:
         if skip[platform]:
@@ -486,9 +524,22 @@ def main() -> tuple[int, list[dict]]:
             for state in rows:
                 state.driver_status[platform] = "SKIP"
                 state.driver_detail[platform] = "platform skipped via --skip-* flag"
+                if (platform in PLATFORMS_TAG_ALONG
+                        and ledger.is_scheduled(platform, state.day_title)):
+                    # Same SKIP status, materially different meaning: the flag
+                    # suppressed a run a *prior* run had already done. Say so
+                    # here — the untick decision below acts on it, and without
+                    # this line the log gives no hint why WIP-Vd cleared on a
+                    # platform that visibly did nothing this run.
+                    logger.info(
+                        "🧾 %s: %s was skipped by the flag, but the tag-along ledger "
+                        "records it as scheduled on %s.",
+                        state.day_title, platform.upper(),
+                        ledger.recorded_at(platform, state.day_title) or "an earlier run",
+                    )
             continue
 
-        eligible = _rows_for_platform(rows, platform, force=args.force)
+        eligible = _rows_for_platform(rows, platform, force=args.force, ledger=ledger)
         if not eligible:
             logger.info("ℹ️  %s: no eligible rows after filtering.", platform.upper())
             continue
@@ -511,21 +562,23 @@ def main() -> tuple[int, list[dict]]:
 
         _record_driver_results(rows, platform, driver_results)
 
-        # Write sentinel link <P>(v) for any LIVE row so re-runs skip it.
-        # Tag-along platforms (TH) have no link column by design — `_set_post_url`
-        # would log a misleading "Role 'post_url_th' not present" warning every
-        # successful TH run. Skip the write for them; the WIP-Vd untick logic
-        # already gates tag-along platforms on the LIVE driver status alone
-        # (see issue #29 + planning/videos/README.md).
+        # Mark every LIVE row as scheduled so re-runs skip it. Ordinary
+        # platforms get a sentinel in link <P>(v); tag-along platforms (TH)
+        # have no such column by design — `_set_post_url` would log a
+        # misleading "Role 'post_url_th' not present" warning on every
+        # successful TH run (issue #29) — so they get a ledger entry instead
+        # (issue #239).
         if not dry_run:
             for entry in driver_results:
                 if entry["status"] != "LIVE":
                     continue
-                if platform in PLATFORMS_TAG_ALONG:
-                    continue
                 # Find the matching state.
                 state = next((s for s in rows if s.day_title == entry["day"]), None)
                 if state is None:
+                    continue
+                if platform in PLATFORMS_TAG_ALONG:
+                    ledger.record(platform, state.day_title,
+                                  detail=entry.get("detail", ""))
                     continue
                 sentinel = _scheduled_sentinel(platform, state.day_title)
                 _set_post_url(notion, state.page_id, cfg["editorial_columns"],
@@ -552,7 +605,7 @@ def main() -> tuple[int, list[dict]]:
 
         status, detail = _aggregate_row_status(state, dry_run)
         wip_action, wip_reason = _maybe_untick_wip(
-            notion, cfg["editorial_columns"], state, dry_run,
+            notion, cfg["editorial_columns"], state, dry_run, ledger,
         )
         summary_rows.append({
             "day": state.day_title,

--- a/planning/videos/videos_ledger.py
+++ b/planning/videos/videos_ledger.py
@@ -1,0 +1,147 @@
+"""Off-column idempotency marker for tag-along video platforms (issue #239).
+
+Every platform in ``PLATFORMS_SCHEDULED`` except Threads gets its idempotency
+for free: the orchestrator writes a sentinel into ``link <P>(v)`` after a LIVE
+run, and ``_rows_for_platform`` skips any platform whose link is populated.
+Threads is a *tag-along* — it deliberately has no ``clip TH(v)`` and no
+``link TH(v)`` column on the editorial DB (issue #29) — so there is nowhere to
+write that sentinel and TH re-runs on every invocation.
+
+That costs nothing on a clean run: all four platforms succeed, WIP-Vd is
+unticked, and there is never a second run. It bites on a *recovery* run, where
+one leg failed and the other three are already scheduled. Re-running to fix the
+failed leg re-posts to Threads, and the only way to avoid that — ``--skip-th``
+— leaves WIP-Vd checked forever, because a flag-skip is deliberately not
+accepted as success. Both outcomes are bad and there is no third option.
+
+This module closes that gap with a small JSON file under ``results/videos/``
+(gitignored) keyed by platform and day title. It is a *cache of what we already
+did*, never a source of truth about Notion. The failure directions are
+deliberately asymmetric:
+
+* A **missing or unreadable** ledger reads as "nothing has been scheduled", so
+  the platform runs — exactly today's behaviour. Losing the file costs a
+  possible duplicate on a recovery run, which is where we already are.
+* A **failed write** is logged loudly but never raises: the row genuinely is
+  scheduled, and blocking the run over a bookkeeping miss would be worse than
+  the missing entry.
+
+Concurrency: ``record`` re-reads the file and merges before writing, and
+publishes via ``os.replace`` so a reader never observes a half-written file. A
+videos run spans several minutes across four browser sessions, which is long
+enough for a second invocation to overlap.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("videos_schedule")
+
+DEFAULT_LEDGER_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / "results" / "videos" / "tag_along_scheduled.json"
+)
+LEDGER_VERSION = 1
+
+
+class TagAlongLedger:
+    """Records that a tag-along platform already scheduled a given day's clip.
+
+    Construct once per orchestrator run and thread it through the decision
+    helpers, so the whole run sees one consistent view and the tests need no
+    filesystem patching.
+    """
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path: Path = Path(path) if path is not None else DEFAULT_LEDGER_PATH
+        self._data: dict = self._read()
+
+    # ---------- reads ----------
+
+    def _read(self) -> dict:
+        """Return the on-disk ledger, or an empty one if it can't be read.
+
+        A missing file is the ordinary first-run case and is silent. Anything
+        else means we lost information we used to have, so it is logged at
+        error level — but it still degrades to "nothing scheduled" rather than
+        aborting the run.
+        """
+        if not self.path.exists():
+            return {"version": LEDGER_VERSION, "scheduled": {}}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as err:
+            logger.error(
+                "❌ Tag-along ledger at %s is unreadable (%s) — treating every "
+                "platform as unscheduled. A recovery run may re-post.",
+                self.path, err,
+            )
+            return {"version": LEDGER_VERSION, "scheduled": {}}
+        if not isinstance(raw, dict) or not isinstance(raw.get("scheduled"), dict):
+            logger.error(
+                "❌ Tag-along ledger at %s has an unexpected shape — treating "
+                "every platform as unscheduled. A recovery run may re-post.",
+                self.path,
+            )
+            return {"version": LEDGER_VERSION, "scheduled": {}}
+        return raw
+
+    def is_scheduled(self, platform: str, day_title: str) -> bool:
+        """True iff a prior run recorded ``platform`` as LIVE for ``day_title``."""
+        return day_title in self._data.get("scheduled", {}).get(platform, {})
+
+    def recorded_at(self, platform: str, day_title: str) -> Optional[str]:
+        """ISO timestamp of the recorded run, or None if there is no entry."""
+        entry = self._data.get("scheduled", {}).get(platform, {}).get(day_title)
+        return entry.get("recorded_at") if isinstance(entry, dict) else None
+
+    # ---------- writes ----------
+
+    def record(self, platform: str, day_title: str, *, detail: str = "") -> bool:
+        """Record a LIVE tag-along schedule. Returns False if the write failed.
+
+        Never raises: the post is already live by the time this is called, so a
+        bookkeeping failure must not take the run down with it.
+        """
+        entry = {
+            "recorded_at": datetime.now().astimezone().isoformat(timespec="seconds"),
+            "detail": detail,
+        }
+        # Merge onto whatever is on disk now, not onto the snapshot taken at
+        # construction — a concurrent run may have recorded another day since.
+        merged = self._read()
+        merged.setdefault("scheduled", {}).setdefault(platform, {})[day_title] = entry
+        merged["version"] = LEDGER_VERSION
+        try:
+            self._write(merged)
+        except OSError as err:
+            logger.warning(
+                "⚠️ %s: %s scheduled but could not record it in the tag-along "
+                "ledger at %s: %s. A later re-run may schedule it again.",
+                day_title, platform.upper(), self.path, err,
+            )
+            return False
+        self._data = merged
+        logger.debug("🧾 %s: recorded %s in the tag-along ledger.", day_title, platform.upper())
+        return True
+
+    def _write(self, data: dict) -> None:
+        """Publish the ledger atomically so a reader never sees a partial file.
+
+        The temp file is per-process: two runs sharing one temp name could
+        interleave their writes and publish a corrupt file, which would defeat
+        the point of staging it at all.
+        """
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(f"{self.path.suffix}.{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+
+__all__ = ["DEFAULT_LEDGER_PATH", "LEDGER_VERSION", "TagAlongLedger"]

--- a/tests/test_videos_th_ledger.py
+++ b/tests/test_videos_th_ledger.py
@@ -1,0 +1,228 @@
+"""The tag-along idempotency ledger (issue #239).
+
+Threads is the one scheduled video platform with no ``link TH(v)`` column, so
+the sentinel every other platform uses for idempotency has nowhere to live and
+TH re-ran on every invocation. On a clean run that never showed, because the
+row's WIP-Vd was unticked the moment all four platforms succeeded. On a
+*recovery* run it left no good option: re-running to fix a failed leg re-posted
+the Threads video, and ``--skip-th`` avoided that only by leaving WIP-Vd
+checked forever.
+
+These tests pin the three behaviours that close the gap, and — more importantly
+— the one that must NOT change: a TH leg with no ledger entry still runs. The
+failure direction matters here. A double post to a live account is strictly
+worse than a stale checkbox, so every "did this already happen?" question must
+answer "no" when it cannot tell.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from planning.videos import schedule_videos_posts as svp  # noqa: E402
+from planning.videos.videos_ledger import TagAlongLedger  # noqa: E402
+
+
+class _LedgerTestCase(unittest.TestCase):
+    """Every ledger lives in its own temp dir — never the real results/videos/."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.path = Path(self._tmp.name) / "videos" / "tag_along_scheduled.json"
+
+    def ledger(self) -> TagAlongLedger:
+        return TagAlongLedger(self.path)
+
+
+class LedgerStorageTests(_LedgerTestCase):
+
+    def test_absent_ledger_reads_as_nothing_scheduled(self):
+        """The first-ever run must behave exactly as it does today."""
+        self.assertFalse(self.path.exists())
+        self.assertFalse(self.ledger().is_scheduled("th", "20260825"))
+
+    def test_record_then_read_back_in_a_fresh_process(self):
+        self.assertTrue(self.ledger().record("th", "20260825", detail="TH:LIVE"))
+        fresh = self.ledger()  # a separate instance == a separate run
+        self.assertTrue(fresh.is_scheduled("th", "20260825"))
+        self.assertIsNotNone(fresh.recorded_at("th", "20260825"))
+
+    def test_record_is_scoped_to_its_platform_and_day(self):
+        self.ledger().record("th", "20260825")
+        fresh = self.ledger()
+        self.assertFalse(fresh.is_scheduled("th", "20260901"))
+        self.assertFalse(fresh.is_scheduled("ig", "20260825"))
+
+    def test_recording_a_second_day_keeps_the_first(self):
+        self.ledger().record("th", "20260825")
+        self.ledger().record("th", "20260901")
+        fresh = self.ledger()
+        self.assertTrue(fresh.is_scheduled("th", "20260825"))
+        self.assertTrue(fresh.is_scheduled("th", "20260901"))
+
+    def test_a_concurrent_writer_is_not_clobbered(self):
+        """``record`` merges onto disk, not onto the snapshot it was built with.
+
+        A videos run spans minutes across four browser sessions — long enough
+        for a second invocation to write between construction and record.
+        """
+        stale = self.ledger()               # snapshot taken now, before...
+        self.ledger().record("th", "20260901")   # ...another run records
+        stale.record("th", "20260825")
+        fresh = self.ledger()
+        self.assertTrue(fresh.is_scheduled("th", "20260901"),
+                        "the concurrent run's entry was clobbered")
+        self.assertTrue(fresh.is_scheduled("th", "20260825"))
+
+    def test_a_corrupt_ledger_degrades_to_nothing_scheduled(self):
+        """Never raise: an unreadable ledger falls back to today's behaviour."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text("{not json at all", encoding="utf-8")
+        with self.assertLogs("videos_schedule", level="ERROR"):
+            self.assertFalse(self.ledger().is_scheduled("th", "20260825"))
+
+    def test_a_ledger_of_the_wrong_shape_degrades_the_same_way(self):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+        with self.assertLogs("videos_schedule", level="ERROR"):
+            self.assertFalse(self.ledger().is_scheduled("th", "20260825"))
+
+    def test_a_failed_write_is_reported_not_raised(self):
+        """The post is already live by then — a bookkeeping miss must not abort."""
+        led = self.ledger()
+        with mock.patch.object(TagAlongLedger, "_write", side_effect=OSError("disk full")):
+            with self.assertLogs("videos_schedule", level="WARNING"):
+                self.assertFalse(led.record("th", "20260825"))
+
+
+def _row(day_title: str = "20260825", *, th_in_scope: bool = True) -> svp._RowState:
+    """A minimal _RowState shaped like a real video row on the TH leg."""
+    state = svp._RowState(
+        page_id="page-" + day_title,
+        day=date(int(day_title[:4]), int(day_title[4:6]), int(day_title[6:])),
+        payload=None,
+        link_status={"li": None, "ig": None, "tw": None, "th": None, "sb": None},
+        in_scope={"li": True, "ig": True, "tw": True, "th": th_in_scope},
+    )
+    return state
+
+
+class EligibilityTests(_LedgerTestCase):
+    """`_rows_for_platform` — does the TH leg run?"""
+
+    def test_th_runs_when_the_ledger_has_no_entry(self):
+        """The behaviour that must NOT change: unknown means run it."""
+        row = _row()
+        eligible = svp._rows_for_platform([row], "th", force=False, ledger=self.ledger())
+        self.assertEqual(len(eligible), 1)
+        self.assertNotIn("th", row.driver_status)
+
+    def test_th_is_skipped_once_the_ledger_records_it(self):
+        self.ledger().record("th", "20260825", detail="TH:LIVE")
+        row = _row()
+        eligible = svp._rows_for_platform([row], "th", force=False, ledger=self.ledger())
+        self.assertEqual(eligible, [])
+        self.assertEqual(row.driver_status["th"], "SKIP")
+        self.assertIn("tag-along ledger", row.driver_detail["th"])
+
+    def test_force_reschedules_a_recorded_row(self):
+        """The deliberate escape hatch — the only way back to a re-post."""
+        self.ledger().record("th", "20260825")
+        row = _row()
+        eligible = svp._rows_for_platform([row], "th", force=True, ledger=self.ledger())
+        self.assertEqual(len(eligible), 1)
+
+    def test_a_recorded_day_does_not_skip_a_different_day(self):
+        self.ledger().record("th", "20260825")
+        row = _row("20260901")
+        eligible = svp._rows_for_platform([row], "th", force=False, ledger=self.ledger())
+        self.assertEqual(len(eligible), 1)
+
+    def test_the_ledger_does_not_gate_a_platform_that_has_a_link_column(self):
+        """Only tag-along platforms consult it; LI/IG/TW keep their sentinel."""
+        self.ledger().record("li", "20260825")
+        row = _row()
+        eligible = svp._rows_for_platform([row], "li", force=False, ledger=self.ledger())
+        self.assertEqual(len(eligible), 1)
+
+
+class UntickDecisionTests(_LedgerTestCase):
+    """`_maybe_untick_wip` — does the row's WIP-Vd checkbox clear?"""
+
+    def _decide(self, state, ledger):
+        """Run the decision with the Notion write stubbed; returns the stub too."""
+        cols = {"wip_checkbox": "Work in Progress Video"}
+        with mock.patch.object(svp, "set_field") as set_field:
+            action, reason = svp._maybe_untick_wip(
+                mock.MagicMock(), cols, state, False, ledger,
+            )
+        return action, reason, set_field
+
+    def _completed_row(self, *, th_status: str, sb_link: str = "https://sb.example/x"):
+        state = _row()
+        state.link_status["sb"] = sb_link
+        for p in ("li", "ig", "tw"):
+            state.driver_status[p] = "LIVE"
+        state.driver_status["th"] = th_status
+        return state
+
+    def test_recovery_run_unticks_when_the_ledger_covers_the_skipped_th_leg(self):
+        """The whole point of #239: no re-post AND no stranded checkbox."""
+        self.ledger().record("th", "20260825", detail="TH:LIVE")
+        state = self._completed_row(th_status="SKIP")
+        action, reason, set_field = self._decide(state, self.ledger())
+        self.assertEqual(action, "unticked", reason)
+        self.assertEqual(set_field.call_args.args[3], False)  # checkbox cleared
+
+    def test_a_skipped_th_leg_with_no_ledger_entry_still_blocks_the_untick(self):
+        """The conservative direction — an unproven leg keeps WIP-Vd checked."""
+        state = self._completed_row(th_status="SKIP")
+        action, reason, set_field = self._decide(state, self.ledger())
+        self.assertEqual(action, "kept-checked")
+        self.assertIn("TH=SKIP", reason)
+
+    def test_a_live_th_leg_still_unticks_without_any_ledger_entry(self):
+        """Unchanged: a LIVE result this run was always sufficient."""
+        state = self._completed_row(th_status="LIVE")
+        action, reason, set_field = self._decide(state, self.ledger())
+        self.assertEqual(action, "unticked", reason)
+
+    def test_the_ledger_backed_untick_says_so_in_the_log(self):
+        """A platform that visibly did nothing this run must not untick silently."""
+        self.ledger().record("th", "20260825", detail="TH:LIVE")
+        state = self._completed_row(th_status="SKIP")
+        with self.assertLogs("videos_schedule", level="INFO") as logs:
+            self._decide(state, self.ledger())
+        self.assertTrue(any("tag-along ledger" in line for line in logs.output),
+                        f"no ledger breadcrumb in {logs.output}")
+
+    def test_a_failed_th_leg_is_never_rescued_by_a_ledger_entry(self):
+        """A stale entry must not paper over a leg that failed *this* run."""
+        self.ledger().record("th", "20260825")
+        state = self._completed_row(th_status="FAIL")
+        action, reason, set_field = self._decide(state, self.ledger())
+        self.assertEqual(action, "kept-checked")
+        self.assertIn("TH=FAIL", reason)
+
+    def test_the_ledger_does_not_rescue_a_skipped_platform_that_has_a_link_column(self):
+        self.ledger().record("li", "20260825")
+        state = self._completed_row(th_status="LIVE")
+        state.driver_status["li"] = "SKIP"      # skipped by flag, link empty
+        action, reason, set_field = self._decide(state, self.ledger())
+        self.assertEqual(action, "kept-checked")
+        self.assertIn("LI=SKIP", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Threads is the only *tag-along* video platform: it has no `clip TH(v)` and no `link TH(v)` column on the editorial DB, by design (#29). Every other platform gets its idempotency from a sentinel written into `link <P>(v)` after a LIVE run, which `_platforms_to_run` then skips on. With no column to write to, TH had no marker at all — so it re-ran on every single invocation.

That is invisible on a clean run, because the row's WIP-Vd is unticked the moment all four platforms succeed and there is never a second run. It bites on a **recovery** run, where one leg failed and the other three are already scheduled. Re-running to fix the failed leg re-posted the Threads video; the only way to avoid that — `--skip-th` — left WIP-Vd checked forever, since a flag-skip is deliberately not accepted as success. There was no third option, and `--force` made it worse rather than better.

This takes the issue's own preferred option 1: record TH completion off-column rather than touching the Notion schema.

- New `planning/videos/videos_ledger.py` — `TagAlongLedger`, backed by `results/videos/tag_along_scheduled.json` (gitignored), keyed by platform and day title.
- A LIVE tag-along result records there instead of hitting `_set_post_url`, which would log a misleading `"Role 'post_url_th' not present"` warning (the reason #29 skipped the write in the first place).
- Both `_rows_for_platform` and `_maybe_untick_wip` consult it. The untick decision keys off **what actually happened** rather than off the SKIP *reason*, which is what lets `--skip-th` untick when a prior run genuinely scheduled TH, and still keep the box checked when it did not.
- `--force` bypasses the ledger, and stays the deliberate way to re-post.

**Failure directions are asymmetric on purpose.** A double post to a live account is strictly worse than a stale checkbox, so every "did this already happen?" question answers *no* when it cannot tell:

- A missing, unreadable, or wrong-shaped ledger reads as "nothing scheduled" — so the leg runs, exactly the pre-ledger behaviour. Corruption is logged at ERROR; only a genuinely absent file is silent.
- A failed write is logged loudly but never raises. The post is already live by the time `record` is called; aborting the run over bookkeeping would be worse than the missing entry.
- An entry can only be created for a non-dry-run `LIVE` driver result. No path fabricates one, and a `FAIL` leg is never rescued by a stale entry.

Writes are atomic (temp file + `os.replace`, temp name per-PID), and `record` merges from disk rather than from its construction-time snapshot, so a concurrent run's entry is not clobbered.

## Validation

**Reproduction proof** — the same scenario (the real partially-failed row: LI failed, IG/TW/TH live) driven against `origin/main` and against this branch in one script:

```
PRE-FIX (origin/main)
  TH leg would re-post to Threads : True
  WIP-Vd outcome with --skip-th   : kept-checked (TH=SKIP (not LIVE / idempotent-skip / out-of-scope))

POST-FIX (this branch)
  TH leg would re-post to Threads : False
  WIP-Vd outcome with --skip-th   : unticked (all platforms OK and link SB(v) populated)

  AC2 — a TH leg that never ran still runs:
    eligible rows with an empty ledger = 1 (expect 1)
```

**Unit + integration** — `python -m unittest discover tests` → `Ran 209 tests, OK (skipped=1)`. Up from 190 on `main`; 19 new in `tests/test_videos_th_ledger.py`. The single skip is the pre-existing `TRIAGE_DB_INTEGRATION` probe, unrelated to this area.

**Byte-compile** — `py_compile` clean on all three changed Python files. No ruff/flake8 config exists in this repo, so there is no lint step to run.

**Behavioural, real CLI** — `python -m planning.videos.schedule_videos_posts --all-wip --dry-run --skip-li --skip-ig --skip-tw --skip-th` against live Notion, read-only, no browser sessions. Exit 0. With a seeded ledger entry the run emits the new breadcrumb:

```
⏭️  Skipping TH (per --skip-th).
🧾 <day>: TH was skipped by the flag, but the tag-along ledger records it as scheduled on <ts>.
```

**Design-conformance** — `ux_surface.py check` → `SPEC_APPLIES=no`, `TOUCHED=no`. Nothing to check; this touches no UI surface.

**Independent cold review** — a fresh agent with no context on the build fetched #239's acceptance criteria itself, read the diff, and re-ran the gate independently rather than trusting this report. Verdict `pass: true`. It traced the safety property directly and confirmed the change adds only new skip conditions for TH and removes none, so it cannot make a double-post more likely. Its one actionable nit — two concurrent runs sharing a single `.tmp` filename, which would have falsified the atomicity claim in the module docstring — is fixed in this branch.

**CI** — this repo has no `.github/` and no workflows, so there is nothing to await.

## Notes

- The ledger starts empty after merge, so it only begins helping from the next successful TH run. A row already scheduled before this landed still needs its WIP-Vd cleared by hand, or a one-line seed of its ledger entry.
- The ledger never prunes. One key per day title, forever — negligible in practice, and noted rather than solved.

Closes #239
