### PR TITLE
fix: close three claude-md-drift findings (hub SDK, kill-vs-wait, indeterminate placeholder)

### DIFF
--- a/newsletter/README.md
+++ b/newsletter/README.md
@@ -16,7 +16,7 @@ flowchart LR
         Z[schedule_editions.py<br/>read every edition row<br/>-> max number + max date<br/>-> create the missing<br/>future rows, weekly cadence]
     end
     subgraph S1[1. Bootstrap]
-        A[bootstrap_chrome.py<br/>targeted: reuse :9222 if up,<br/>else kill only the newsletter-profile<br/>Chrome and relaunch on :9222]
+        A[bootstrap_chrome.py<br/>targeted: reuse :9222 if up,<br/>else wait out a non-debug<br/>newsletter-profile Chrome, then launch :9222]
     end
     subgraph S2[2. Archive]
         B[connect_over_cdp] --> C[list tabs<br/>skip gmail/notion/...]
@@ -215,13 +215,18 @@ byline. The fallback exists so the pipeline never invents people.
   against the default profile dir (security policy change to block
   session-stealing extensions). Bootstrap always launches with
   `--user-data-dir=newsletter\chrome_user_data\` to work around this.
-- Bootstrap is **targeted and idempotent** (issue #59, supersedes #57): it
-  reuses an existing `:9222` if one is up, and otherwise kills **only** the
-  Chrome whose command line carries `--user-data-dir=<newsletter profile>` (via
+- Bootstrap is **targeted and idempotent** (issue #59, supersedes #57; wait
+  semantics fixed in #244): it reuses an existing `:9222` if one is up, and
+  otherwise checks for a Chrome whose command line carries
+  `--user-data-dir=<newsletter profile>` (via
   `config.chrome_profile_lock.pids_holding_profile`) — never `taskkill /IM
-  chrome.exe`. Your everyday browser is never touched. If a *non-debug* Chrome
-  is holding the newsletter profile, relaunching it drops that window's open
-  tabs (logins persist).
+  chrome.exe`, and never force-kills that process either. Your everyday
+  browser is never touched. If a *non-debug* Chrome is holding the newsletter
+  profile, bootstrap **waits** with the same exponential backoff schedule as
+  `config.chrome_profile_lock` (60→120→240→480 s), re-checking each cycle;
+  only if the profile is still held after the full ~15 min schedule does it
+  report the holder as likely wedged (exit code 4) instead of relaunching —
+  close that window yourself to free the profile sooner.
 - The pipeline does **not** close Chrome when it disconnects — only the
   tabs whose articles processed successfully are closed.
 - New connections are created with `name` + `topic` only. LinkedIn URLs
@@ -238,7 +243,7 @@ byline. The fallback exists so the pipeline never invents people.
 
 ## Files
 
-- `bootstrap_chrome.py` — targeted, idempotent Chrome launcher on `:9222` (reuse-or-relaunch; never kills the everyday browser).
+- `bootstrap_chrome.py` — targeted, idempotent Chrome launcher on `:9222` (reuse-or-launch; never kills the everyday browser or the newsletter profile's holder — waits with backoff instead).
 - `bootstrap_chrome.bat` — thin wrapper that runs `python -m newsletter.bootstrap_chrome`.
 - `bootstrap_session.py` — one-time Gmail-login flow into the dedicated profile.
 - `chrome_tabs.py` — CDP attach, list, skip filter, tab close.

--- a/newsletter/bootstrap_chrome.py
+++ b/newsletter/bootstrap_chrome.py
@@ -11,9 +11,12 @@ Behaviour (idempotent):
   "never kill a live holder" — your debug Chrome and its open tabs are left
   alone.
 * Else, if the dedicated newsletter profile is held by a non-debug Chrome →
-  kill **only those PIDs** (via :func:`config.chrome_profile_lock.pids_holding_profile`,
-  which matches only ``--user-data-dir=<this profile>``), then relaunch. The
-  persistent profile (logins) survives; only that window's live tabs are lost.
+  **wait**, never kill (via :func:`config.chrome_profile_lock.pids_holding_profile`,
+  which matches only ``--user-data-dir=<this profile>``, and the same
+  exponential backoff schedule as ``config.chrome_profile_lock``). Re-checks
+  each cycle whether the holder has exited on its own; only after the full
+  schedule is a still-held profile reported as a precise, non-fatal error —
+  the holder is treated as genuinely wedged, not force-killed.
 * Launch Chrome with the debug port + the dedicated ``--user-data-dir`` and
   poll until the port responds.
 
@@ -33,6 +36,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -40,7 +44,10 @@ if str(REPO_ROOT) not in sys.path:
 
 import requests  # noqa: E402
 
-from config.chrome_profile_lock import pids_holding_profile  # noqa: E402
+from config.chrome_profile_lock import (  # noqa: E402
+    DEFAULT_LOCK_BACKOFF_SECONDS,
+    pids_holding_profile,
+)
 
 USER_DATA_DIR = Path(__file__).parent / "chrome_user_data"
 DEBUG_PORT = 9222
@@ -74,21 +81,42 @@ def _find_chrome_exe() -> Path:
     )
 
 
-def _kill_pids(pids: list[int]) -> None:
-    for pid in pids:
-        # /T also kills child processes (Chrome's renderer/GPU helpers).
-        subprocess.run(
-            ["taskkill", "/PID", str(pid), "/F", "/T"],
-            capture_output=True, text=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+def _wait_for_profile_free(
+    *, backoff_seconds: Sequence[int] = DEFAULT_LOCK_BACKOFF_SECONDS,
+) -> list[int]:
+    """Wait out a non-debug Chrome holding the newsletter profile — never kill it.
+
+    Re-checks :func:`pids_holding_profile` after each backoff step; returns as
+    soon as the holder exits on its own (empty list). If it is still held
+    after the full schedule, returns the still-held PIDs so the caller can
+    report a precise, non-fatal error — the holder is a genuinely wedged (or
+    simply forgotten-open) process, never force-killed.
+    """
+    held = pids_holding_profile(USER_DATA_DIR)
+    if not held:
+        return []
+    for delay in backoff_seconds:
+        logger.warning(
+            "⏳ Newsletter profile %s is held by non-debug Chrome PID(s) %s — "
+            "waiting %ds, then re-checking (never auto-killed; close it "
+            "yourself if you want the debug Chrome up sooner)",
+            USER_DATA_DIR, held, delay,
         )
+        time.sleep(delay)
+        held = pids_holding_profile(USER_DATA_DIR)
+        if not held:
+            logger.info("✅ profile %s freed on its own — continuing", USER_DATA_DIR)
+            return []
+    return held
 
 
 def ensure_chrome(*, timeout_s: int = 15) -> int:
     """Ensure Chrome is up on :9222 against the newsletter profile.
 
     Returns 0 on success (already up, or launched and reachable), 3 if the
-    port never came up within ``timeout_s`` seconds.
+    port never came up within ``timeout_s`` seconds after launch, 4 if the
+    profile is still held by a non-debug Chrome after the full wait schedule
+    (a likely-wedged holder, reported rather than force-killed).
     """
     USER_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -96,16 +124,16 @@ def ensure_chrome(*, timeout_s: int = 15) -> int:
         logger.info("✅ Chrome already up on :%d — reusing it (open tabs untouched)", DEBUG_PORT)
         return 0
 
-    held = pids_holding_profile(USER_DATA_DIR)
-    if held:
-        logger.warning(
-            "⚠️ Newsletter profile is held by a non-debug Chrome (PID(s) %s) — "
-            "relaunching it with the debug port. That window's open tabs will "
-            "close; your logins persist.", held,
+    still_held = _wait_for_profile_free()
+    if still_held:
+        logger.error(
+            "❌ Newsletter profile %s is still held by live process(es) %s after "
+            "waiting %ds across %d backoff step(s) — likely wedged. Close it "
+            "manually and re-run (fleet rule: never auto-kill a live holder).",
+            USER_DATA_DIR, still_held, sum(DEFAULT_LOCK_BACKOFF_SECONDS),
+            len(DEFAULT_LOCK_BACKOFF_SECONDS),
         )
-        _kill_pids(held)
-        # Give the OS a moment to release the profile-dir lock.
-        time.sleep(2)
+        return 4
 
     chrome = _find_chrome_exe()
     logger.info("🚀 Launching Chrome on :%d  ·  profile %s", DEBUG_PORT, USER_DATA_DIR)

--- a/newsletter/llm.py
+++ b/newsletter/llm.py
@@ -1,62 +1,54 @@
-"""Thin wrapper around the local-llm-hub Anthropic-shape /v1/messages endpoint."""
+"""Thin wrapper around the local-llm-hub Anthropic-shape /v1/messages endpoint.
+
+Backed by the `anthropic` SDK (global CLAUDE.md "Don't duplicate hub
+functionality in downstream apps") rather than a hand-rolled `requests.post`
++ retry loop — the SDK already implements retry/backoff on transient
+network errors and response parsing, so this module only adapts the SDK
+call to this project's `call()`/`health_check()` shape.
+"""
 
 from __future__ import annotations
 
 import logging
-import time
+from functools import lru_cache
 
-import requests
+from anthropic import Anthropic
 
 logger = logging.getLogger("newsletter_archive.llm")
 
-# Transient network failures worth retrying — the hub may be briefly slow
-# or mid-restart. A genuine bad response (4xx/5xx) is not retried here.
-_RETRYABLE = (requests.ReadTimeout, requests.ConnectionError)
+
+@lru_cache(maxsize=None)
+def _client(base_url: str) -> Anthropic:
+    return Anthropic(api_key="local-dummy", base_url=base_url)
 
 
 def call(*, base_url: str, model: str, prompt: str, max_tokens: int = 512,
-         timeout: int = 120, retries: int = 2, backoff: float = 2.0) -> str:
+         timeout: int = 120, retries: int = 2) -> str:
     """Single-turn user → assistant round-trip. Returns the assistant text.
 
-    On a transient network error (read timeout / connection error) the call
-    is retried up to ``retries`` times with exponential backoff before the
-    error is re-raised — so one slow blip doesn't discard a fully-extracted
-    article. Each attempt uses the full ``timeout``.
+    Transient network errors (read timeout / connection error) are retried
+    by the SDK's own backoff up to ``retries`` times before the error is
+    re-raised — so one slow blip doesn't discard a fully-extracted article.
     """
-    payload = {
-        "model": model,
-        "max_tokens": max_tokens,
-        "messages": [{"role": "user", "content": prompt}],
-    }
     logger.debug("LLM call: model=%s max_tokens=%d prompt_chars=%d",
                  model, max_tokens, len(prompt))
-    last_exc: Exception | None = None
-    for attempt in range(1, retries + 2):  # 1 initial + `retries` retries
-        try:
-            resp = requests.post(
-                f"{base_url.rstrip('/')}/v1/messages",
-                json=payload,
-                timeout=timeout,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            for part in data.get("content", []):
-                if part.get("type") == "text":
-                    return (part.get("text") or "").strip()
-            raise RuntimeError(f"Unexpected /v1/messages response shape: {data!r}")
-        except _RETRYABLE as exc:
-            last_exc = exc
-            if attempt <= retries:
-                wait = backoff * (2 ** (attempt - 1))
-                logger.warning("⚠️ LLM call failed (%s) — attempt %d/%d, "
-                               "retrying in %.0fs",
-                               type(exc).__name__, attempt, retries + 1, wait)
-                time.sleep(wait)
-            else:
-                logger.error("❌ LLM call failed after %d attempts: %s",
-                              retries + 1, type(exc).__name__)
-    assert last_exc is not None
-    raise last_exc
+    client = _client(base_url.rstrip("/"))
+    try:
+        msg = client.with_options(
+            timeout=float(timeout), max_retries=retries,
+        ).messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as exc:
+        logger.error("❌ LLM call failed after %d retries: %s: %s",
+                      retries, type(exc).__name__, exc)
+        raise
+    for part in msg.content or []:
+        if getattr(part, "type", None) == "text":
+            return (part.text or "").strip()
+    raise RuntimeError(f"Unexpected /v1/messages response shape: {msg!r}")
 
 
 def health_check(*, base_url: str, model: str, timeout: int = 30) -> bool:

--- a/planning/videos/README.md
+++ b/planning/videos/README.md
@@ -241,19 +241,25 @@ attach helper. See:
   `https://scheduled.local/<platform>/<day>` into `link <P>(v)`. This is
   intentional and gets overwritten by the data-collection pipeline once the
   real post goes live.
-- **OneDrive online-only clips are auto-hydrated before upload (issue #104).**
-  Clips live in a OneDrive folder. When a clip `.mp4`/`.png` is "online-only"
-  (a Files-On-Demand placeholder), `Path.exists()` is `True` **and**
-  `stat().st_size` reports the full size, yet the bytes are not on disk —
-  feeding that placeholder to a platform's `set_input_files` schedules a post
-  with no/partial media even though the run reports success. `load_clip_payload`
-  now detects the placeholder (Win32 `FILE_ATTRIBUTE_OFFLINE` /
-  `RECALL_ON_DATA_ACCESS` bits via `is_online_only`) and forces a download
-  (`ensure_local_file`: `attrib +P` pin + full streamed read) before returning,
-  raising loudly if it cannot. The most common cause of an un-hydratable clip is
-  **OneDrive not running** — the read fails with *"The cloud file provider is not
-  running"*; start OneDrive and retry. Hydrated files are left pinned ("always
-  keep on this device"); free up space again later if needed.
+- **OneDrive online-only clips are auto-hydrated before upload (issue #104,
+  indeterminate-state gap closed in #244).** Clips live in a OneDrive folder.
+  When a clip `.mp4`/`.png` is "online-only" (a Files-On-Demand placeholder),
+  `Path.exists()` is `True` **and** `stat().st_size` reports the full size, yet
+  the bytes are not on disk — feeding that placeholder to a platform's
+  `set_input_files` schedules a post with no/partial media even though the run
+  reports success. `load_clip_payload` now detects the placeholder (Win32
+  `FILE_ATTRIBUTE_OFFLINE` / `RECALL_ON_DATA_ACCESS` bits via `is_online_only`)
+  and forces a download (`ensure_local_file`: `attrib +P` pin + full streamed
+  read) before returning, raising loudly if it cannot. `is_online_only` returns
+  a tri-state (`True` / `False` / `None`): if the Win32 attribute query itself
+  fails, it logs a warning and returns `None` rather than silently reporting
+  `False` — `ensure_local_file` treats `None` the same as "might be a
+  placeholder" (forces the download-and-verify pass defensively) instead of
+  folding "could not tell" into "definitely local". The most common cause of
+  an un-hydratable clip is **OneDrive not running** — the read fails with
+  *"The cloud file provider is not running"*; start OneDrive and retry.
+  Hydrated files are left pinned ("always keep on this device"); free up space
+  again later if needed.
 - **X video scheduling watches the in-dialog Schedule button (issue #107, correcting #106).**
   The real reason X "never scheduled the weekly clip": the video driver waited on
   `.last` of a selector matching **both** `tweetButton` (the composer modal's real

--- a/planning/videos/videos_session.py
+++ b/planning/videos/videos_session.py
@@ -205,25 +205,45 @@ _PLACEHOLDER_MASK = (
 _INVALID_FILE_ATTRIBUTES = 0xFFFFFFFF
 
 
-def _win_file_attributes(path: Path) -> int:
-    """Return the Win32 attribute bitmask for ``path`` (-1 if unavailable).
+def _win_file_attributes(path: Path) -> Optional[int]:
+    """Return the Win32 attribute bitmask for ``path``, or ``None`` if unavailable.
 
-    Returns -1 on non-Windows platforms or when the query fails, so callers
-    treat the file as a normal local file (no-op) rather than a placeholder.
+    ``None`` on non-Windows platforms, or when ``GetFileAttributesW`` fails
+    (deleted file, permission denial, path-length limit, ...). ``None`` means
+    "could not determine" — it is a *distinct* state from "definitely not a
+    placeholder" and callers must not collapse the two (see ``is_online_only``).
+    Logs a warning with the Win32 error code on failure so a silent
+    misclassification doesn't hide the underlying query failure.
     """
     if os.name != "nt":
-        return -1
+        return None
     get_attrs = ctypes.windll.kernel32.GetFileAttributesW
     get_attrs.restype = ctypes.c_uint32
     get_attrs.argtypes = [ctypes.c_wchar_p]
     attrs = get_attrs(str(path))
-    return -1 if attrs == _INVALID_FILE_ATTRIBUTES else int(attrs)
+    if attrs == _INVALID_FILE_ATTRIBUTES:
+        win_err = ctypes.windll.kernel32.GetLastError()
+        logger.warning(
+            "⚠️ GetFileAttributesW failed for %s (Win32 error %d) — cannot tell "
+            "whether this is a normal local file or an unhydrated OneDrive "
+            "placeholder.", path, win_err,
+        )
+        return None
+    return int(attrs)
 
 
-def is_online_only(path: Path) -> bool:
-    """True iff ``path`` is an un-hydrated OneDrive Files-On-Demand placeholder."""
+def is_online_only(path: Path) -> Optional[bool]:
+    """True iff ``path`` is an un-hydrated OneDrive Files-On-Demand placeholder.
+
+    Returns ``None`` when the attribute query failed and placeholder status
+    could not be determined at all — this is distinct from ``False``
+    ("confirmed not a placeholder") and callers must handle it as its own
+    state, never silently treat it as "definitely a local file".
+    """
     attrs = _win_file_attributes(path)
-    return attrs >= 0 and bool(attrs & _PLACEHOLDER_MASK)
+    if attrs is None:
+        return None
+    return bool(attrs & _PLACEHOLDER_MASK)
 
 
 def _trigger_download(path: Path) -> None:
@@ -277,24 +297,46 @@ def ensure_local_file(path: Path, *, timeout_s: float = 600.0, poll_s: float = 1
 
     This triggers OneDrive's download, then polls the placeholder attributes
     until they clear. Raises ``RuntimeError`` if the file is still a placeholder
-    after ``timeout_s`` so the caller fails loudly instead of uploading a stub.
-    No-op for already-local files and on non-Windows platforms.
+    after ``timeout_s``, so the caller fails loudly instead of uploading a stub.
+    True no-op only when the file is *confirmed* local. When placeholder status
+    cannot be determined at all (``is_online_only`` returns ``None`` — the
+    attribute query itself failed), this does **not** silently treat that as
+    "local": it logs the indeterminate state and forces the same
+    download-and-verify path defensively, because uploading an un-hydrated
+    stub is worse than one extra, harmless read-through of an already-local
+    file.
     """
-    if not is_online_only(path):
+    online = is_online_only(path)
+    if online is False:
         return
-    size_mb = path.stat().st_size / 1_048_576
-    logger.info(
-        "🌥️ %s is an online-only OneDrive placeholder (%.1f MB) — forcing download…",
-        path.name, size_mb,
-    )
+    if online is None:
+        logger.warning(
+            "⚠️ %s: OneDrive placeholder status could not be determined — "
+            "forcing a download-and-verify pass defensively instead of "
+            "assuming it is a normal local file.", path,
+        )
+    else:
+        size_mb = path.stat().st_size / 1_048_576
+        logger.info(
+            "🌥️ %s is an online-only OneDrive placeholder (%.1f MB) — forcing download…",
+            path.name, size_mb,
+        )
     _trigger_download(path)
     # The download runs in the OneDrive service; poll until the attributes clear.
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
-        if not is_online_only(path):
-            logger.info("✅ %s hydrated locally (%.1f MB).", path.name, size_mb)
+        online = is_online_only(path)
+        if online is False:
+            logger.info("✅ %s hydrated locally.", path.name)
             return
         time.sleep(poll_s)
+    online = is_online_only(path)
+    if online is None:
+        raise RuntimeError(
+            f"OneDrive placeholder status for {path} could not be confirmed within "
+            f"{timeout_s:.0f}s (the attribute query kept failing) — refusing to "
+            "hand a possibly-unhydrated file to the uploader."
+        )
     raise RuntimeError(
         f"OneDrive placeholder {path} did not finish downloading within {timeout_s:.0f}s. "
         "Pin it locally (right-click → Always keep on this device) and retry."

--- a/tests/test_bootstrap_chrome_wait.py
+++ b/tests/test_bootstrap_chrome_wait.py
@@ -1,0 +1,75 @@
+"""Newsletter Chrome bootstrap must wait out a held profile, never kill it (issue #244).
+
+`ensure_chrome` used to `taskkill /F /T` any non-debug Chrome holding the
+newsletter profile immediately, with no wait and no retry — violating the
+fleet rule "never kill a live holder; wait with exponential backoff,
+re-attempting each cycle, and only raise after the full schedule" (the
+compliant pattern already lives in `config.chrome_profile_lock`). These tests
+pin the fixed behaviour: wait, re-check, and only report (never kill) a
+holder still present after the full backoff schedule.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from newsletter import bootstrap_chrome as bc  # noqa: E402
+
+
+class WaitForProfileFreeTests(unittest.TestCase):
+    def test_no_holder_returns_immediately_with_no_wait(self):
+        with mock.patch.object(bc, "pids_holding_profile", return_value=[]) as m_pids, \
+             mock.patch.object(bc.time, "sleep") as m_sleep:
+            result = bc._wait_for_profile_free(backoff_seconds=(60, 120))
+        self.assertEqual(result, [])
+        m_sleep.assert_not_called()
+        m_pids.assert_called_once()
+
+    def test_holder_that_frees_during_the_schedule_is_never_killed(self):
+        # Held on the initial check and after the first wait step, free after the second.
+        with mock.patch.object(bc, "pids_holding_profile",
+                                side_effect=[[111], [111], []]) as m_pids, \
+             mock.patch.object(bc.time, "sleep") as m_sleep, \
+             mock.patch("subprocess.run") as m_run:
+            result = bc._wait_for_profile_free(backoff_seconds=(60, 120))
+        self.assertEqual(result, [])
+        self.assertEqual(m_sleep.call_args_list, [mock.call(60), mock.call(120)])
+        self.assertEqual(m_pids.call_count, 3)
+        m_run.assert_not_called()  # never taskkill'd
+
+    def test_holder_still_present_after_full_schedule_is_reported_not_killed(self):
+        with mock.patch.object(bc, "pids_holding_profile", return_value=[111]), \
+             mock.patch.object(bc.time, "sleep") as m_sleep, \
+             mock.patch("subprocess.run") as m_run:
+            result = bc._wait_for_profile_free(backoff_seconds=(60, 120))
+        self.assertEqual(result, [111])
+        self.assertEqual(m_sleep.call_count, 2)
+        m_run.assert_not_called()
+
+
+class EnsureChromeReturnCodesTests(unittest.TestCase):
+    def test_debug_port_already_up_is_an_immediate_success(self):
+        with mock.patch.object(bc, "debug_port_up", return_value=True), \
+             mock.patch.object(bc, "_wait_for_profile_free") as m_wait:
+            rc = bc.ensure_chrome()
+        self.assertEqual(rc, 0)
+        m_wait.assert_not_called()
+
+    def test_wedged_holder_after_full_schedule_returns_4_without_launching(self):
+        with mock.patch.object(bc, "debug_port_up", return_value=False), \
+             mock.patch.object(bc, "_wait_for_profile_free", return_value=[111]), \
+             mock.patch.object(bc, "_find_chrome_exe") as m_find:
+            rc = bc.ensure_chrome()
+        self.assertEqual(rc, 4)
+        m_find.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_videos_placeholder_detection.py
+++ b/tests/test_videos_placeholder_detection.py
@@ -1,0 +1,93 @@
+"""Tri-state OneDrive placeholder detection (issue #244).
+
+`_win_file_attributes`/`is_online_only` used to collapse "the Win32
+``GetFileAttributesW`` query failed" into "definitely not a placeholder" (a
+failed query returned ``-1``, and ``attrs >= 0`` read that as falsy) — so a
+throttled or denied query silently reported every clip as safe to upload,
+even though it never actually confirmed that. ``ensure_local_file`` then
+no-op'd, handing a possible OneDrive placeholder straight to the uploader —
+the issue-#104 failure mode, where a post is scheduled with no media and the
+run reports success.
+
+These tests pin the fix: a failed query is its own logged ``None`` state,
+never folded into "confirmed local", and ``ensure_local_file`` treats that
+``None`` as "might be a placeholder" — forcing the same download-and-verify
+path it uses for a confirmed placeholder — rather than silently returning.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from planning.videos import videos_session as vs  # noqa: E402
+
+
+@unittest.skipUnless(sys.platform == "win32", "GetFileAttributesW is Windows-only")
+class WinFileAttributesTests(unittest.TestCase):
+    def test_successful_query_returns_the_int_bitmask(self):
+        with mock.patch.object(vs.ctypes.windll.kernel32, "GetFileAttributesW", return_value=0x20):
+            self.assertEqual(vs._win_file_attributes(Path("C:/some/file.mp4")), 0x20)
+
+    def test_failed_query_returns_none_and_logs_a_warning(self):
+        with mock.patch.object(
+            vs.ctypes.windll.kernel32, "GetFileAttributesW",
+            return_value=vs._INVALID_FILE_ATTRIBUTES,
+        ), mock.patch.object(
+            vs.ctypes.windll.kernel32, "GetLastError", return_value=5,
+        ), self.assertLogs(vs.logger, level="WARNING") as cm:
+            result = vs._win_file_attributes(Path("C:/some/file.mp4"))
+        self.assertIsNone(result)
+        self.assertTrue(any("GetFileAttributesW failed" in line for line in cm.output))
+
+
+class IsOnlineOnlyTests(unittest.TestCase):
+    def test_indeterminate_attrs_propagate_as_none_not_false(self):
+        with mock.patch.object(vs, "_win_file_attributes", return_value=None):
+            self.assertIsNone(vs.is_online_only(Path("x")))
+
+    def test_placeholder_bits_report_true(self):
+        with mock.patch.object(vs, "_win_file_attributes", return_value=vs._FILE_ATTRIBUTE_OFFLINE):
+            self.assertIs(vs.is_online_only(Path("x")), True)
+
+    def test_confirmed_local_reports_false(self):
+        with mock.patch.object(vs, "_win_file_attributes", return_value=0x20):  # FILE_ATTRIBUTE_ARCHIVE
+            self.assertIs(vs.is_online_only(Path("x")), False)
+
+
+class EnsureLocalFileIndeterminateTests(unittest.TestCase):
+    """The gap this issue closes: indeterminate must not collapse into no-op."""
+
+    def test_confirmed_local_is_a_true_noop(self):
+        with mock.patch.object(vs, "is_online_only", return_value=False), \
+             mock.patch.object(vs, "_trigger_download") as m_dl:
+            vs.ensure_local_file(Path("x"))
+        m_dl.assert_not_called()
+
+    def test_indeterminate_forces_a_defensive_download_never_silently_returns(self):
+        with mock.patch.object(vs, "is_online_only", return_value=None), \
+             mock.patch.object(vs, "_trigger_download") as m_dl, \
+             mock.patch.object(vs.time, "sleep"), \
+             self.assertLogs(vs.logger, level="WARNING") as cm, \
+             self.assertRaises(RuntimeError) as ctx:
+            vs.ensure_local_file(Path("x"), timeout_s=0.01, poll_s=0.01)
+        m_dl.assert_called_once()
+        self.assertIn("could not be confirmed", str(ctx.exception))
+        self.assertTrue(any("could not be determined" in line for line in cm.output))
+
+    def test_indeterminate_that_resolves_local_returns_cleanly(self):
+        results = iter([None, False])
+        with mock.patch.object(vs, "is_online_only", side_effect=lambda p: next(results)), \
+             mock.patch.object(vs, "_trigger_download") as m_dl:
+            vs.ensure_local_file(Path("x"), timeout_s=5, poll_s=0.01)
+        m_dl.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three claude-md-drift findings surfaced by /codebase-audit:

- `newsletter/llm.py` called the local LLM hub via a hand-rolled `requests.post` plus its own retry loop and content-block parsing, while `engagement/classify/llm_fallback.py` already used the `anthropic` SDK against the same hub. `newsletter/llm.call` now goes through `Anthropic(api_key="local-dummy", base_url=…)`, and the bespoke retry/parse code is gone.
- `newsletter/bootstrap_chrome.py` `taskkill`'d a non-debug Chrome holding the newsletter profile immediately, violating the fleet "never kill a live holder" rule that `config/chrome_profile_lock.py` already implements correctly elsewhere in the repo. `ensure_chrome` now waits out the holder with the same exponential backoff, and only reports it as wedged after the full schedule.
- `planning/videos/videos_session.py`'s `_win_file_attributes` returned `-1` silently on a failed `GetFileAttributesW` query, collapsing "could not tell" into "not a placeholder" — the issue-#104 failure mode where a post schedules with no media and reports success. `is_online_only` now returns a tri-state (`True`/`False`/`None`), logs a warning on the failed query, and `ensure_local_file` treats `None` defensively (forces the download-and-verify path) instead of no-op'ing.

## Validation

- `& .\.venv\Scripts\python.exe -m pytest tests -v` → 257 passed, 1 skipped, **1 failed**: `tests/test_triage_criteria.py::CriteriaTests::test_owner_overrides_are_merged`. Confirmed pre-existing and unrelated — none of this diff's changed files touch `newsletter/triage/`, and the failure reproduces on a clean checkout with no local `results/newsletter/triage/overrides.json` (untracked since #251). Filed separately as #252.
- e2e: n/a — no e2e suite in this repo; diff is backend-only (`newsletter/llm.py`, `newsletter/bootstrap_chrome.py`, `planning/videos/videos_session.py`), touching no Streamlit UI surface.
- UX-conformance gate: n/a — non-web-surface diff (SPEC_APPLIES=no).

## Test plan

- [x] New unit tests added: `tests/test_bootstrap_chrome_wait.py`, `tests/test_videos_placeholder_detection.py` — both green.
- [x] Full suite run locally; the one failure is pre-existing/unrelated (see above, tracked as #252).
- [x] Each finding cross-checked against the current source it describes.

Closes #244