### PR TITLE
feat: schedule future newsletter editions in Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Four pipelines, one repo:
   and the daily Substack run can consume them.
 - **Newsletter** (`newsletter/`, `newsletter_pipeline.py`) — the weekly
   newsletter workflow, split into independent non-interactive steps
-  (`bootstrap` / `archive` / `normalize` / `build`, plus `create` and
-  `all` composites) so each runs on its own from the app or a console.
-  **Bootstrap** launches the dedicated newsletter Chrome on `:9222`
+  (`schedule` / `bootstrap` / `archive` / `normalize` / `build`, plus
+  `create` and `all` composites) so each runs on its own from the app or
+  a console. **Schedule** tops the buffer of *future* newsletter rows in
+  Notion back up to eight, continuing the number sequence from the
+  highest existing edition and the weekly cadence from the latest date —
+  without those rows **Archive** has nowhere to file an article and stops
+  (issue #230). **Bootstrap** launches the dedicated newsletter Chrome on `:9222`
   without touching the everyday browser (targeted, idempotent — issue
   #59). **Archive** walks the open article tabs in that CDP-attached
   Chrome into Notion (readability-lxml extraction → Gemini-Lite topic +
@@ -126,7 +130,7 @@ content-management/                   # repo root
 │   └── screenshots/                  # manifest.json + generated per-tab screenshots (tracked)
 ├── planning_pipeline.py              # orchestrator: LI → IG → TW → TH (--all-wip)
 ├── reporting_pipeline.py             # orchestrator: APIs → Supabase → Notion → Substack
-├── newsletter_pipeline.py            # orchestrator: bootstrap/archive/normalize/build subcommands
+├── newsletter_pipeline.py            # orchestrator: schedule/bootstrap/archive/normalize/build subcommands
 ├── launch_app.bat                    # Streamlit control panel launcher (Windows CMD)
 ├── launch_planning.bat               # planning launcher (Windows CMD)
 ├── launch_reporting.bat              # reporting launcher (Windows CMD)

--- a/app/tab_newsletter.py
+++ b/app/tab_newsletter.py
@@ -10,13 +10,22 @@ status work unchanged. The must-read picker reads the topics sidecar that
 ⑤ Substack draft (issue #184) is deliberately outside the ▶ combo — it writes
 to an external platform, so it stays an explicit, separately-clicked action. It
 creates a **private** draft and never publishes.
+
+⓪ Schedule editions (issue #230) sits before ① because ② Archive can only file
+an article against a *future* newsletter row: with the buffer drained it aborts
+outright. The block reads the buffer state for its caption through a cached
+helper so a Streamlit rerun doesn't hit the Notion API on every keystroke.
 """
 
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
 import streamlit as st
+
+if TYPE_CHECKING:  # annotation only — the real import stays lazy (app startup)
+    from newsletter.schedule_editions import BufferState
 
 from app.process_runner import (
     VENV_PY,
@@ -28,12 +37,17 @@ from app.process_runner import (
 
 PIPELINE_NAME = "newsletter"
 
+#: Tracks the pipeline slot's running state across reruns so the cached buffer
+#: read can be dropped the moment a run finishes (see :func:`_sync_buffer_cache`).
+_WAS_RUNNING_KEY = "newsletter-schedule-was-running"
+
 
 def run() -> None:
     st.subheader("📰 newsletter — weekly archive + build")
     st.caption(
-        "① Bootstrap Chrome → open your article tabs → ② Archive into Notion → "
-        "③ Normalize titles + URLs → ④ Build HTML. Run any step alone, or ▶ for ②③④. "
+        "⓪ Keep future editions stocked in Notion → ① Bootstrap Chrome → open your "
+        "article tabs → ② Archive into Notion → ③ Normalize titles + URLs → "
+        "④ Build HTML. Run any step alone, or ▶ for ②③④. "
         "⑤ pushes the same lists into a private Substack draft."
     )
     st.info(
@@ -66,6 +80,10 @@ def run() -> None:
 
     base = [str(VENV_PY), "newsletter_pipeline.py"]
     dbg = ["--debug"] if debug else []
+
+    _sync_buffer_cache(running)
+    _render_schedule_editions(running, base, dbg)
+    st.divider()
 
     # ── ① bootstrap ──────────────────────────────────────────────────
     st.button(
@@ -128,6 +146,85 @@ def run() -> None:
 
     must_read = _render_must_read_picker(num)
     _render_substack_draft(num, has_num, running, base, dbg, must_read)
+
+
+@st.cache_data(ttl=120, show_spinner="⏬ reading the newsletter buffer from Notion…")
+def _read_buffer_state() -> tuple[BufferState | None, str]:
+    """Cached Notion read behind the ⓪ caption: ``(state, error)``.
+
+    Short TTL rather than no cache at all — every widget interaction in this tab
+    triggers a rerun, and an uncached read would hit the Notion API each time.
+    The spinner is not decoration: the uncached read pages the whole newsletter
+    DB and takes tens of seconds, and without it the ⓪ block renders as a bare
+    heading over empty space for that whole time.
+    """
+    from newsletter.schedule_editions import read_buffer_state
+
+    try:
+        return read_buffer_state(), ""
+    except Exception as exc:  # noqa: BLE001 — surfaced to the user, never raised
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _sync_buffer_cache(running: bool) -> None:
+    """Drop the cached buffer read when the pipeline slot goes running → idle.
+
+    The log panel reruns roughly once a second while a step is in flight, so
+    this transition is observed and the caption refreshes on its own once the
+    ⓪ run finishes — no manual refresh button needed.
+    """
+    if st.session_state.get(_WAS_RUNNING_KEY, False) and not running:
+        _read_buffer_state.clear()
+    st.session_state[_WAS_RUNNING_KEY] = running
+
+
+def _render_schedule_editions(running: bool, base: list[str], dbg: list[str]) -> None:
+    """⓪ Top the buffer of future newsletter rows in Notion back up.
+
+    The count is only a *default* taken from the cached read — the subprocess
+    re-reads the maximum edition number at write time, so a stale caption can
+    never produce a duplicate number.
+    """
+    from newsletter.schedule_editions import DEFAULT_TARGET
+
+    st.markdown("**⓪ Schedule future editions**")
+
+    state, error = _read_buffer_state()
+    # 0 is a real, reachable value: it is what a full buffer asks for, and it
+    # disables the button rather than creating a ninth edition nobody wanted.
+    default_count = state.shortfall(DEFAULT_TARGET) if state is not None else 1
+
+    with st.container(horizontal=True, gap="small"):
+        count = int(st.number_input(
+            "editions to create",
+            min_value=0, max_value=52, value=default_count, step=1,
+            key="newsletter-schedule-count",
+            help=f"Defaults to the shortfall against a {DEFAULT_TARGET}-edition "
+                 f"buffer. 0 means there is nothing to do.",
+        ))
+        st.button(
+            "⓪ Schedule editions",
+            key="newsletter-schedule",
+            disabled=running or count == 0,
+            on_click=start_pipeline,
+            args=(PIPELINE_NAME, base + ["schedule", "--count", str(count)] + dbg),
+            width="stretch",
+        )
+
+    if error:
+        st.warning(f"⚠️ couldn't read the newsletter buffer from Notion — {error}")
+        st.caption("→ the step still works; it does its own read. The count above is a guess.")
+    elif state is None:
+        st.warning("⚠️ no newsletter edition in Notion carries both a number and a Date — "
+                   "the sequence has nothing to continue from.")
+    else:
+        shortfall = state.shortfall(DEFAULT_TARGET)
+        tail = f"{shortfall} to add" if shortfall else f"buffer full (target {DEFAULT_TARGET})"
+        st.caption(
+            f"latest {state.latest_label} · {state.latest_date.isoformat()} · "
+            f"{state.future_count} future edition"
+            f"{'' if state.future_count == 1 else 's'} — {tail}"
+        )
 
 
 def _render_substack_draft(

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -18,7 +18,7 @@ flowchart TB
 
   RPIPE["reporting_pipeline.py"]
   PPIPE["planning_pipeline.py --all-wip"]
-  NPIPE["newsletter_pipeline.py\nbootstrap / archive / normalize / build /\nsubstack-draft"]
+  NPIPE["newsletter_pipeline.py\nschedule / bootstrap / archive / normalize / build /\nsubstack-draft"]
   APP["app/app.py — Streamlit control panel\ntab_reporting · tab_planning · tab_newsletter ·\ntab_triage · tab_editorial · tab_engagement"]
   AUTOHEAL["app/autoheal_console.py"]
 
@@ -69,6 +69,7 @@ flowchart TB
   RESULTSPLAN -.->|"selector-drift failure"| AUTOHEALSKILL
 
   subgraph newsletter_mod["newsletter/ — weekly issue pipeline"]
+    NSCHED["schedule_editions.py\n(top up future edition rows)"]
     NBOOT["bootstrap_chrome.py\n(dedicated Chrome, CDP :9222)"]
     NARCHIVE["chrome_tabs + extractor +\nauthor_resolver + summarizer/llm"]
     NNORM["normalize_names + normalize_url"]
@@ -79,6 +80,9 @@ flowchart TB
     NTRIAGERUN["triage/run.py — weekly engine\nfetch + score (2 stages) + rank + report\n+ feedback.py (decisions → sender tiers)"]
     NTRIAGEREVIEW["triage/db.py + review.py + lessons.py\nstore, editable review, distilled criteria notes\n(lessons.json → prompt brief)"]
   end
+  NPIPE --> NSCHED
+  NSCHED -->|"max number + max Date →\ncreate N{NNN} rows, weekly cadence"| NOTION
+  NSCHED -.->|"future rows archive can target"| NARCHIVE
   NPIPE --> NBOOT --> NARCHIVE --> NNORM --> NBUILD
   NTRIAGE -->|"gmail.readonly via vendored\ngmail_readonly/ + google_oauth_common/"| GMAILAPI[("Gmail API\nlabel 'newsletters'")]
   NTRIAGE -->|"positives: articles + editions"| NOTION

--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -12,6 +12,9 @@ ferraroroberto/content-management#18 (full pipeline + monorepo migration).
 
 ```mermaid
 flowchart LR
+    subgraph S0[0. Schedule]
+        Z[schedule_editions.py<br/>read every edition row<br/>-> max number + max date<br/>-> create the missing<br/>future rows, weekly cadence]
+    end
     subgraph S1[1. Bootstrap]
         A[bootstrap_chrome.py<br/>targeted: reuse :9222 if up,<br/>else kill only the newsletter-profile<br/>Chrome and relaunch on :9222]
     end
@@ -35,7 +38,7 @@ flowchart LR
         O[same grouped articles] --> P[native HTTP API<br/>cookie auth]
         P --> Q[private draft edition<br/>never published]
     end
-    S1 --> S2 --> S3 --> S4
+    S0 --> S1 --> S2 --> S3 --> S4
     S4 -.-> S5
 ```
 
@@ -111,6 +114,7 @@ The pipeline is split into independent, non-interactive subcommands (issue #59)
 
 | Command | What it does |
 |---|---|
+| `newsletter_pipeline.py schedule [--count N] [--target 8] [--dry-run] [--debug]` | Create the missing **future** newsletter rows in Notion so `archive` always has somewhere to file an article. |
 | `newsletter_pipeline.py bootstrap` | Ensure Chrome is up on `:9222` (targeted — never kills the everyday browser). |
 | `newsletter_pipeline.py archive [--debug]` | Archive every eligible open tab → Notion, write + close. |
 | `newsletter_pipeline.py normalize [--days 14] [--debug]` | normalize_names + normalize_url. |
@@ -137,6 +141,32 @@ Lower-level module entry points:
 Add `--debug` to any of the above for verbose logs. All runs append to
 `logs/newsletter_archive.log` (archive entry points) or stdout (the
 others).
+
+## Scheduling future editions (issue #230)
+
+`archive` files each article against the first **future** newsletter row that
+still has room for its topic (`notion_io.pick_newsletter`, which filters
+`Date >= today`). When the buffer of future rows runs dry it aborts outright:
+
+```
+❌ No future newsletter has room for topic '<topic>' — stopping
+```
+
+`schedule` tops that buffer back up. It reads every row of the newsletter DB
+once, takes the highest `number` and the highest `Date` **independently**, and
+creates the rows that follow:
+
+```powershell
+& .\.venv\Scripts\python.exe newsletter_pipeline.py schedule --dry-run   # plan only, writes nothing
+& .\.venv\Scripts\python.exe newsletter_pipeline.py schedule             # top up to 8 future editions
+& .\.venv\Scripts\python.exe newsletter_pipeline.py schedule --count 4   # create exactly 4
+```
+
+- **Numbering** continues from the highest edition anywhere in the table, zero-padded to three digits (`N234`) — `build_newsletter.normalize_newsletter_number` rejects anything else, so an unpadded number would only fail later, at ④ Build. Taking the max number separately from the max date is what makes a duplicate impossible even if the two ever disagree.
+- **Dating** carries the weekly cadence off the latest row, so the Saturday alignment is inherited rather than recomputed.
+- **Idempotent.** With the buffer already at target it creates nothing, says so, and exits 0.
+- New rows carry `number` and `Date` only — every other column on that DB is a rollup over the related `articles` DB, so they fill themselves in as articles are archived.
+- The maximum is re-read inside the step, at write time. The ⓪ block in the app's 📰 tab only *pre-fills* the count from a cached read, so a stale caption can never produce a duplicate number.
 
 ## Notion field map
 
@@ -220,6 +250,7 @@ byline. The fallback exists so the pipeline never invents people.
 - `cache.py` — in-memory caches + URL canonicaliser + fuzzy name match.
 - `notion_io.py` — DB read/write helpers with retry-with-backoff.
 - `pipeline.py` — archive batch orchestrator.
+- `schedule_editions.py` — future-edition scheduler: buffer state + the pure number/date sequence generator.
 - `dry_run.py` — single-tab entrypoint.
 - `normalize_names.py` — article title sentence-case rewriter.
 - `normalize_names_words.json` — sidecar: proper-name whitelist + special

--- a/newsletter/notion_io.py
+++ b/newsletter/notion_io.py
@@ -165,8 +165,44 @@ def pick_newsletter(
     return None
 
 
+def iter_newsletter_editions(
+    client: Client, *, newsletter_db_id: str,
+) -> Iterator[Dict[str, Any]]:
+    """Yield every row of the newsletter DB, oldest first.
+
+    Used by the ``schedule`` step, which needs the whole table rather than the
+    first row that has room: the next number must continue from the highest
+    edition that exists *anywhere*, not just the newest-dated one.
+    """
+    sorts = [{"property": "Date", "direction": "ascending"}]
+    return _iter_database(client, newsletter_db_id, sorts=sorts)
+
+
 # ---------------------------------------------------------------------------
 # writes
+
+
+def create_newsletter_edition(
+    client: Client, *, newsletter_db_id: str, number: str, edition_date: date,
+) -> Dict[str, Any]:
+    """Create an empty future edition row — ``number`` (title) + ``Date`` only.
+
+    Every other column on the newsletter DB is a rollup over the related
+    ``articles`` DB, so a fresh row fills itself in as articles are archived
+    against it.
+    """
+    page = _retry(
+        lambda: client.pages.create(
+            parent={"database_id": newsletter_db_id},
+            properties={
+                "number": {"title": [{"type": "text", "text": {"content": number}}]},
+                "Date": {"date": {"start": edition_date.isoformat()}},
+            },
+        ),
+        label=f"create newsletter {number}",
+    )
+    logger.info("➕ Created newsletter edition: %s (%s)", number, edition_date.isoformat())
+    return page
 
 
 def create_connection(client: Client, *, connections_db_id: str, name: str,

--- a/newsletter/schedule_editions.py
+++ b/newsletter/schedule_editions.py
@@ -43,7 +43,7 @@ _NUMBER_RE = re.compile(r"^N?(\d+)$", re.IGNORECASE)
 # pure helpers
 
 
-def parse_edition_number(raw: str) -> Optional[int]:
+def parse_edition_number(raw: Optional[str]) -> Optional[int]:
     """``"N233"`` / ``"233"`` -> ``233``; anything else -> ``None``.
 
     Deliberately laxer than ``build_newsletter.normalize_newsletter_number``

--- a/newsletter/schedule_editions.py
+++ b/newsletter/schedule_editions.py
@@ -1,0 +1,228 @@
+"""Top up the buffer of future newsletter editions in Notion (issue #230).
+
+``newsletter/pipeline.py``'s archive step targets the first *future* edition
+row that still has room for the article's topic (``notion_io.pick_newsletter``,
+which filters ``Date >= today``). When the buffer of future rows runs dry the
+archive step stops outright::
+
+    ❌ No future newsletter has room for topic '<topic>' — stopping
+
+Creating those rows is pure arithmetic on the existing table — the next number
+continues the sequence, the next date is one cadence step on from the latest —
+so this module does it. It reads the whole newsletter DB once, derives the
+buffer state, and creates however many rows are missing.
+
+The sequence generator (:func:`plan_editions`) is deliberately pure: no Notion,
+no config, no clock. It is what ``tests/test_schedule_editions.py`` pins.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from config.loader import load_full_config
+from config.logger_config import setup_logger
+from newsletter import notion_io
+
+logger = logging.getLogger("newsletter_archive.schedule_editions")
+
+#: How many future editions the buffer aims to hold (~two months of runway).
+DEFAULT_TARGET = 8
+
+#: Weeks are the newsletter's cadence; every existing row is a Saturday.
+CADENCE_DAYS = 7
+
+_NUMBER_RE = re.compile(r"^N?(\d+)$", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+
+
+def parse_edition_number(raw: str) -> Optional[int]:
+    """``"N233"`` / ``"233"`` -> ``233``; anything else -> ``None``.
+
+    Deliberately laxer than ``build_newsletter.normalize_newsletter_number``
+    (which insists on exactly three digits) because this one *reads* whatever
+    Notion holds. Formatting on the way back out is the strict side.
+    """
+    match = _NUMBER_RE.match((raw or "").strip())
+    return int(match.group(1)) if match else None
+
+
+def format_edition_number(value: int) -> str:
+    """``233`` -> ``"N233"``, zero-padded to three digits.
+
+    The padding is load-bearing: ``normalize_newsletter_number``
+    (``newsletter/build_newsletter.py``) rejects anything that isn't exactly
+    three digits, so an unpadded ``N34`` would break ④ Build downstream.
+    """
+    return f"N{value:03d}"
+
+
+def plan_editions(
+    *, latest_number: int, latest_date: date, count: int,
+    cadence_days: int = CADENCE_DAYS,
+) -> List[Tuple[str, date]]:
+    """The ``count`` editions that follow ``latest_number`` / ``latest_date``.
+
+    Returns ``[(number, date), …]`` in ascending order, where the *k*-th entry
+    (1-based) is ``N{latest_number + k}`` dated ``latest_date + k·cadence``.
+    Carrying the cadence off the latest row inherits its weekday rather than
+    recomputing it, so the Saturday alignment holds without a calendar rule.
+
+    ``count <= 0`` is a legitimate no-op and returns ``[]``.
+    """
+    if count <= 0:
+        return []
+    return [
+        (format_edition_number(latest_number + k),
+         latest_date + timedelta(days=cadence_days * k))
+        for k in range(1, count + 1)
+    ]
+
+
+@dataclass(frozen=True)
+class BufferState:
+    """What the newsletter DB currently holds, as the scheduler sees it."""
+
+    latest_number: int
+    latest_date: date
+    future_count: int
+    total: int
+
+    @property
+    def latest_label(self) -> str:
+        return format_edition_number(self.latest_number)
+
+    def shortfall(self, target: int = DEFAULT_TARGET) -> int:
+        return max(0, target - self.future_count)
+
+
+def summarize_editions(
+    rows: Iterable[Dict[str, Any]], *, today: date,
+) -> Optional[BufferState]:
+    """Fold raw Notion rows into a :class:`BufferState`.
+
+    Takes the highest *number* and the highest *date* independently rather than
+    reading both off one row: that is what makes a duplicate number impossible
+    even if the table's numbering and dating ever disagree.
+
+    Returns ``None`` when no row carries both a parsable number and a date —
+    there is no sequence to continue from, and inventing one is the caller's
+    problem to report, not this function's to guess.
+    """
+    numbers: List[int] = []
+    dates: List[date] = []
+    future = 0
+    total = 0
+    for row in rows:
+        number = parse_edition_number(notion_io._read_title(row, "number"))  # noqa: SLF001
+        raw_date = (row.get("properties", {}).get("Date", {}).get("date") or {}).get("start")
+        parsed: Optional[date] = None
+        if raw_date:
+            try:
+                # Notion dates may carry a time/offset; the day is all we use.
+                parsed = date.fromisoformat(raw_date[:10])
+            except ValueError:
+                logger.warning("⚠️ Unparsable Date on edition %s: %r", number, raw_date)
+        if number is None and parsed is None:
+            continue
+        total += 1
+        if number is not None:
+            numbers.append(number)
+        if parsed is not None:
+            dates.append(parsed)
+            if parsed >= today:
+                future += 1
+    if not numbers or not dates:
+        return None
+    return BufferState(
+        latest_number=max(numbers), latest_date=max(dates),
+        future_count=future, total=total,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notion-backed
+
+
+def read_buffer_state(
+    client: Any = None, *, newsletter_db_id: Optional[str] = None,
+    today: Optional[date] = None,
+) -> Optional[BufferState]:
+    """Read the live buffer state from Notion.
+
+    With no arguments it builds its own client from ``config.json``, so the
+    Streamlit tab can call it for the caption without duplicating the wiring.
+    """
+    if client is None or newsletter_db_id is None:
+        cfg = load_full_config()
+        archive_cfg = cfg["newsletter_archive"]
+        client = client or notion_io.init_client(cfg["notion"]["api_token"])
+        newsletter_db_id = newsletter_db_id or archive_cfg["newsletter_db_id"]
+    rows = notion_io.iter_newsletter_editions(client, newsletter_db_id=newsletter_db_id)
+    return summarize_editions(rows, today=today or date.today())
+
+
+def run(*, count: Optional[int] = None, target: int = DEFAULT_TARGET,
+        dry_run: bool = False, debug: bool = False) -> int:
+    """Create the missing future editions. Returns a process exit code.
+
+    ``count`` creates exactly that many; without it the buffer is topped up to
+    ``target``. The maximum is re-read here, at write time — never taken from
+    whatever the app's cached caption last showed — so two runs can't collide
+    on the same number.
+    """
+    setup_logger(
+        "newsletter_archive", file_logging=True,
+        level=logging.DEBUG if debug else logging.INFO,
+    )
+    cfg = load_full_config()
+    if "newsletter_archive" not in cfg:
+        logger.error("❌ config.json is missing the 'newsletter_archive' section")
+        return 1
+    newsletter_db_id = cfg["newsletter_archive"]["newsletter_db_id"]
+    client = notion_io.init_client(cfg["notion"]["api_token"])
+
+    logger.info("⏬ Reading newsletter editions from Notion…")
+    state = read_buffer_state(client, newsletter_db_id=newsletter_db_id)
+    if state is None:
+        logger.error("❌ No newsletter edition with both a number and a Date — "
+                     "nothing to continue the sequence from")
+        return 1
+
+    logger.info("📰 Latest %s (%s) · %d future edition(s) of %d total",
+                state.latest_label, state.latest_date.isoformat(),
+                state.future_count, state.total)
+
+    to_create = count if count is not None else state.shortfall(target)
+    if to_create <= 0:
+        logger.info("✅ Buffer already full — %d future edition(s) ≥ target %d; "
+                    "nothing to create", state.future_count, target)
+        return 0
+
+    plan = plan_editions(latest_number=state.latest_number,
+                         latest_date=state.latest_date, count=to_create)
+    verb = "Would create" if dry_run else "Creating"
+    logger.info("🗓️  %s %d edition(s):", verb, len(plan))
+    for number, edition_date in plan:
+        logger.info("   %s → %s (%s)", number, edition_date.isoformat(),
+                    edition_date.strftime("%A"))
+
+    if dry_run:
+        logger.info("🧪 [DRY-RUN] Nothing written to Notion")
+        return 0
+
+    for number, edition_date in plan:
+        notion_io.create_newsletter_edition(
+            client, newsletter_db_id=newsletter_db_id,
+            number=number, edition_date=edition_date,
+        )
+    logger.info("🎉 Created %d future edition(s) — buffer now %d",
+                len(plan), state.future_count + len(plan))
+    return 0

--- a/newsletter_pipeline.py
+++ b/newsletter_pipeline.py
@@ -8,6 +8,7 @@ Streamlit-only path.
 Subcommands::
 
     newsletter_pipeline.py bootstrap                         # ensure Chrome on :9222 (targeted)
+    newsletter_pipeline.py schedule  [--count N] [--target 8] [--dry-run] [--debug]
     newsletter_pipeline.py archive   [--debug]               # open tabs -> Notion
     newsletter_pipeline.py normalize [--days 14] [--debug]   # titles + URLs
     newsletter_pipeline.py build     --newsletter NNN [--debug] [--no-open]
@@ -19,6 +20,9 @@ Subcommands::
 
 * ``bootstrap`` launches the dedicated newsletter Chrome on :9222 **without**
   killing the everyday browser (see ``newsletter/bootstrap_chrome.py``).
+* ``schedule`` tops the buffer of future newsletter rows in Notion back up to
+  8, so ``archive`` always has a row to file articles against (see
+  ``newsletter/schedule_editions.py``). Not part of ``create`` / ``all``.
 * ``archive`` / ``normalize`` / ``build`` / ``create`` are all non-interactive.
 * ``create`` = archive -> normalize -> build (no must-read prompt), chained.
 * ``all`` is the one sanctioned interactive console flow: bootstrap -> a single
@@ -50,6 +54,7 @@ force_utf8_stdio()
 from newsletter import bootstrap_chrome  # noqa: E402
 from newsletter import build_newsletter, normalize_names, normalize_url  # noqa: E402
 from newsletter import pipeline as archive_pipeline  # noqa: E402
+from newsletter import schedule_editions  # noqa: E402
 from newsletter import substack_draft  # noqa: E402
 
 logger = logging.getLogger("newsletter_pipeline")
@@ -80,6 +85,13 @@ def _banner(title: str) -> None:
 def step_bootstrap() -> int:
     _banner("bootstrap Chrome on :9222 (targeted — everyday browser untouched)")
     return bootstrap_chrome.ensure_chrome()
+
+
+def step_schedule(*, count: int | None, target: int, dry_run: bool,
+                  debug: bool) -> int:
+    _banner("schedule future newsletter editions in Notion")
+    return schedule_editions.run(count=count, target=target,
+                                 dry_run=dry_run, debug=debug)
 
 
 def step_archive(debug: bool) -> int:
@@ -195,13 +207,25 @@ def _add_newsletter(p: argparse.ArgumentParser, *, required: bool) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Newsletter pipeline: bootstrap → archive → normalize → build."
+        description="Newsletter pipeline: schedule → bootstrap → archive → normalize → build."
     )
     parser.add_argument("--debug", action="store_true",
                         help="Verbose logs (also accepted per-subcommand)")
     sub = parser.add_subparsers(dest="cmd")
 
     sub.add_parser("bootstrap", help="Ensure Chrome is up on :9222 (targeted)")
+
+    p_sched = sub.add_parser(
+        "schedule", help="Create the missing future newsletter rows in Notion")
+    p_sched.add_argument("--count", type=int, default=None,
+                         help="Create exactly N editions (default: top the "
+                              "buffer up to --target)")
+    p_sched.add_argument("--target", type=int, default=schedule_editions.DEFAULT_TARGET,
+                         help="Desired number of future editions "
+                              f"(default {schedule_editions.DEFAULT_TARGET})")
+    p_sched.add_argument("--dry-run", action="store_true",
+                         help="Print the rows that would be created; write nothing")
+    p_sched.add_argument("--debug", action="store_true")
 
     p_arch = sub.add_parser("archive", help="Archive open Chrome tabs to Notion")
     p_arch.add_argument("--debug", action="store_true")
@@ -253,6 +277,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if cmd == "bootstrap":
         return step_bootstrap()
+    if cmd == "schedule":
+        return step_schedule(count=args.count, target=args.target,
+                             dry_run=args.dry_run, debug=debug)
     if cmd == "archive":
         return step_archive(debug=debug)
     if cmd == "normalize":

--- a/tests/test_schedule_editions.py
+++ b/tests/test_schedule_editions.py
@@ -1,0 +1,164 @@
+"""The future-edition scheduler's arithmetic must be exactly right (issue #230).
+
+``newsletter/schedule_editions.py`` creates the empty future rows that ②
+Archive files articles against. Two of its properties are load-bearing and
+neither is visible until something downstream breaks:
+
+* **The number never duplicates.** It continues from the highest edition that
+  exists *anywhere* in the table, not off whichever row happens to be newest —
+  so a table whose numbering and dating disagree still yields a fresh number.
+* **The number is zero-padded to three digits.** ``normalize_newsletter_number``
+  (``newsletter/build_newsletter.py``) rejects anything else, so an unpadded
+  ``N34`` would sail through the write and only fail later, at ④ Build.
+
+Everything pinned here is pure — no Notion, no network, no clock.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+
+from newsletter.build_newsletter import normalize_newsletter_number
+from newsletter.schedule_editions import (
+    DEFAULT_TARGET,
+    BufferState,
+    format_edition_number,
+    parse_edition_number,
+    plan_editions,
+    summarize_editions,
+)
+
+
+def _row(number: str | None, day: str | None) -> dict:
+    """A Notion page shaped like a newsletter DB row."""
+    props: dict = {}
+    if number is not None:
+        props["number"] = {"title": [{"plain_text": number}]}
+    props["Date"] = {"date": ({"start": day} if day is not None else None)}
+    return {"properties": props}
+
+
+class ParseAndFormatTests(unittest.TestCase):
+    def test_parse_accepts_both_spellings(self):
+        self.assertEqual(parse_edition_number("N233"), 233)
+        self.assertEqual(parse_edition_number("233"), 233)
+        self.assertEqual(parse_edition_number("  n057 "), 57)
+
+    def test_parse_rejects_junk(self):
+        for raw in ("", "   ", "draft", "N", "N23a", None):
+            self.assertIsNone(parse_edition_number(raw), raw)
+
+    def test_format_zero_pads_to_three_digits(self):
+        self.assertEqual(format_edition_number(57), "N057")
+        self.assertEqual(format_edition_number(233), "N233")
+
+    def test_formatted_numbers_survive_the_build_step(self):
+        # The whole reason for the padding: ④ Build parses these back.
+        for value in (7, 57, 233, 999):
+            self.assertEqual(
+                normalize_newsletter_number(format_edition_number(value)),
+                format_edition_number(value),
+            )
+
+
+class PlanEditionsTests(unittest.TestCase):
+    def test_sequence_continues_by_number_and_week(self):
+        plan = plan_editions(latest_number=233, latest_date=date(2026, 9, 26), count=3)
+        self.assertEqual(plan, [
+            ("N234", date(2026, 10, 3)),
+            ("N235", date(2026, 10, 10)),
+            ("N236", date(2026, 10, 17)),
+        ])
+
+    def test_weekday_is_inherited_from_the_latest_row(self):
+        # 2026-09-26 is a Saturday; every generated date must be one too.
+        plan = plan_editions(latest_number=233, latest_date=date(2026, 9, 26), count=8)
+        self.assertTrue(all(d.weekday() == 5 for _, d in plan), plan)
+
+    def test_non_positive_count_is_a_no_op(self):
+        for count in (0, -1):
+            self.assertEqual(
+                plan_editions(latest_number=233, latest_date=date(2026, 9, 26),
+                              count=count),
+                [],
+            )
+
+    def test_crossing_a_month_and_year_boundary(self):
+        plan = plan_editions(latest_number=299, latest_date=date(2026, 12, 26), count=2)
+        self.assertEqual(plan, [
+            ("N300", date(2027, 1, 2)),
+            ("N301", date(2027, 1, 9)),
+        ])
+
+
+class SummarizeEditionsTests(unittest.TestCase):
+    TODAY = date(2026, 8, 23)
+
+    def test_counts_future_editions_the_way_pick_newsletter_does(self):
+        rows = [
+            _row("N230", "2026-08-01"),   # past
+            _row("N231", "2026-08-23"),   # today — on_or_after, so future
+            _row("N232", "2026-08-30"),   # future
+        ]
+        state = summarize_editions(rows, today=self.TODAY)
+        self.assertEqual(state.future_count, 2)
+        self.assertEqual(state.total, 3)
+        self.assertEqual(state.latest_number, 232)
+        self.assertEqual(state.latest_date, date(2026, 8, 30))
+        self.assertEqual(state.latest_label, "N232")
+
+    def test_max_number_is_independent_of_max_date(self):
+        # A row numbered high but dated low must still bump the sequence, or
+        # the next write would re-use N235 and duplicate it.
+        rows = [_row("N235", "2026-01-03"), _row("N231", "2026-09-05")]
+        state = summarize_editions(rows, today=self.TODAY)
+        self.assertEqual(state.latest_number, 235)
+        self.assertEqual(state.latest_date, date(2026, 9, 5))
+        self.assertEqual(plan_editions(latest_number=state.latest_number,
+                                       latest_date=state.latest_date, count=1),
+                         [("N236", date(2026, 9, 12))])
+
+    def test_datetime_valued_dates_are_truncated_to_the_day(self):
+        rows = [_row("N231", "2026-08-30T00:00:00.000+02:00")]
+        state = summarize_editions(rows, today=self.TODAY)
+        self.assertEqual(state.latest_date, date(2026, 8, 30))
+
+    def test_rows_missing_number_or_date_do_not_break_the_fold(self):
+        rows = [
+            _row("N230", "2026-08-01"),
+            _row(None, "2026-09-06"),      # dated but unnumbered
+            _row("N231", None),            # numbered but undated
+            _row(None, None),              # neither — skipped entirely
+            _row("draft", "2026-09-13"),   # unparsable number
+        ]
+        state = summarize_editions(rows, today=self.TODAY)
+        self.assertEqual(state.total, 4)
+        self.assertEqual(state.latest_number, 231)
+        self.assertEqual(state.latest_date, date(2026, 9, 13))
+        self.assertEqual(state.future_count, 2)
+
+    def test_returns_none_when_there_is_no_sequence_to_continue(self):
+        self.assertIsNone(summarize_editions([], today=self.TODAY))
+        self.assertIsNone(summarize_editions([_row(None, "2026-09-06")], today=self.TODAY))
+        self.assertIsNone(summarize_editions([_row("N231", None)], today=self.TODAY))
+
+
+class ShortfallTests(unittest.TestCase):
+    def _state(self, future: int) -> BufferState:
+        return BufferState(latest_number=233, latest_date=date(2026, 9, 26),
+                           future_count=future, total=233)
+
+    def test_shortfall_tops_up_to_the_target(self):
+        self.assertEqual(self._state(6).shortfall(DEFAULT_TARGET), 2)
+        self.assertEqual(self._state(0).shortfall(DEFAULT_TARGET), DEFAULT_TARGET)
+
+    def test_a_full_buffer_asks_for_nothing(self):
+        self.assertEqual(self._state(DEFAULT_TARGET).shortfall(DEFAULT_TARGET), 0)
+        self.assertEqual(self._state(DEFAULT_TARGET + 5).shortfall(DEFAULT_TARGET), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

② Archive files each article against the first *future* newsletter row that still has room for its topic (`notion_io.pick_newsletter`, which filters `Date >= today`). With the buffer of future rows drained it aborts outright — `❌ No future newsletter has room for topic '<topic>' — stopping`. Creating those rows was pure arithmetic done by hand, one row a week.

- **New `newsletter_pipeline.py schedule [--count N] [--target 8] [--dry-run] [--debug]`** — non-interactive, like every other step. Reads every edition row once, takes the highest `number` and the highest `Date` **independently**, and creates the rows that follow. Taking them independently is what makes a duplicate number impossible even if the table's numbering and dating ever disagree.
- **Numbering** is zero-padded to three digits — `build_newsletter.normalize_newsletter_number` rejects anything else, so an unpadded `N34` would sail through the write and only fail later, at ④ Build. A test pins that generated numbers survive that parser.
- **Dating** carries the weekly cadence off the latest row, so the Saturday alignment is inherited rather than recomputed.
- **`newsletter/schedule_editions.py`** holds the buffer-state fold and the sequence generator (pure — no Notion, no clock); the write helper `create_newsletter_edition` lives in `notion_io.py` next to the other `create_*` functions, behind `_retry`, and sets only `number` + `Date` (every other column is a rollup that fills itself in).
- **⓪ block in the 📰 tab** — buffer caption plus a count pre-filled with the shortfall. The count is only a *default*: the subprocess re-reads the maximum at write time, so a stale caption cannot duplicate a number. At a full buffer the count is `0` and the button is **disabled** rather than creating an edition nobody asked for. The caption's Notion read is cached (120 s TTL) and dropped on the pipeline slot's running → idle transition, so it refreshes itself once a run finishes.

Docs: `README.md`, `newsletter/README.md` (new section + CLI-table row + workflow diagram), and `docs/architecture.mmd`.

## Validation

**Gate** — `& .\.venv\Scripts\python.exe -m unittest discover tests` → **Ran 224 tests, OK (skipped=1)**, 0 failures / 0 errors. The one skip is a pre-existing Supabase integration probe, unrelated to this diff. `py_compile` clean on all five changed/added `.py` files. No ruff configured in this repo.

**New tests** — `tests/test_schedule_editions.py`, 15 tests, all pure: number parse/format round-trips through `normalize_newsletter_number`, the sequence generator (weekday inheritance, month/year boundary, non-positive count), the buffer fold (max number independent of max date, datetime-valued dates, rows missing number or date, empty table), and the shortfall arithmetic.

**CLI, against the live database**
- `schedule --dry-run` → `Latest N233 (2026-09-26) · 5 future edition(s) of 233 total`; planned N234/N235/N236, all Saturdays; nothing written.
- real run → created those three, `buffer now 8`.
- re-run → `Buffer already full — 8 future edition(s) ≥ target 8; nothing to create`, exit 0 (idempotent).
- `schedule --count 2 --dry-run` → override honoured (N237/N238).

**The reported failure itself** — `pick_newsletter` re-asked with the clock at `2026-09-27` (past the old latest edition, i.e. the drained-buffer condition that made ② Archive abort) now resolves to **N234** for all three topics. Read-only probe.

**UI, driven in a real browser** — the ⓪ block rendered `latest N236 · 2026-10-17 · 8 future editions — buffer full (target 8)` with count `0` and the button disabled; stepping to `1` enabled it; the click fired the subprocess (this repo has been bitten by #155, where `on_click` buttons nested in `st.columns()` silently fail — the new button uses `st.container(horizontal=True)` like the ②③④ row); the log panel streamed to `# exit code 0`; the caption then auto-refreshed to `latest N237 · 2026-10-24 · 9 future editions`. Text-only result — no screenshot attached.

**Design gate** — `ux_surface.py check` → `SPEC_APPLIES=no` (Streamlit POC exemption), so no design-conformance leg.

**Independent review** — a fresh agent with no knowledge of the build fetched the issue's acceptance criteria itself, read the diff, and re-ran the gate independently (224 tests, OK, skipped=1) plus its own read-only live CLI probes. Verdict: pass, with only cosmetic non-blocking nits; the one real nit (`parse_edition_number` annotated non-Optional while tested with `None`) is fixed in ce89509.

Closes #230
