### PR TITLE
fix: harden article title and link rendering in the HTML builder

### DIFF
--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -23,6 +23,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import logging
 import os
@@ -243,16 +244,38 @@ def group_articles_by_topic(articles: List[Dict[str, Any]], topics: Sequence[str
 # ---------------------------------------------------------------- HTML render
 
 
+# Only these schemes are emitted as a clickable ``href``. Article titles and
+# links are archived verbatim from third-party pages, so neither string is
+# trusted markup: every one is escaped before it reaches the template, and an
+# off-list scheme is rendered as inert text rather than a link.
+_LINKABLE_SCHEMES = ("http://", "https://")
+
+
+def _render_link(name: str, url: str) -> str:
+    """One ``<li>`` for an article, with both fields escaped for HTML.
+
+    ``name`` and ``url`` come from the Notion row the archive step wrote from
+    an arbitrary third-party page, so they are treated as text, never markup:
+    ``html.escape(..., quote=True)`` also escapes ``"`` so neither can close
+    the ``href`` attribute. A URL whose scheme is not in
+    :data:`_LINKABLE_SCHEMES` keeps the title readable but is not linked.
+    """
+    safe_name = html.escape(name, quote=True)
+    if url.lower().startswith(_LINKABLE_SCHEMES):
+        return f'  <li><a href="{html.escape(url, quote=True)}">{safe_name}</a></li>'
+    return f"  <li>{safe_name} ({html.escape(url, quote=True)})</li>"
+
+
 def generate_html_lists(grouped: Dict[str, List[Tuple[str, str]]], topics: Sequence[str] = TOPICS) -> str:
     out: List[str] = []
     for topic in topics:
         heading = topic[0].upper() + topic[1:]
-        out.append(f"<h2>{heading}</h2>")
+        out.append(f"<h2>{html.escape(heading, quote=True)}</h2>")
         articles = grouped[topic]
         if articles:
             out.append("<ul>")
             for name, url in articles:
-                out.append(f'  <li><a href="{url}">{name}</a></li>')
+                out.append(_render_link(name, url))
             out.append("</ul>")
         else:
             out.append("<ul></ul>")

--- a/tests/test_build_newsletter_rendering.py
+++ b/tests/test_build_newsletter_rendering.py
@@ -1,0 +1,101 @@
+"""Article titles and links render as text, never as markup.
+
+``newsletter/build_newsletter.py`` assembles the weekly HTML from the Notion
+article rows the archive step wrote. Both fields on those rows are copied
+verbatim from an arbitrary third-party page — the title from the page's own
+``<title>`` / readability short-title, the link from the tab that was open —
+so neither is authored by us and neither may be treated as markup. The built
+file is then written to ``results/newsletter/`` and opened in the operator's
+own browser, which makes "renders as text" a property worth pinning rather
+than assuming.
+
+Pinned here, all pure (no Notion, no network, no browser):
+
+* a title carrying markup characters survives as escaped text — no element
+  from the input appears in the output;
+* a link carrying a quote cannot terminate the ``href`` attribute it sits in;
+* a link whose scheme is not ``http``/``https`` keeps its title readable but
+  is not emitted as a clickable ``href``;
+* ordinary titles and links are unchanged, so the escaping is not paid for
+  with a mangled newsletter.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from newsletter.build_newsletter import generate_complete_html, generate_html_lists
+
+TOPICS = ["personal development", "innovation", "leadership and management"]
+
+
+def _grouped(*articles: tuple[str, str]) -> dict[str, list[tuple[str, str]]]:
+    """One topic carrying ``articles``; the other two empty."""
+    return {
+        "personal development": list(articles),
+        "innovation": [],
+        "leadership and management": [],
+    }
+
+
+class ArticleTitleRenderingTests(unittest.TestCase):
+    def test_markup_in_a_title_is_escaped_not_emitted(self):
+        title = '"><img src=x onerror=alert(1)>Ten lessons'
+        out = generate_html_lists(_grouped((title, "https://example.com/a")), TOPICS)
+        # The element from the input must not survive as an element, and the
+        # leading quote must not survive as a real quote — both become text.
+        self.assertNotIn("<img", out)
+        self.assertNotIn('">', out.replace('<a href="https://example.com/a">', ""))
+        self.assertIn("&lt;img", out)
+        self.assertIn("&quot;&gt;", out)
+
+    def test_ampersand_in_a_title_becomes_an_entity(self):
+        out = generate_html_lists(_grouped(("Tools & rituals", "https://example.com/a")), TOPICS)
+        self.assertIn("Tools &amp; rituals", out)
+        self.assertNotIn("Tools & rituals", out)
+
+    def test_a_plain_title_is_unchanged(self):
+        out = generate_html_lists(_grouped(("Ten lessons on focus", "https://example.com/a")), TOPICS)
+        self.assertIn('<a href="https://example.com/a">Ten lessons on focus</a>', out)
+
+
+class ArticleLinkRenderingTests(unittest.TestCase):
+    def test_a_quote_in_a_link_cannot_close_the_href(self):
+        url = 'https://example.com/a" onmouseover="alert(1)'
+        out = generate_html_lists(_grouped(("Ten lessons", url)), TOPICS)
+        # The quote from the input must not survive as a real quote, so no
+        # second attribute can be grafted onto the anchor.
+        self.assertNotIn('" onmouseover=', out)
+        self.assertIn("&quot;", out)
+        # Exactly one attribute-closing quote after the href opener.
+        anchor = out[out.index('<a href="'):]
+        self.assertEqual(anchor[len('<a href="'):].count('"'), 1)
+
+    def test_an_off_list_scheme_is_not_linked(self):
+        out = generate_html_lists(_grouped(("Ten lessons", "javascript:alert(1)")), TOPICS)
+        self.assertNotIn("<a href=", out)
+        self.assertIn("Ten lessons", out)
+
+    def test_https_and_http_links_stay_clickable(self):
+        for url in ("https://example.com/a", "http://example.com/b"):
+            with self.subTest(url=url):
+                out = generate_html_lists(_grouped(("Ten lessons", url)), TOPICS)
+                self.assertIn(f'<a href="{url}">', out)
+
+
+class CompleteDocumentTests(unittest.TestCase):
+    def test_the_full_document_carries_the_escaped_form(self):
+        doc = generate_complete_html(
+            _grouped(('<script>alert(1)</script>', "https://example.com/a")), TOPICS
+        )
+        self.assertNotIn("<script>alert(1)</script>", doc)
+        self.assertIn("&lt;script&gt;", doc)
+        # The document's own template markup is untouched.
+        self.assertIn("<!DOCTYPE html>", doc)
+        self.assertIn("<h2>Personal development</h2>", doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Article titles and links on a newsletter row are archived verbatim from arbitrary third-party pages, so neither field is authored by this repo. The HTML builder was interpolating both straight into the generated markup, and the result is written to `results/newsletter/` and opened in the operator's own browser. Both fields are now escaped as text before they reach the template, and a link whose scheme is not `http`/`https` keeps its title readable instead of being emitted as a clickable target.

## Test plan

- [x] `tests/test_build_newsletter_rendering.py` added — 7 cases covering escaped titles, links that cannot close their own attribute, off-list schemes, and unchanged ordinary rows.
- [x] Proven to fail against the previous renderer: 5 of the 7 cases fail when the change to `newsletter/build_newsletter.py` is reverted, all 7 pass with it.
- [x] Full suite green: `& .\.venv\Scripts\python.exe -m unittest discover tests` → `Ran 231 tests … OK (skipped=1)`.

Closes #248