### PR TITLE
docs: fix six stale/dead-end documentation findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,13 @@ content-management/                   # repo root
 ├── app/                              # Streamlit control panel (tabs: reporting/editorial/planning/newsletter/triage/engagement)
 ├── config/                           # config.json, mapping.json, logger_config, chrome_launch, console
 │   └── doc_capture/                  # deterministic control-panel screenshot engine (README tour)
+├── gmail_readonly/                   # portable, read-only Gmail OAuth + search component (vendored)
+├── google_oauth_common/              # shared installed-app OAuth bootstrap for the portable Google packages (vendored)
 ├── results/                          # outputs — planning summaries + raw API JSON
 ├── logs/                             # per-module .log files
 ├── docs/                             # durable topic reference docs (tracked)
 │   └── screenshots/                  # manifest.json + generated per-tab screenshots (tracked)
+├── tests/                            # unittest + pytest-style suite — see Verification below
 ├── planning_pipeline.py              # orchestrator: LI → IG → TW → TH (--all-wip)
 ├── reporting_pipeline.py             # orchestrator: APIs → Supabase → Notion → Substack
 ├── newsletter_pipeline.py            # orchestrator: schedule/bootstrap/archive/normalize/build subcommands
@@ -608,7 +611,28 @@ description, source globs, navigation, **required** mask selectors per tab).
 Idempotent by input hash — a rerun with unchanged `app/tab_*.py` sources
 captures nothing and leaves the README untouched. Hard safety invariant: a
 manifest entry without `mask` selectors is refused (skipped with a warning),
-never captured raw. Tests: `& .\.venv\Scripts\python.exe -m unittest discover tests -v`.
+never captured raw. See [Verification](#-verification) below for the test
+suite command.
+
+## ✅ Verification
+
+No CI pipeline — run the test suite locally before shipping. Most of `tests/`
+is `unittest.TestCase`-based and picked up by discovery:
+
+```powershell
+& .\.venv\Scripts\python.exe -m unittest discover tests -v
+```
+
+`tests/test_gmail_readonly.py` is pytest-style (plain test functions, not
+`unittest.TestCase`) — `unittest discover` silently skips it, no error, no
+warning. Run it separately with pytest, or run the whole suite through pytest
+instead, which understands both styles:
+
+```powershell
+& .\.venv\Scripts\python.exe -m pytest tests/test_gmail_readonly.py -v
+# or, to cover everything (unittest- and pytest-style) in one pass:
+& .\.venv\Scripts\python.exe -m pytest tests -v
+```
 
 ## 📝 License and contact
 

--- a/engagement/README.md
+++ b/engagement/README.md
@@ -58,7 +58,7 @@ No new secrets needed — uses `config.supabase.service_role_key` and `config.no
 
 ## Gotchas
 
-- **Selectors are unvalidated on first run.** The LinkedIn comment-area DOM was never used by the planning composer. `scrape_comments.py` has multiple candidate selectors per concept (`SEL_COMMENT_ARTICLE`, `SEL_COMMENT_TEXT`, etc.) and logs which one matched. If a post returns 0 comments, expect to iterate the selector lists.
+- **Selectors are unvalidated on first run.** The LinkedIn comment-area DOM was never used by the planning composer. `scrape_comments.py` hooks the comment list via two `data-testid` selectors (`SEL_COMMENT_LIST_CONTAINER`, `SEL_COMMENT_TEXT_NODES`). If a post returns 0 comments, `_dump_debug` writes an HTML + full-page PNG snapshot to `results/engagement/debug/`, and a DOM shape miss surfaces as the `no_list_container` structural error (tracked separately from a genuinely comment-free post — `_evaluate_scrape_health` only flags the run `"broken"` when every post structurally failed). Use the dump + structural-error signal to debug, not a selector-match log.
 - **Headful by default.** Headless would be brittle for first-run selector debugging. Use `--headless` once selectors are validated.
 - **Idempotent.** Both tables are upserted on `(platform, comment_id)` and `(platform, account_url)` respectively — safe to re-run on the same posts.
 - **Relative time parsing is approximate.** LinkedIn shows `2h`, `5m`, `1d`. We reconstruct an absolute timestamp from scrape time, so `posted_at` drifts up to ~one tick of the LI display unit. Fine for cadence rules.

--- a/planning/substack/README.md
+++ b/planning/substack/README.md
@@ -173,7 +173,7 @@ above.
 | `illustrations_folder` | Absolute folder containing the daily image. Joined with `image_filename`. |
 | `editorial_db_id` | Notion editorial database id. |
 | `notion_columns` | Role-to-column map. Roles: `title_day`, `text_body`, `image_filename`, `post_url`. The `follow SB` follower column is **not** in this map — it is populated by the reporting pipeline (`reporting/scrape_client/substack.py::fetch_profile` → `data_processor` → `notion_update`, mapped from `profile.num_followers_substack`) like every other platform's follower count. |
-| `note_source` | Optional, `"playwright"` (default) or `"native"`. Which backend publishes the daily Note — the Chrome composer, or the HTTP API with the harvested cookie. Video notes ignore this and always use Playwright. |
+| `note_source` | Optional, `"playwright"` (default) or `"native"`. Which backend publishes the daily Note — the Chrome composer, or the HTTP API with the harvested cookie. Video notes (issue #189) support the same flag. |
 | `headless` | Optional bool (default `false`). |
 | `dry_run_default` | Optional bool (default `false`). When `true`, step 1 always runs as a dry-run unless `--force` is passed. |
 

--- a/planning/substack/post_substack_note.py
+++ b/planning/substack/post_substack_note.py
@@ -20,7 +20,8 @@ rollback):
 Everything either side of publishing — the Notion read, the idempotence guard,
 the empty-body refusal, the image resolution and the ``post_url`` write-back —
 is shared, so the two backends differ only in how the Note reaches Substack.
-Video notes are Playwright-only (see ``post_substack_video_note.py``).
+Video notes (see ``post_substack_video_note.py``) support the same
+``note_source`` flag (issue #189).
 """
 
 from __future__ import annotations

--- a/reporting/notion/README.md
+++ b/reporting/notion/README.md
@@ -39,7 +39,10 @@ pip install notion-client psycopg2-binary pandas python-dotenv requests
 ```
 
 2. Configure your environment:
-   - Copy `.env.example` to `.env` and fill in your credentials
+   - Copy `reporting/process/.env_example` to `reporting/process/.env` and
+     fill in your credentials — this module reuses the same DB connection
+     helper as the `reporting/process` pipeline (see its README), so it
+     shares that file rather than having its own
    - Update `config/config.json` with your Notion API token and database settings
 
 ## ⚙️ Configuration
@@ -98,13 +101,14 @@ Updates specific Notion database entries with data from Supabase based on date m
 
 **Usage:**
 ```bash
-python -m reporting.notion.notion_update YYYYMMDD [--debug] [--database-id DATABASE_ID]
+python -m reporting.notion.notion_update YYYYMMDD [--debug] [--database-id DATABASE_ID] [-y|--yes]
 ```
 
 **Arguments:**
 - `YYYYMMDD`: Target date for updates (required)
 - `--debug`: Enable debug logging
 - `--database-id`: Override database ID from config
+- `-y`, `--yes`: Auto-confirm the update prompt (skip the "Press Enter to continue" wait) — the flag that makes this step runnable unattended
 
 **Example:**
 ```bash
@@ -363,7 +367,7 @@ All scripts use a centralized logging configuration with:
 
 To support new Notion property types:
 
-1. Update `_extract_property_value()` in `notion_supabase_sync.py`
+1. Update `extract_property_value()` in `reporting/notion/_client.py`
 2. Add type mapping in `_get_postgres_type()`
 3. Update the property type mapping table in this README
 

--- a/reporting/process/.env_example
+++ b/reporting/process/.env_example
@@ -1,0 +1,13 @@
+# For local development
+db_user_local=postgres
+db_password_local=your_password
+db_host_local=127.0.0.1
+db_port_local=5432
+db_name_local=postgres
+
+# For cloud deployment
+db_user_cloud=your_cloud_user
+db_password_cloud=your_cloud_password
+db_host_cloud=your_host.supabase.com
+db_port_cloud=5432
+db_name_cloud=postgres

--- a/reporting/social_client/README.md
+++ b/reporting/social_client/README.md
@@ -58,6 +58,7 @@ python -m reporting.social_client.social_api_client [options]
 - `--skip-existing`: Skip platforms with today's data already collected (default: enabled)
 - `--no-skip`: Force re-fetching of data even if today's file exists
 - `--platform PLATFORM_NAME`: Process only a specific platform
+- `--date YYYY-MM-DD`: Reference date to collect for, instead of today — this is the flag `reporting_pipeline.py` passes on every run
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Six documentation drift findings surfaced by /codebase-audit: a missing Verification section (the repo's verification gate was effectively undocumented for both new contributors and fleet skills), a dead-end setup step referencing a non-existent .env.example (now committed as reporting/process/.env_example, shared with reporting/process's README), a workflow step pointing at a deleted method (repointed to extract_property_value in reporting/notion/_client.py), two missing CLI flags (--date, -y/--yes), a stale claim that video notes ignore note_source (they support it per issue #189), and a gotcha describing selector constants that no longer exist (rewritten around the current data-testid hooks and the debug-dump/structural-error path).

## Validation

- `& .\.venv\Scripts\python.exe -m pytest tests -v` → 245 passed, 1 skipped, 0 failed.
- e2e: skip — diff is exclusively README/docstring/`.env_example` template changes, no browser-testable surface touched.
- UX-conformance gate: n/a — non-web-surface diff (SPEC_APPLIES=no).

## Test plan

- [x] Full suite green locally.
- [x] Each finding cross-checked against the current source it documents (notion/_client.py, engagement selectors, planning/substack video-note module, reporting_pipeline.py flags).

Closes #247