### PR TITLE
refactor: collapse the duplication findings from the codebase audit

### DIFF
--- a/.agents/skills/schedule-autoheal/SKILL.md
+++ b/.agents/skills/schedule-autoheal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schedule-autoheal
-description: Run a planning scheduler and autonomously self-heal selector breakage caused by platform UI drift. Runs the scheduler (dry-run or live), classifies any failure, and for UI-drift it probes the live DOM, applies a selector-only fix, re-validates with a dry-run, and — when confident — files an issue, opens a PR, and merges end-to-end. When not confident (ambiguous DOM, login-required, or data errors) it pings the user on Slack and stops for interactive handling. Use when running the weekly planning schedulers unattended, e.g. "/schedule-autoheal all --dry-run", "/schedule-autoheal twitter --live".
+description: Run a planning scheduler unattended and self-heal selector breakage from platform UI drift — probe the live DOM, apply a selector-only fix, re-validate by dry-run, then when confident file an issue, open a PR and merge; when not confident, ping Slack and stop. E.g. "/schedule-autoheal all --dry-run", "/schedule-autoheal twitter --live".
 ---
 
 # schedule-autoheal
@@ -59,8 +59,8 @@ Heal at most **one platform per invocation cycle**; re-run to pick up the next.
      `planning/<platform>/schedule_<platform>_posts.py`. Search for the old accessible
      name / role call near the failing step.
 4. **Apply a selector-only edit.** Re-anchor the role/text selector on the new accessible
-   name from the probe. Prefer role + name anchors; **never** anchor on a class (the
-   READMEs warn class names rotate). The diff MUST be a pure selector-string change — no
+   name from the probe. Prefer role + name anchors; **never** anchor on a class (class
+   names rotate — the READMEs warn). The diff MUST be a pure selector-string change — no
    control-flow, scheduling-logic, or unrelated edits. A reviewer should read it in seconds.
 5. **Re-validate:** re-run that platform `--dry-run`. Bounded retries — **max 2** heal
    attempts per row; if still failing, **escalate** (Step 5).
@@ -107,11 +107,11 @@ Pass the bare channel id (the helper also accepts a pasted archive URL). The mes
 contain: platform, failing step, the screenshot path, the probe's top candidates, and
 exactly what you need decided.
 
-Why the bot and not the Slack MCP connector: the MCP connector posts **as the user**, so
-Slack never fires a notification for it and the escalation lands silently — defeating the
-point of an unattended scheduler. The bot posts as a separate identity, which actually
-notifies. The bot token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never
-in this repo; see `fleet-config/docs/slack-workflow.md`.
+Use the bot, not the Slack MCP connector: the MCP connector posts **as the user**, so
+Slack never fires a notification and the escalation lands silently — defeating an
+unattended scheduler. The bot posts as a separate identity, which actually notifies. Its
+token lives in `~/.claude/settings.json` env (`SLACK_BOT_TOKEN`), never in this repo; see
+`fleet-config/docs/slack-workflow.md`.
 
 If `autoheal_channel` is blank **or** the helper reports a failure (missing token, API
 error), surface that plainly in the run output and still **stop**. Either way: do not

--- a/config/logger_config.py
+++ b/config/logger_config.py
@@ -54,5 +54,28 @@ def setup_logger(name, level=logging.INFO, file_logging=True):
         f_formatter = logging.Formatter(log_format)
         f_handler.setFormatter(f_formatter)
         logger.addHandler(f_handler)
-    
+
     return logger
+
+
+def configure_root_logging(debug: bool = False) -> None:
+    """Configure the root logger for scripts that log via the bare
+    ``logging`` module rather than a named logger — was a verbatim
+    ``_setup_logging`` copy in ``newsletter/build_newsletter.py``,
+    ``newsletter/normalize_names.py``, ``newsletter/normalize_url.py`` and
+    ``newsletter/substack_draft.py``.
+
+    Re-configures UTF-8 stdio so emoji-bearing log lines don't crash a
+    cp1252 console, then attaches one ``StreamHandler`` to the root logger
+    if none exists yet (idempotent across repeated calls in one process).
+    """
+    level = logging.DEBUG if debug else logging.INFO
+    force_utf8_stdio()
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stdout)],
+        )
+    else:
+        logging.getLogger().setLevel(level)

--- a/newsletter/build_newsletter.py
+++ b/newsletter/build_newsletter.py
@@ -34,9 +34,11 @@ import webbrowser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-import requests
+from notion_client.errors import APIResponseError, HTTPResponseError, RequestTimeoutError
 
 from config.loader import load_full_config
+from config.logger_config import configure_root_logging
+from newsletter import notion_io
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RESULTS_DIR = REPO_ROOT / "results" / "newsletter"
@@ -59,12 +61,15 @@ _MUST_READ_PERM: Dict[int, Tuple[int, int, int]] = {
 
 
 class NotionClient:
-    """Notion HTTP + pagination for the two databases the newsletter reads.
+    """Notion client + pagination for the two databases the newsletter reads.
 
-    Holds only connection state (auth headers, db ids) — no article
+    Holds only connection state (SDK client, db ids) — no article
     extraction, grouping, or rendering logic lives here so each concern can
     be tested and reused on its own (``newsletter/substack_draft.py`` reuses
     :func:`group_articles_by_topic` without importing this class at all).
+    Query pagination and write retry go through ``newsletter.notion_io``, the
+    same module the archive path uses, so a Notion hiccup here gets the same
+    documented backoff instead of failing outright.
     """
 
     def __init__(self):
@@ -74,11 +79,7 @@ class NotionClient:
         self.newsletter_db_id = self.config["newsletter_db_id"]
         if not all([self.notion_api_key, self.articles_db_id, self.newsletter_db_id]):
             raise ValueError("Missing notion_api_key or DB ids in config")
-        self.headers = {
-            "Authorization": f"Bearer {self.notion_api_key}",
-            "Notion-Version": "2022-06-28",
-            "Content-Type": "application/json",
-        }
+        self.client = notion_io.init_client(self.notion_api_key)
         logging.info("✅ Newsletter builder initialized")
         logging.info(f"📊 Articles DB: {self.articles_db_id}")
         logging.info(f"📊 Newsletter DB: {self.newsletter_db_id}")
@@ -95,27 +96,11 @@ class NotionClient:
 
     def _query_notion_database(self, database_id: str,
                                filter_data: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
-        url = f"https://api.notion.com/v1/databases/{database_id}/query"
-        payload: Dict[str, Any] = {}
-        if filter_data:
-            payload["filter"] = filter_data
-        all_results: List[Dict[str, Any]] = []
-        cursor: Optional[str] = None
-        while True:
-            if cursor:
-                payload["start_cursor"] = cursor
-            try:
-                resp = requests.post(url, headers=self.headers, json=payload, timeout=30)
-                resp.raise_for_status()
-                data = resp.json()
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Failed to query Notion: {e}")
-                raise
-            all_results.extend(data.get("results", []))
-            if not data.get("has_more"):
-                break
-            cursor = data.get("next_cursor")
-        return all_results
+        try:
+            return notion_io.query_database(self.client, database_id, query_filter=filter_data)
+        except Exception as e:
+            logging.error(f"❌ Failed to query Notion: {e}")
+            raise
 
     def find_newsletter_by_title(self, newsletter_title: str) -> Optional[Dict[str, Any]]:
         logging.info(f"🔍 Searching for newsletter: {newsletter_title}")
@@ -443,7 +428,7 @@ def run(newsletter_number: str, debug: bool = False, *,
     * else ``interactive_must_read`` → prompt on stdin (console flow).
     * else → write the HTML + sidecar only (the app's non-blocking path).
     """
-    _setup_logging(debug)
+    configure_root_logging(debug)
     nl_num = normalize_newsletter_number(newsletter_number)
 
     logging.info(f"🚀 Building newsletter: {nl_num}")
@@ -483,20 +468,6 @@ def run(newsletter_number: str, debug: bool = False, *,
     return out_path
 
 
-def _setup_logging(debug: bool = False):
-    level = logging.DEBUG if debug else logging.INFO
-    from config.console import force_utf8_stdio
-    force_utf8_stdio()
-    if not logging.getLogger().handlers:
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler(sys.stdout)],
-        )
-    else:
-        logging.getLogger().setLevel(level)
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--newsletter", type=str,
@@ -504,7 +475,7 @@ def main() -> int:
                         'Prompted if omitted.')
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
-    _setup_logging(args.debug)
+    configure_root_logging(args.debug)
     try:
         nl = args.newsletter
         if not nl:
@@ -518,7 +489,7 @@ def main() -> int:
             return 2
         run(nl, debug=args.debug)
         return 0
-    except (ValueError, FileNotFoundError, requests.exceptions.RequestException) as e:
+    except (ValueError, FileNotFoundError, APIResponseError, HTTPResponseError, RequestTimeoutError) as e:
         logging.error(f"❌ Failed to build newsletter: {e}")
         return 1
     except Exception as e:

--- a/newsletter/normalize_names.py
+++ b/newsletter/normalize_names.py
@@ -28,14 +28,13 @@ import argparse
 import json
 import logging
 import re
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import requests
-
 from config.loader import load_full_config
+from config.logger_config import configure_root_logging
+from newsletter import notion_io
 
 WORDS_CONFIG = Path(__file__).parent / "normalize_names_words.json"
 
@@ -77,11 +76,7 @@ class NotionNameNormalizer:
         self.database_id = self.config["database_id"]
         if not all([self.notion_api_key, self.database_id]):
             raise ValueError("Missing notion_api_key or articles_db_id in config")
-        self.headers = {
-            "Authorization": f"Bearer {self.notion_api_key}",
-            "Notion-Version": "2022-06-28",
-            "Content-Type": "application/json",
-        }
+        self.client = notion_io.init_client(self.notion_api_key)
 
     def _load_word_lists(self):
         self.proper_names = set(self.config["proper_name_whitelist"])
@@ -111,32 +106,15 @@ class NotionNameNormalizer:
         logging.info(
             f"🔍 Querying articles created since {filter_date_str} ({days} days back)"
         )
-        body: Dict[str, Any] = {
-            "filter": {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]},
-            "sorts": [{"property": "created", "direction": "descending"}],
-        }
-        pages: List[Dict[str, Any]] = []
-        cursor: Optional[str] = None
-        while True:
-            if cursor:
-                body["start_cursor"] = cursor
-            try:
-                resp = requests.post(
-                    f"https://api.notion.com/v1/databases/{self.database_id}/query",
-                    headers=self.headers, json=body, timeout=30,
-                )
-                resp.raise_for_status()
-                data = resp.json()
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Notion API error: {e}")
-                raise
-            results = data.get("results", [])
-            if not results:
-                break
-            pages.extend(results)
-            if not data.get("has_more"):
-                break
-            cursor = data.get("next_cursor")
+        query_filter = {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]}
+        sorts = [{"property": "created", "direction": "descending"}]
+        try:
+            pages = notion_io.query_database(
+                self.client, self.database_id, query_filter=query_filter, sorts=sorts,
+            )
+        except Exception as e:
+            logging.error(f"❌ Notion API error: {e}")
+            raise
         logging.info(f"📊 Total pages retrieved: {len(pages)}")
         return pages
 
@@ -155,19 +133,13 @@ class NotionNameNormalizer:
         return page_id, last_edited_time, name_text
 
     def _update_page_title(self, page_id: str, new_value: str) -> bool:
-        body = {
-            "properties": {
-                "article": {"title": [{"type": "text", "text": {"content": new_value}}]}
-            }
+        properties = {
+            "article": {"title": [{"type": "text", "text": {"content": new_value}}]}
         }
         try:
-            resp = requests.patch(
-                f"https://api.notion.com/v1/pages/{page_id}",
-                headers=self.headers, json=body, timeout=30,
-            )
-            resp.raise_for_status()
+            notion_io.update_page(self.client, page_id, properties)
             return True
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logging.error(f"❌ Failed to update page {page_id[:8]}…: {e}")
             return False
 
@@ -380,23 +352,8 @@ class NotionNameNormalizer:
 
 def run(days: int = 14, dry_run: bool = False, debug: bool = False) -> List[Dict[str, Any]]:
     """Orchestrator-friendly entry point — same behaviour as ``main()``."""
-    _setup_logging(debug)
+    configure_root_logging(debug)
     return NotionNameNormalizer().process_database(days=days, dry_run=dry_run)
-
-
-def _setup_logging(debug: bool = False):
-    level = logging.DEBUG if debug else logging.INFO
-    # Re-configure UTF-8 stdio so emoji-bearing log lines don't crash cp1252.
-    from config.console import force_utf8_stdio
-    force_utf8_stdio()
-    if not logging.getLogger().handlers:
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler(sys.stdout)],
-        )
-    else:
-        logging.getLogger().setLevel(level)
 
 
 def main() -> int:
@@ -408,7 +365,7 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true",
                         help="Show changes without writing to Notion")
     args = parser.parse_args()
-    _setup_logging(args.debug)
+    configure_root_logging(args.debug)
     try:
         if args.test:
             normaliser = NotionNameNormalizer()

--- a/newsletter/normalize_url.py
+++ b/newsletter/normalize_url.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import sys
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
@@ -31,6 +30,8 @@ from urllib.parse import urlparse, urlunparse
 import requests
 
 from config.loader import load_full_config
+from config.logger_config import configure_root_logging
+from newsletter import notion_io
 
 
 class NotionURLNormalizer:
@@ -43,11 +44,7 @@ class NotionURLNormalizer:
         self.domains_preserving_params = set(self.config.get("domains_preserving_params", []))
         if not all([self.notion_api_key, self.database_id]):
             raise ValueError("Missing notion_api_key or articles_db_id in config")
-        self.headers = {
-            "Authorization": f"Bearer {self.notion_api_key}",
-            "Notion-Version": "2022-06-28",
-            "Content-Type": "application/json",
-        }
+        self.client = notion_io.init_client(self.notion_api_key)
         logging.info("✅ URL normalizer initialized")
         logging.info(f"📊 Database ID: {self.database_id}")
         logging.info(f"🛡️ Preserved domains: {sorted(self.domains_preserving_params)}")
@@ -100,32 +97,15 @@ class NotionURLNormalizer:
         logging.info(
             f"🔍 Querying articles created since {filter_date_str} ({days} days back)"
         )
-        body: Dict[str, Any] = {
-            "filter": {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]},
-            "sorts": [{"property": "created", "direction": "descending"}],
-        }
-        pages: List[Dict[str, Any]] = []
-        cursor: Optional[str] = None
-        while True:
-            if cursor:
-                body["start_cursor"] = cursor
-            try:
-                resp = requests.post(
-                    f"https://api.notion.com/v1/databases/{self.database_id}/query",
-                    headers=self.headers, json=body, timeout=30,
-                )
-                resp.raise_for_status()
-                data = resp.json()
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Notion API error: {e}")
-                raise
-            results = data.get("results", [])
-            if not results:
-                break
-            pages.extend(results)
-            if not data.get("has_more"):
-                break
-            cursor = data.get("next_cursor")
+        query_filter = {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]}
+        sorts = [{"property": "created", "direction": "descending"}]
+        try:
+            pages = notion_io.query_database(
+                self.client, self.database_id, query_filter=query_filter, sorts=sorts,
+            )
+        except Exception as e:
+            logging.error(f"❌ Notion API error: {e}")
+            raise
         logging.info(f"📊 Total pages retrieved: {len(pages)}")
         return pages
 
@@ -142,15 +122,11 @@ class NotionURLNormalizer:
         return page_id, last_edited, url_content
 
     def _update_page_url(self, page_id: str, new_url: str) -> bool:
-        body = {"properties": {"link": {"url": new_url}}}
+        properties = {"link": {"url": new_url}}
         try:
-            resp = requests.patch(
-                f"https://api.notion.com/v1/pages/{page_id}",
-                headers=self.headers, json=body, timeout=30,
-            )
-            resp.raise_for_status()
+            notion_io.update_page(self.client, page_id, properties)
             return True
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             logging.error(f"❌ Failed to update page {page_id[:8]}…: {e}")
             return False
 
@@ -198,24 +174,10 @@ class NotionURLNormalizer:
 
 def run(days: int = 14, dry_run: bool = False, testing_mode: bool = False,
         debug: bool = False) -> List[Dict[str, Any]]:
-    _setup_logging(debug)
+    configure_root_logging(debug)
     return NotionURLNormalizer().process_database(
         days=days, dry_run=dry_run, testing_mode=testing_mode,
     )
-
-
-def _setup_logging(debug: bool = False):
-    level = logging.DEBUG if debug else logging.INFO
-    from config.console import force_utf8_stdio
-    force_utf8_stdio()
-    if not logging.getLogger().handlers:
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler(sys.stdout)],
-        )
-    else:
-        logging.getLogger().setLevel(level)
 
 
 def main() -> int:
@@ -227,7 +189,7 @@ def main() -> int:
     parser.add_argument("--testing", action="store_true",
                         help="HEAD/GET each cleaned URL to verify it resolves")
     args = parser.parse_args()
-    _setup_logging(args.debug)
+    configure_root_logging(args.debug)
     try:
         if args.test:
             normaliser = NotionURLNormalizer()

--- a/newsletter/notion_io.py
+++ b/newsletter/notion_io.py
@@ -50,6 +50,29 @@ def init_client(api_token: str) -> Client:
     return Client(auth=api_token)
 
 
+def query_database(
+    client: Client, db_id: str, *, query_filter: Optional[Dict[str, Any]] = None,
+    sorts: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Paginated, retried query returning every matching row.
+
+    Single-source for the "query a Notion DB and page through every result"
+    loop that used to be hand-rolled with raw ``requests`` in
+    ``build_newsletter.NotionClient``, ``normalize_names.NotionNameNormalizer``
+    and ``normalize_url.NotionURLNormalizer`` — none of which retried on a
+    transient Notion error, unlike the archive path below.
+    """
+    return list(_iter_database(client, db_id, query_filter=query_filter, sorts=sorts))
+
+
+def update_page(client: Client, page_id: str, properties: Dict[str, Any]) -> Dict[str, Any]:
+    """Patch a page's properties with the shared retry/backoff."""
+    return _retry(
+        lambda: client.pages.update(page_id=page_id, properties=properties),
+        label=f"update page {page_id[:8]}…",
+    )
+
+
 # ---------------------------------------------------------------------------
 # property readers
 

--- a/newsletter/substack_draft.py
+++ b/newsletter/substack_draft.py
@@ -42,11 +42,11 @@ from __future__ import annotations
 
 import argparse
 import logging
-import sys
 import webbrowser
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from config.loader import load_block
+from config.logger_config import configure_root_logging
 from newsletter.books import find_book_for_newsletter
 from newsletter.build_newsletter import (
     TOPICS,
@@ -144,7 +144,7 @@ def run(
 
     Returns ``None`` when ``delete_after`` removed the throwaway draft.
     """
-    _setup_logging(debug)
+    configure_root_logging(debug)
     nl_num = normalize_newsletter_number(newsletter_number)
 
     client = NotionClient()
@@ -198,20 +198,6 @@ def run(
         webbrowser.open(edit_url)
         logging.info("🌐 Opened draft in browser: %s", edit_url)
     return edit_url
-
-
-def _setup_logging(debug: bool = False) -> None:
-    level = logging.DEBUG if debug else logging.INFO
-    from config.console import force_utf8_stdio
-    force_utf8_stdio()
-    if not logging.getLogger().handlers:
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler(sys.stdout)],
-        )
-    else:
-        logging.getLogger().setLevel(level)
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/planning/_bootstrap.py
+++ b/planning/_bootstrap.py
@@ -1,0 +1,80 @@
+"""Shared implementation for the per-platform Chrome-profile bootstrap scripts.
+
+Five near-verbatim ~60-line modules (twitter, threads, instagram, linkedin,
+substack) differed only in logger name, config loader, default login URL and
+prompt text. This collapses them into one ``run_bootstrap`` plus five thin
+``main()`` shims, mirroring how ``PlatformSession`` already collapsed the
+per-platform session modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Callable
+
+from playwright.sync_api import sync_playwright
+
+from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs
+
+
+def parse_bootstrap_args(description: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return parser.parse_args()
+
+
+def run_bootstrap(
+    *,
+    platform_label: str,
+    logger_name: str,
+    load_config: Callable[[], dict],
+    resolve_user_data_dir: Callable[[str], Path],
+    configure_logger: Callable[..., logging.Logger],
+    default_login_url: str,
+    login_prompt: str,
+    debug: bool,
+) -> int:
+    """Drive the interactive one-time login that prepares a dedicated Chrome
+    profile for one platform.
+
+    Launches **real Chrome** (channel="chrome") pointed at the project-local
+    profile directory configured as ``<platform>.user_data_dir``. The user's
+    regular Chrome profile is **not touched**: a separate, dedicated on-disk
+    directory is created by Playwright under the repo, and Chrome writes its
+    session cookies there. After login the dedicated profile retains the
+    session, so subsequent scheduler runs reuse it without prompting.
+    """
+    logger = configure_logger(logger_name, debug=debug)
+
+    cfg = load_config()
+    user_data_dir = resolve_user_data_dir(cfg["user_data_dir"])
+    user_data_dir.mkdir(parents=True, exist_ok=True)
+
+    login_url = cfg.get("login_url", default_login_url)
+
+    logger.info("🚀 %s session bootstrap", platform_label)
+    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
+    logger.info("   (this is SEPARATE from your normal Chrome profile)")
+
+    with sync_playwright() as pw:
+        context = pw.chromium.launch_persistent_context(
+            **stealth_launch_kwargs(str(user_data_dir), headless=False),
+        )
+        context.add_init_script(STEALTH_INIT_SCRIPT)
+        page = context.pages[0] if context.pages else context.new_page()
+        page.goto(login_url, wait_until="domcontentloaded")
+        # Intentional print (the bootstrap pause is the one place this is OK).
+        print(login_prompt)
+        try:
+            input()
+        except KeyboardInterrupt:
+            logger.warning("❌ Bootstrap cancelled before login.")
+            context.close()
+            return 2
+
+        # Persistent context flushes the profile to disk on close.
+        context.close()
+        logger.info("✅ Chrome profile saved → %s", user_data_dir)
+    return 0

--- a/planning/_captions.py
+++ b/planning/_captions.py
@@ -1,0 +1,74 @@
+"""Shared caption-resolution helpers for the planning schedulers.
+
+``canonical_caption_from_publish_ig`` was a byte-identical copy in
+``planning.instagram.clone_to_other_platforms`` and inlined again in
+``planning.linkedin.schedule_linkedin_posts.fetch_illustration``, the latter
+justified by "kept local to avoid a cross-package import, since the LinkedIn
+module pulls in Playwright" — the exact workaround ``planning/_dates.py`` was
+created to retire. This module only touches ``reporting.notion.editorial``
+(Playwright-free), so it is safe for every scheduler to import directly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from reporting.notion.editorial import get_field, retrieve_page
+
+
+def canonical_caption_from_publish_ig(
+    notion,
+    illustration_page_id: str,
+    illust_cols: dict,
+    ed_cols: dict,
+    logger: logging.Logger,
+    page: dict | None = None,
+) -> str:
+    """Follow an illustration's ``publishIG`` relation back to all editorial
+    rows that published it, sort by day ascending, and return the earliest
+    one's ``text IG`` (the canonical first-publication caption).
+
+    Fallback: ``text IG to copy`` formula on the illustration page.
+
+    ``page`` lets a caller that already fetched the illustration page (e.g.
+    for its filename/alt-text) pass it through instead of triggering a
+    redundant Notion round-trip.
+    """
+    if page is None:
+        page = retrieve_page(notion, illustration_page_id)
+    publish_col = illust_cols["publish_relation"]
+    publish_rels = page.get("properties", {}).get(publish_col, {}).get("relation", []) or []
+
+    if publish_rels:
+        candidates: list[tuple[str, str]] = []
+        for rel in publish_rels:
+            rel_id = rel.get("id")
+            if not rel_id:
+                continue
+            try:
+                ed_page = retrieve_page(notion, rel_id)
+            except Exception as err:
+                logger.warning("⚠️ could not fetch %s for publishIG resolution: %s", rel_id, err)
+                continue
+            day_str = get_field(ed_page, "title_day", ed_cols) or ""
+            text = get_field(ed_page, "caption_text", ed_cols) or ""
+            day_str = str(day_str).strip()
+            text = str(text).strip()
+            if day_str:
+                candidates.append((day_str, text))
+
+        candidates.sort(key=lambda x: x[0])  # YYYYMMDD lex = chronological
+        for day_str, text in candidates:
+            if text:
+                logger.info(
+                    "📝 canonical caption from publishIG row %s: %d chars", day_str, len(text)
+                )
+                return text
+
+    fallback = str(get_field(page, "caption_fallback", illust_cols) or "").strip()
+    if fallback:
+        logger.warning(
+            "⚠️ publishIG yielded no caption — falling back to '%s' formula (%d chars)",
+            illust_cols["caption_fallback"], len(fallback),
+        )
+    return fallback

--- a/planning/instagram/bootstrap_session.py
+++ b/planning/instagram/bootstrap_session.py
@@ -3,27 +3,18 @@
 Usage:
     python -m instagram.bootstrap_session [--debug]
 
-Launches **real Chrome** (channel="chrome") pointed at the project-local
-profile directory configured as ``instagram.user_data_dir`` (default:
-``instagram/chrome_user_data/``). The user's regular Chrome profile is **not
-touched**: a separate, dedicated on-disk directory is created by Playwright
-under the repo, and Chrome writes its session cookies there.
-
-After login the dedicated profile retains the session, so subsequent runs of
-``schedule_instagram_posts`` reuse it without prompting. Mirror of
-``linkedin/bootstrap_session.py``.
+See ``planning._bootstrap.run_bootstrap`` for the shared implementation
+(mirror of ``linkedin/bootstrap_session.py``, ``twitter/bootstrap_session.py``,
+``threads/bootstrap_session.py``, ``substack/bootstrap_session.py``).
 """
 
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 
-from playwright.sync_api import sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from planning._bootstrap import parse_bootstrap_args, run_bootstrap  # noqa: E402
 from planning.instagram.instagram_session import (  # noqa: E402
     _resolve_user_data_dir,
     configure_logger,
@@ -32,50 +23,25 @@ from planning.instagram.instagram_session import (  # noqa: E402
 
 LOGIN_URL_DEFAULT = "https://business.facebook.com/"
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="One-time Meta (FB+IG) session bootstrap.")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+LOGIN_PROMPT = (
+    "\n>>> Log in to Meta inside the opened Chrome window.\n"
+    "    Make sure both Facebook and the connected Instagram business account are accessible.\n"
+    "    Then return here and press Enter to save the session...\n"
+)
 
 
 def main() -> int:
-    args = parse_args()
-    logger = configure_logger("instagram_bootstrap", debug=args.debug)
-
-    cfg = load_instagram_config()
-    user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-    user_data_dir.mkdir(parents=True, exist_ok=True)
-
-    login_url = cfg.get("login_url", LOGIN_URL_DEFAULT)
-
-    logger.info("🚀 Meta (Instagram + Facebook) session bootstrap")
-    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
-    logger.info("   (this is SEPARATE from your normal Chrome profile)")
-
-    with sync_playwright() as pw:
-        context = pw.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(user_data_dir), headless=False),
-        )
-        context.add_init_script(STEALTH_INIT_SCRIPT)
-        page = context.pages[0] if context.pages else context.new_page()
-        page.goto(login_url, wait_until="domcontentloaded")
-        # Intentional print (the bootstrap pause is the one place this is OK).
-        print(
-            "\n>>> Log in to Meta inside the opened Chrome window.\n"
-            "    Make sure both Facebook and the connected Instagram business account are accessible.\n"
-            "    Then return here and press Enter to save the session...\n"
-        )
-        try:
-            input()
-        except KeyboardInterrupt:
-            logger.warning("❌ Bootstrap cancelled before login.")
-            context.close()
-            return 2
-
-        context.close()
-        logger.info("✅ Chrome profile saved → %s", user_data_dir)
-    return 0
+    args = parse_bootstrap_args("One-time Meta (FB+IG) session bootstrap.")
+    return run_bootstrap(
+        platform_label="Meta (Instagram + Facebook)",
+        logger_name="instagram_bootstrap",
+        load_config=load_instagram_config,
+        resolve_user_data_dir=_resolve_user_data_dir,
+        configure_logger=configure_logger,
+        default_login_url=LOGIN_URL_DEFAULT,
+        login_prompt=LOGIN_PROMPT,
+        debug=args.debug,
+    )
 
 
 if __name__ == "__main__":

--- a/planning/instagram/clone_to_other_platforms.py
+++ b/planning/instagram/clone_to_other_platforms.py
@@ -63,7 +63,6 @@ from planning.instagram.instagram_session import (  # noqa: E402
     load_notion_token,
 )
 from reporting.notion.editorial import (  # noqa: E402
-    get_field,
     init_notion_client,
     query_rows_by_filter,
     retrieve_page,
@@ -78,6 +77,7 @@ from planning._dates import (  # noqa: E402
     parse_single_date,
     parse_week_start,
 )
+from planning._captions import canonical_caption_from_publish_ig  # noqa: E402
 
 logger = logging.getLogger("instagram_clone")
 
@@ -168,60 +168,6 @@ def fetch_wip_ig_rows(notion, db_id: str, ed_cols: dict, days: list[date]) -> li
 
 # ---------- Source resolution ----------
 
-def _canonical_caption_from_publish_ig(
-    notion,
-    illustration_page_id: str,
-    illust_cols: dict,
-    ed_cols: dict,
-) -> str:
-    """Follow an illustration's ``publishIG`` relation back to all editorial
-    rows that published it, sort by day ascending, and return the earliest
-    one's ``text IG`` (the canonical first-publication caption).
-
-    Fallback: ``text IG to copy`` formula on the illustration page.
-
-    Mirror of ``linkedin.schedule_linkedin_posts.fetch_illustration`` caption
-    logic (kept local to avoid a cross-package import, since the LinkedIn
-    module pulls in Playwright at import time).
-    """
-    page = retrieve_page(notion, illustration_page_id)
-    publish_col = illust_cols["publish_relation"]
-    publish_rels = page.get("properties", {}).get(publish_col, {}).get("relation", []) or []
-
-    if publish_rels:
-        candidates: list[tuple[str, str]] = []
-        for rel in publish_rels:
-            rel_id = rel.get("id")
-            if not rel_id:
-                continue
-            try:
-                ed_page = retrieve_page(notion, rel_id)
-            except Exception as err:
-                logger.warning("⚠️ could not fetch %s for publishIG resolution: %s", rel_id, err)
-                continue
-            day_str = get_field(ed_page, "title_day", ed_cols) or ""
-            text = get_field(ed_page, "caption_text", ed_cols) or ""
-            day_str = str(day_str).strip()
-            text = str(text).strip()
-            if day_str:
-                candidates.append((day_str, text))
-
-        candidates.sort(key=lambda x: x[0])  # YYYYMMDD lex = chronological
-        for day_str, text in candidates:
-            if text:
-                logger.info(
-                    "📝 canonical caption from publishIG row %s: %d chars", day_str, len(text)
-                )
-                return text
-
-    fallback = str(get_field(page, "caption_fallback", illust_cols) or "").strip()
-    if fallback:
-        logger.warning(
-            "⚠️ publishIG yielded no caption — falling back to '%s' formula (%d chars)",
-            illust_cols["caption_fallback"], len(fallback),
-        )
-    return fallback
-
 
 def _first_thread_illustration_id(notion, post_page_id: str, posts_cols: dict) -> str:
     """Read the posts-page ``illustration`` relation and return its first id."""
@@ -262,8 +208,8 @@ def resolve_source(notion, cfg: dict, row: IgRow) -> CloneSource:
             # (earliest first-publication row's `text IG`, with the
             # `text IG to copy` formula as fallback). Same rule the LinkedIn
             # scheduler and the Sunday-thread branch below use.
-            caption = _canonical_caption_from_publish_ig(
-                notion, illust_id, illust_cols, ed_cols
+            caption = canonical_caption_from_publish_ig(
+                notion, illust_id, illust_cols, ed_cols, logger
             )
             if not caption:
                 raise RuntimeError(
@@ -290,8 +236,8 @@ def resolve_source(notion, cfg: dict, row: IgRow) -> CloneSource:
     first_illust_id = _first_thread_illustration_id(
         notion, row.post_ig_ids[0], posts_cols
     )
-    canonical = _canonical_caption_from_publish_ig(
-        notion, first_illust_id, illust_cols, ed_cols
+    canonical = canonical_caption_from_publish_ig(
+        notion, first_illust_id, illust_cols, ed_cols, logger
     )
     if not canonical:
         raise RuntimeError(

--- a/planning/instagram/schedule_instagram_posts.py
+++ b/planning/instagram/schedule_instagram_posts.py
@@ -67,35 +67,14 @@ from reporting.notion.editorial import (  # noqa: E402
     set_field,
 )
 from reporting.notion.notion_update import format_database_id  # noqa: E402
+from planning._dates import (  # noqa: E402
+    date_to_day_title,
+    next_monday,
+    parse_single_date,
+    parse_week_start,
+)
 
 logger = logging.getLogger("instagram_schedule")
-
-
-# ---------- Date helpers ----------
-
-def next_monday(today: Optional[date] = None) -> date:
-    today = today or date.today()
-    days_ahead = (7 - today.weekday()) % 7
-    if days_ahead == 0:
-        days_ahead = 7
-    return today + timedelta(days=days_ahead)
-
-
-def parse_week_start(s: Optional[str]) -> date:
-    if not s:
-        return next_monday()
-    return datetime.strptime(s, "%Y-%m-%d").date()
-
-
-def parse_single_date(s: str) -> date:
-    s = s.strip()
-    if "-" in s:
-        return datetime.strptime(s, "%Y-%m-%d").date()
-    return datetime.strptime(s, "%Y%m%d").date()
-
-
-def date_to_day_title(d: date) -> str:
-    return d.strftime("%Y%m%d")
 
 
 # ---------- Row model ----------

--- a/planning/linkedin/bootstrap_session.py
+++ b/planning/linkedin/bootstrap_session.py
@@ -3,26 +3,18 @@
 Usage:
     python -m linkedin.bootstrap_session [--debug]
 
-Launches **real Chrome** (channel="chrome") pointed at the project-local profile
-directory configured as ``linkedin.user_data_dir`` (default:
-``linkedin/chrome_user_data/``). The user's regular Chrome profile is **not
-touched**: a separate, dedicated on-disk directory is created by Playwright
-under the repo, and Chrome writes its session cookies there.
-
-After login the dedicated profile retains the session, so subsequent runs of
-``schedule_linkedin_posts`` reuse it without prompting.
+See ``planning._bootstrap.run_bootstrap`` for the shared implementation
+(mirror of ``instagram/bootstrap_session.py``, ``twitter/bootstrap_session.py``,
+``threads/bootstrap_session.py``, ``substack/bootstrap_session.py``).
 """
 
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 
-from playwright.sync_api import sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from planning._bootstrap import parse_bootstrap_args, run_bootstrap  # noqa: E402
 from planning.linkedin.linkedin_session import (  # noqa: E402
     _resolve_user_data_dir,
     configure_logger,
@@ -31,47 +23,24 @@ from planning.linkedin.linkedin_session import (  # noqa: E402
 
 LOGIN_URL_DEFAULT = "https://www.linkedin.com/login"
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="One-time LinkedIn session bootstrap.")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+LOGIN_PROMPT = (
+    "\n>>> Log in to LinkedIn inside the opened Chrome window, "
+    "then press Enter here to save the session...\n"
+)
 
 
 def main() -> int:
-    args = parse_args()
-    logger = configure_logger("linkedin_bootstrap", debug=args.debug)
-
-    cfg = load_linkedin_config()
-    user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-    user_data_dir.mkdir(parents=True, exist_ok=True)
-
-    login_url = cfg.get("login_url", LOGIN_URL_DEFAULT)
-
-    logger.info("🚀 LinkedIn session bootstrap")
-    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
-    logger.info("   (this is SEPARATE from your normal Chrome profile)")
-
-    with sync_playwright() as pw:
-        context = pw.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(user_data_dir), headless=False),
-        )
-        context.add_init_script(STEALTH_INIT_SCRIPT)
-        page = context.pages[0] if context.pages else context.new_page()
-        page.goto(login_url, wait_until="domcontentloaded")
-        # Intentional print (the issue allows this single bootstrap pause).
-        print("\n>>> Log in to LinkedIn inside the opened Chrome window, then press Enter here to save the session...\n")
-        try:
-            input()
-        except KeyboardInterrupt:
-            logger.warning("❌ Bootstrap cancelled before login.")
-            context.close()
-            return 2
-
-        # Persistent context flushes the profile to disk on close.
-        context.close()
-        logger.info("✅ Chrome profile saved → %s", user_data_dir)
-    return 0
+    args = parse_bootstrap_args("One-time LinkedIn session bootstrap.")
+    return run_bootstrap(
+        platform_label="LinkedIn",
+        logger_name="linkedin_bootstrap",
+        load_config=load_linkedin_config,
+        resolve_user_data_dir=_resolve_user_data_dir,
+        configure_logger=configure_logger,
+        default_login_url=LOGIN_URL_DEFAULT,
+        login_prompt=LOGIN_PROMPT,
+        debug=args.debug,
+    )
 
 
 if __name__ == "__main__":

--- a/planning/linkedin/schedule_linkedin_posts.py
+++ b/planning/linkedin/schedule_linkedin_posts.py
@@ -111,6 +111,7 @@ from planning._dates import (  # noqa: E402
     parse_single_date,
     parse_week_start,
 )
+from planning._captions import canonical_caption_from_publish_ig  # noqa: E402
 
 Route = Literal["ILL", "POST", "CAROUSEL"]
 
@@ -318,46 +319,9 @@ def fetch_illustration(notion, illustration_page_id: str, cfg: dict) -> Illustra
         fname_str = f"{fname_str}.png"
 
     # --- Caption: earliest publishIG editorial row's `text IG` ---
-    caption = ""
-    publish_col = illust_cols["publish_relation"]
-    publish_rels = page.get("properties", {}).get(publish_col, {}).get("relation", []) or []
-
-    if publish_rels:
-        candidates: list[tuple[str, str]] = []
-        for rel in publish_rels:
-            rel_id = rel.get("id")
-            if not rel_id:
-                continue
-            try:
-                ed_page = retrieve_page(notion, rel_id)
-            except Exception as err:
-                logger.warning("⚠️ could not fetch %s for publishIG resolution: %s", rel_id, err)
-                continue
-            day_str = get_field(ed_page, "title_day", ed_cols) or ""
-            text = get_field(ed_page, "caption_text", ed_cols) or ""
-            day_str = str(day_str).strip()
-            text = str(text).strip()
-            if day_str:
-                candidates.append((day_str, text))
-
-        candidates.sort(key=lambda x: x[0])  # YYYYMMDD lex = chronological
-        for day_str, text in candidates:
-            if text:
-                caption = text
-                logger.info(
-                    "📝 caption from earliest publishIG row (%s): %d chars",
-                    day_str, len(caption),
-                )
-                break
-
-    if not caption:
-        fallback_text = get_field(page, "caption_fallback", illust_cols) or ""
-        caption = str(fallback_text).strip()
-        if caption:
-            logger.warning(
-                "⚠️ publishIG yielded no caption — falling back to '%s' formula (%d chars)",
-                illust_cols["caption_fallback"], len(caption),
-            )
+    caption = canonical_caption_from_publish_ig(
+        notion, illustration_page_id, illust_cols, ed_cols, logger, page=page
+    )
 
     return IllustrationData(
         image_filename=fname_str,

--- a/planning/substack/bootstrap_session.py
+++ b/planning/substack/bootstrap_session.py
@@ -3,28 +3,21 @@
 Usage:
     python -m substack.bootstrap_session [--debug]
 
-Launches **real Chrome** (channel="chrome") pointed at the project-local profile
-directory configured as ``substack.user_data_dir`` (default:
-``substack/chrome_user_data/``). The user's regular Chrome profile is **not
-touched**: a separate, dedicated on-disk directory is created by Playwright
-under the repo, and Chrome writes its session cookies there.
-
 After login the dedicated profile retains the session, so subsequent runs of
 ``post_substack_note`` (and ``reporting/scrape_client/substack.py``) reuse it
-without prompting.
+without prompting. See ``planning._bootstrap.run_bootstrap`` for the shared
+implementation (mirror of ``instagram/bootstrap_session.py``,
+``twitter/bootstrap_session.py``, ``threads/bootstrap_session.py``,
+``linkedin/bootstrap_session.py``).
 """
 
 from __future__ import annotations
 
-import argparse
-import logging
 import sys
 from pathlib import Path
 
-from playwright.sync_api import sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from planning._bootstrap import parse_bootstrap_args, run_bootstrap  # noqa: E402
 from planning.substack.substack_session import (  # noqa: E402
     _resolve_user_data_dir,
     configure_logger,
@@ -33,45 +26,24 @@ from planning.substack.substack_session import (  # noqa: E402
 
 SIGN_IN_URL = "https://substack.com/sign-in"
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="One-time Substack session bootstrap.")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+LOGIN_PROMPT = (
+    "\n>>> Log in inside the opened Chrome window, "
+    "then press Enter here to save the session...\n"
+)
 
 
 def main() -> int:
-    args = parse_args()
-    logger = configure_logger("substack_bootstrap", debug=args.debug)
-
-    cfg = load_substack_config()
-    user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-    user_data_dir.mkdir(parents=True, exist_ok=True)
-
-    logger.info("🚀 Substack session bootstrap")
-    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
-    logger.info("   (this is SEPARATE from your normal Chrome profile)")
-
-    with sync_playwright() as pw:
-        context = pw.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(user_data_dir), headless=False),
-        )
-        context.add_init_script(STEALTH_INIT_SCRIPT)
-        page = context.pages[0] if context.pages else context.new_page()
-        page.goto(SIGN_IN_URL, wait_until="domcontentloaded")
-        # Intentional print (the issue allows this single bootstrap pause).
-        print("\n>>> Log in inside the opened Chrome window, then press Enter here to save the session...\n")
-        try:
-            input()
-        except KeyboardInterrupt:
-            logger.warning("❌ Bootstrap cancelled before login.")
-            context.close()
-            return 2
-
-        # Persistent context flushes the profile to disk on close.
-        context.close()
-        logger.info("✅ Chrome profile saved → %s", user_data_dir)
-    return 0
+    args = parse_bootstrap_args("One-time Substack session bootstrap.")
+    return run_bootstrap(
+        platform_label="Substack",
+        logger_name="substack_bootstrap",
+        load_config=load_substack_config,
+        resolve_user_data_dir=_resolve_user_data_dir,
+        configure_logger=configure_logger,
+        default_login_url=SIGN_IN_URL,
+        login_prompt=LOGIN_PROMPT,
+        debug=args.debug,
+    )
 
 
 if __name__ == "__main__":

--- a/planning/threads/bootstrap_session.py
+++ b/planning/threads/bootstrap_session.py
@@ -3,27 +3,18 @@
 Usage:
     python -m threads.bootstrap_session [--debug]
 
-Launches **real Chrome** (channel="chrome") pointed at the project-local
-profile directory configured as ``threads.user_data_dir`` (default:
-``threads/chrome_user_data/``). The user's regular Chrome profile is **not
-touched**: a separate, dedicated on-disk directory is created by Playwright
-under the repo, and Chrome writes its session cookies there.
-
-After login the dedicated profile retains the session, so subsequent runs of
-``schedule_threads_posts`` reuse it without prompting. Mirror of
-``instagram/bootstrap_session.py``.
+See ``planning._bootstrap.run_bootstrap`` for the shared implementation
+(mirror of ``instagram/bootstrap_session.py``, ``twitter/bootstrap_session.py``,
+``linkedin/bootstrap_session.py``, ``substack/bootstrap_session.py``).
 """
 
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 
-from playwright.sync_api import sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from planning._bootstrap import parse_bootstrap_args, run_bootstrap  # noqa: E402
 from planning.threads.threads_session import (  # noqa: E402
     _resolve_user_data_dir,
     configure_logger,
@@ -32,51 +23,26 @@ from planning.threads.threads_session import (  # noqa: E402
 
 LOGIN_URL_DEFAULT = "https://www.threads.com/@ferraroroberto"
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="One-time Threads session bootstrap.")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+LOGIN_PROMPT = (
+    "\n>>> Log in to Threads inside the opened Chrome window.\n"
+    "    (Threads authenticates via Instagram, so you may need to sign in there too.)\n"
+    "    Once you can see your profile feed at threads.com/@ferraroroberto,\n"
+    "    return here and press Enter to save the session...\n"
+)
 
 
 def main() -> int:
-    args = parse_args()
-    logger = configure_logger("threads_bootstrap", debug=args.debug)
-
-    cfg = load_threads_config()
-    user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-    user_data_dir.mkdir(parents=True, exist_ok=True)
-
-    login_url = cfg.get("login_url", LOGIN_URL_DEFAULT)
-
-    logger.info("🚀 Threads session bootstrap")
-    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
-    logger.info("   (this is SEPARATE from your normal Chrome profile)")
-
-    with sync_playwright() as pw:
-        context = pw.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(user_data_dir), headless=False),
-        )
-        context.add_init_script(STEALTH_INIT_SCRIPT)
-        page = context.pages[0] if context.pages else context.new_page()
-        page.goto(login_url, wait_until="domcontentloaded")
-        # Intentional print (the bootstrap pause is the one place this is OK).
-        print(
-            "\n>>> Log in to Threads inside the opened Chrome window.\n"
-            "    (Threads authenticates via Instagram, so you may need to sign in there too.)\n"
-            "    Once you can see your profile feed at threads.com/@ferraroroberto,\n"
-            "    return here and press Enter to save the session...\n"
-        )
-        try:
-            input()
-        except KeyboardInterrupt:
-            logger.warning("❌ Bootstrap cancelled before login.")
-            context.close()
-            return 2
-
-        context.close()
-        logger.info("✅ Chrome profile saved → %s", user_data_dir)
-    return 0
+    args = parse_bootstrap_args("One-time Threads session bootstrap.")
+    return run_bootstrap(
+        platform_label="Threads",
+        logger_name="threads_bootstrap",
+        load_config=load_threads_config,
+        resolve_user_data_dir=_resolve_user_data_dir,
+        configure_logger=configure_logger,
+        default_login_url=LOGIN_URL_DEFAULT,
+        login_prompt=LOGIN_PROMPT,
+        debug=args.debug,
+    )
 
 
 if __name__ == "__main__":

--- a/planning/twitter/bootstrap_session.py
+++ b/planning/twitter/bootstrap_session.py
@@ -3,27 +3,18 @@
 Usage:
     python -m twitter.bootstrap_session [--debug]
 
-Launches **real Chrome** (channel="chrome") pointed at the project-local
-profile directory configured as ``twitter.user_data_dir`` (default:
-``twitter/chrome_user_data/``). The user's regular Chrome profile is **not
-touched**: a separate, dedicated on-disk directory is created by Playwright
-under the repo, and Chrome writes its session cookies there.
-
-After login the dedicated profile retains the session, so subsequent runs of
-``schedule_twitter_posts`` reuse it without prompting. Mirror of
-``instagram/bootstrap_session.py``.
+See ``planning._bootstrap.run_bootstrap`` for the shared implementation
+(mirror of ``instagram/bootstrap_session.py``, ``threads/bootstrap_session.py``,
+``linkedin/bootstrap_session.py``, ``substack/bootstrap_session.py``).
 """
 
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 
-from playwright.sync_api import sync_playwright
-
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.chrome_launch import STEALTH_INIT_SCRIPT, stealth_launch_kwargs  # noqa: E402
+from planning._bootstrap import parse_bootstrap_args, run_bootstrap  # noqa: E402
 from planning.twitter.twitter_session import (  # noqa: E402
     _resolve_user_data_dir,
     configure_logger,
@@ -32,50 +23,25 @@ from planning.twitter.twitter_session import (  # noqa: E402
 
 LOGIN_URL_DEFAULT = "https://x.com/home"
 
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="One-time X (Twitter) session bootstrap.")
-    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+LOGIN_PROMPT = (
+    "\n>>> Log in to X inside the opened Chrome window.\n"
+    "    Once you can see the home feed at x.com/home,\n"
+    "    return here and press Enter to save the session...\n"
+)
 
 
 def main() -> int:
-    args = parse_args()
-    logger = configure_logger("twitter_bootstrap", debug=args.debug)
-
-    cfg = load_twitter_config()
-    user_data_dir = _resolve_user_data_dir(cfg["user_data_dir"])
-    user_data_dir.mkdir(parents=True, exist_ok=True)
-
-    login_url = cfg.get("login_url", LOGIN_URL_DEFAULT)
-
-    logger.info("🚀 X (Twitter) session bootstrap")
-    logger.info("📁 Dedicated Chrome profile directory: %s", user_data_dir)
-    logger.info("   (this is SEPARATE from your normal Chrome profile)")
-
-    with sync_playwright() as pw:
-        context = pw.chromium.launch_persistent_context(
-            **stealth_launch_kwargs(str(user_data_dir), headless=False),
-        )
-        context.add_init_script(STEALTH_INIT_SCRIPT)
-        page = context.pages[0] if context.pages else context.new_page()
-        page.goto(login_url, wait_until="domcontentloaded")
-        # Intentional print (the bootstrap pause is the one place this is OK).
-        print(
-            "\n>>> Log in to X inside the opened Chrome window.\n"
-            "    Once you can see the home feed at x.com/home,\n"
-            "    return here and press Enter to save the session...\n"
-        )
-        try:
-            input()
-        except KeyboardInterrupt:
-            logger.warning("❌ Bootstrap cancelled before login.")
-            context.close()
-            return 2
-
-        context.close()
-        logger.info("✅ Chrome profile saved → %s", user_data_dir)
-    return 0
+    args = parse_bootstrap_args("One-time X (Twitter) session bootstrap.")
+    return run_bootstrap(
+        platform_label="X (Twitter)",
+        logger_name="twitter_bootstrap",
+        load_config=load_twitter_config,
+        resolve_user_data_dir=_resolve_user_data_dir,
+        configure_logger=configure_logger,
+        default_login_url=LOGIN_URL_DEFAULT,
+        login_prompt=LOGIN_PROMPT,
+        debug=args.debug,
+    )
 
 
 if __name__ == "__main__":

--- a/reporting/notion/_client.py
+++ b/reporting/notion/_client.py
@@ -11,8 +11,10 @@ The logger is configured at import (mirroring ``supabase_uploader.py``) so
 regardless of which caller imports it.
 """
 
-from typing import Any
+from typing import Any, Optional
+import json
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -20,6 +22,7 @@ from notion_client import Client
 
 # Add the repo root to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
+from config.loader import load_full_config
 from config.logger_config import setup_logger
 
 # Set up logger - will use existing logger if available
@@ -39,6 +42,63 @@ def init_notion_client(api_token):
     except Exception as e:
         logger.error(f"❌ Error initializing Notion client: {e}")
         return None
+
+
+def load_project_config(config_path: Optional[str] = None,
+                        logger: Optional[logging.Logger] = None) -> dict:
+    """Load project config from JSON file.
+
+    With no override, reads through ``config.loader`` (the project's
+    single-source loader) so the default path stays in exactly one place.
+    An explicit ``config_path`` reads that file directly instead — used by
+    CLI tools' ``--config`` flag. Single-source for what was a byte-identical
+    ``_load_config`` copy in ``notion_database_list.NotionDatabaseLister``
+    and ``notion_supabase_sync.NotionSupabaseSync``.
+    """
+    log = logger or logging.getLogger(__name__)
+    if config_path is None:
+        log.debug("📂 Loading configuration via config.loader (config/config.json)")
+        config = load_full_config()
+        log.info("✅ Configuration loaded successfully")
+        return config
+
+    log.debug(f"📂 Loading configuration from {config_path}")
+
+    if not os.path.exists(config_path):
+        log.error(f"❌ Configuration file not found: {config_path}")
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    log.info("✅ Configuration loaded successfully")
+    return config
+
+
+def notion_rest_headers(api_token: str) -> dict:
+    """Standard Notion REST API headers for the hand-rolled ``requests``
+    callers (``notion_database_list.py``, ``notion_supabase_sync.py``) that
+    predate the official SDK client used elsewhere in this package."""
+    return {
+        "Authorization": f"Bearer {api_token}",
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28",
+    }
+
+
+def slugify_identifier(name: str) -> str:
+    """Lowercase + replace non-alnum/underscore characters with ``_``,
+    collapsing repeats. Shared first pass for the DB-name → table-name
+    (``notion_database_list._normalize_table_name``) and property-name →
+    column-name (``notion_supabase_sync._normalize_column_name``)
+    normalizers, which then apply their own digit-prefix and
+    case-specific empty-string fallback.
+    """
+    normalized = name.lower().strip()
+    normalized = "".join(c if c.isalnum() or c == "_" else "_" for c in normalized)
+    while "__" in normalized:
+        normalized = normalized.replace("__", "_")
+    return normalized
 
 
 def format_database_id(database_id):

--- a/reporting/notion/notion_database_list.py
+++ b/reporting/notion/notion_database_list.py
@@ -10,8 +10,12 @@ from dotenv import load_dotenv
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.loader import load_full_config
 from config.logger_config import setup_logger
+from reporting.notion._client import (
+    load_project_config,
+    notion_rest_headers,
+    slugify_identifier,
+)
 
 # Set up logger - will use existing logger if available
 logger = logging.getLogger("notion_database_list")
@@ -24,40 +28,11 @@ class NotionDatabaseLister:
     
     def __init__(self, config_path: str = None):
         """Initialize with configuration."""
-        self.config = self._load_config(config_path)
+        self.config = load_project_config(config_path, logger=logger)
         self.notion_token = self.config["notion"]["api_token"]
-        self.headers = {
-            "Authorization": f"Bearer {self.notion_token}",
-            "Content-Type": "application/json",
-            "Notion-Version": "2022-06-28"
-        }
-        
-    def _load_config(self, config_path: str = None) -> dict:
-        """Load configuration from JSON file.
+        self.headers = notion_rest_headers(self.notion_token)
 
-        With no override, reads through ``config.loader`` (the project's
-        single-source loader) so the default path stays in exactly one place.
-        The ``--config`` override still reads its own path directly, since
-        that's not something ``config.loader`` supports.
-        """
-        if config_path is None:
-            logger.debug("📂 Loading configuration via config.loader (config/config.json)")
-            config = load_full_config()
-            logger.info("✅ Configuration loaded successfully")
-            return config
 
-        logger.debug(f"📂 Loading configuration from {config_path}")
-
-        if not os.path.exists(config_path):
-            logger.error(f"❌ Configuration file not found: {config_path}")
-            raise FileNotFoundError(f"Configuration file not found: {config_path}")
-
-        with open(config_path, 'r') as f:
-            config = json.load(f)
-
-        logger.info("✅ Configuration loaded successfully")
-        return config
-    
     def _search_databases(self, start_cursor: str = None) -> Dict[str, Any]:
         """Search for all databases using Notion API."""
         url = "https://api.notion.com/v1/search"
@@ -83,12 +58,7 @@ class NotionDatabaseLister:
     
     def _normalize_table_name(self, name: str) -> str:
         """Normalize database name to valid PostgreSQL table name."""
-        # Convert to lowercase and replace spaces/special chars with underscores
-        normalized = name.lower().strip()
-        normalized = "".join(c if c.isalnum() or c == "_" else "_" for c in normalized)
-        # Remove consecutive underscores
-        while "__" in normalized:
-            normalized = normalized.replace("__", "_")
+        normalized = slugify_identifier(name)
         # Ensure it doesn't start with a number
         if normalized and normalized[0].isdigit():
             normalized = f"table_{normalized}"

--- a/reporting/notion/notion_supabase_sync.py
+++ b/reporting/notion/notion_supabase_sync.py
@@ -13,9 +13,13 @@ from dotenv import load_dotenv
 
 # Add the parent directory to sys.path to allow importing from sibling packages
 sys.path.append(str(Path(__file__).parent.parent.parent))
-from config.loader import load_full_config
 from config.logger_config import setup_logger
-from reporting.notion._client import extract_property_value
+from reporting.notion._client import (
+    extract_property_value,
+    load_project_config,
+    notion_rest_headers,
+    slugify_identifier,
+)
 from reporting.process.supabase_uploader import get_db_connection, load_db_config
 
 # Set up logger - will use existing logger if available
@@ -29,47 +33,17 @@ class NotionSupabaseSync:
     def __init__(self, config_path: str = None, environment: str = "cloud", database_list_path: str = None):  # type: ignore
         """Initialize the sync with configuration."""
         self.environment = environment
-        self.config = self._load_config(config_path)
+        self.config = load_project_config(config_path, logger=logger)
         self.notion_token = self.config["notion"]["api_token"]
         self.poll_every = self.config["notion"]["poll_every"]
         self.page_size = self.config["notion"]["page_size"]
-        
+
         # Load databases from notion_database_list.json
         self.databases = self._load_database_list(database_list_path)
-        
-        self.headers = {
-            "Authorization": f"Bearer {self.notion_token}",
-            "Content-Type": "application/json",
-            "Notion-Version": "2022-06-28"
-        }
+
+        self.headers = notion_rest_headers(self.notion_token)
         self.last_sync_times = {}  # Track last sync time per database
-        
-    def _load_config(self, config_path: str = None) -> dict:  # type: ignore
-        """Load configuration from JSON file.
 
-        With no override, reads through ``config.loader`` (the project's
-        single-source loader) so the default path stays in exactly one place.
-        The ``--config`` override still reads its own path directly, since
-        that's not something ``config.loader`` supports.
-        """
-        if config_path is None:
-            logger.debug("📂 Loading configuration via config.loader (config/config.json)")
-            config = load_full_config()
-            logger.info("✅ Configuration loaded successfully")
-            return config
-
-        logger.debug(f"📂 Loading configuration from {config_path}")
-
-        if not os.path.exists(config_path):
-            logger.error(f"❌ Configuration file not found: {config_path}")
-            raise FileNotFoundError(f"Configuration file not found: {config_path}")
-
-        with open(config_path, 'r') as f:
-            config = json.load(f)
-
-        logger.info("✅ Configuration loaded successfully")
-        return config
-    
     def _load_database_list(self, database_list_path: str = None) -> List[dict]:  # type: ignore
         """Load database list from JSON file and filter by replication status."""
         if database_list_path is None:
@@ -151,12 +125,7 @@ class NotionSupabaseSync:
 
     def _normalize_column_name(self, name: str) -> str:
         """Normalize Notion property names to valid PostgreSQL column names."""
-        # Replace spaces and special characters with underscores
-        normalized = name.lower().strip()
-        normalized = "".join(c if c.isalnum() or c == "_" else "_" for c in normalized)
-        # Remove consecutive underscores
-        while "__" in normalized:
-            normalized = normalized.replace("__", "_")
+        normalized = slugify_identifier(name)
         # Ensure it doesn't start with a number
         if normalized and normalized[0].isdigit():
             normalized = f"col_{normalized}"

--- a/reporting/notion/notion_update.py
+++ b/reporting/notion/notion_update.py
@@ -45,25 +45,13 @@ def parse_date(date_str):
         logger.error(f"❌ Error parsing date '{date_str}': {e}")
         raise
 
-def search_by_date(notion, database_id, target_date):
-    """Search for a row in the database where the 'date' field matches the day before target date."""
+def find_row_for_date(notion, database_id, iso_date):
+    """Query the database for the row whose 'date' field equals `iso_date`
+    (YYYY-MM-DD). Single-source lookup shared by `search_by_date`,
+    `search_by_current_date`, and the next-day 'next' relation lookup below —
+    each previously hand-rolled its own copy of this query."""
     try:
-        # Convert the input date to a datetime object
-        date_obj = parse_date(target_date)
-        
-        # Calculate previous day
-        prev_date_obj = date_obj - timedelta(days=1)
-        prev_date_str = prev_date_obj.strftime("%Y-%m-%d")
-        
-        logger.debug(f"🔍 Searching for previous date: {prev_date_str} (day before {target_date})")
-        
-        # Format the database ID if needed
         formatted_id = format_database_id(database_id)
-        
-        # Convert to ISO format (YYYY-MM-DD)
-        iso_date = prev_date_obj.strftime("%Y-%m-%d")
-        
-        # Query the database with date filter
         response = notion.databases.query(
             database_id=formatted_id,
             filter={
@@ -73,19 +61,37 @@ def search_by_date(notion, database_id, target_date):
                 }
             }
         )
-        
+
         results = response.get('results', [])
-        
+
         if not results:
-            logger.warning(f"⚠️ No rows found for previous date: {prev_date_str}")
+            logger.warning(f"⚠️ No rows found for date: {iso_date}")
             return None
-        
+
         if len(results) > 1:
-            logger.warning(f"⚠️ Multiple rows found for previous date: {prev_date_str}. Using the first one.")
-        
-        logger.info(f"✅ Found row for previous date: {prev_date_str}")
+            logger.warning(f"⚠️ Multiple rows found for date: {iso_date}. Using the first one.")
+
+        logger.info(f"✅ Found row for date: {iso_date}")
         return results[0]
-    
+
+    except Exception as e:
+        logger.error(f"❌ Error searching by date: {e}")
+        return None
+
+def search_by_date(notion, database_id, target_date):
+    """Search for a row in the database where the 'date' field matches the day before target date."""
+    try:
+        # Convert the input date to a datetime object
+        date_obj = parse_date(target_date)
+
+        # Calculate previous day
+        prev_date_obj = date_obj - timedelta(days=1)
+        iso_date = prev_date_obj.strftime("%Y-%m-%d")
+
+        logger.debug(f"🔍 Searching for previous date: {iso_date} (day before {target_date})")
+
+        return find_row_for_date(notion, database_id, iso_date)
+
     except Exception as e:
         logger.error(f"❌ Error searching by date: {e}")
         return None
@@ -95,38 +101,13 @@ def search_by_current_date(notion, database_id, target_date):
     try:
         # Convert the input date to a datetime object
         date_obj = parse_date(target_date)
-        
-        logger.debug(f"🔍 Searching for current date: {target_date}")
-        
-        # Format the database ID if needed
-        formatted_id = format_database_id(database_id)
-        
-        # Convert to ISO format (YYYY-MM-DD)
+
         iso_date = date_obj.strftime("%Y-%m-%d")
-        
-        # Query the database with date filter
-        response = notion.databases.query(
-            database_id=formatted_id,
-            filter={
-                "property": "date",
-                "date": {
-                    "equals": iso_date
-                }
-            }
-        )
-        
-        results = response.get('results', [])
-        
-        if not results:
-            logger.warning(f"⚠️ No rows found for current date: {target_date}")
-            return None
-        
-        if len(results) > 1:
-            logger.warning(f"⚠️ Multiple rows found for current date: {target_date}. Using the first one.")
-        
-        logger.info(f"✅ Found row for current date: {target_date}")
-        return results[0]
-    
+
+        logger.debug(f"🔍 Searching for current date: {target_date}")
+
+        return find_row_for_date(notion, database_id, iso_date)
+
     except Exception as e:
         logger.error(f"❌ Error searching by current date: {e}")
         return None
@@ -578,16 +559,12 @@ def main():
     next_day_obj = date_obj + timedelta(days=1)
     next_day_iso = next_day_obj.strftime("%Y-%m-%d")
     logger.debug(f"🔍 Looking up next-day row for {next_day_iso}")
-    next_day_response = notion.databases.query(
-        database_id=format_database_id(database_id),
-        filter={"property": "date", "date": {"equals": next_day_iso}},
-    )
-    next_day_results = next_day_response.get('results', [])
+    next_day_row = find_row_for_date(notion, database_id, next_day_iso)
 
-    if not next_day_results:
+    if not next_day_row:
         logger.warning(f"⚠️ No row found for next day ({next_day_iso}); 'next' will be skipped")
     else:
-        next_day_page_id = next_day_results[0].get('id', '')
+        next_day_page_id = next_day_row.get('id', '')
         current_next_relation = current_properties.get('next', {}).get('relation', [])
         current_next_id = current_next_relation[0].get('id', '') if current_next_relation else None
 

--- a/reporting/social_client/social_api_client.py
+++ b/reporting/social_client/social_api_client.py
@@ -61,11 +61,15 @@ def check_file_exists_for_date(platform_key, config, date_str):
         logger.info(f"🔄 Found existing file for {platform_key} dated {date_str}: {filename}")
     return exists, file_path
 
-def _fetch_via_playwright(platform_key, reference_date):
-    """Delegate to the per-platform scraper in ``reporting.scrape_client``.
+def _fetch_via_module(module_suffix, label, platform_key, reference_date):
+    """Delegate to a per-platform fetcher module in ``reporting.scrape_client``.
 
-    ``platform_key`` is e.g. ``"linkedin_profile"`` → calls
-    ``reporting.scrape_client.linkedin.fetch_profile(reference_date)``.
+    ``platform_key`` is e.g. ``"linkedin_profile"`` → module
+    ``reporting.scrape_client.linkedin{module_suffix}``, function
+    ``fetch_profile(reference_date)``. Shared implementation for
+    ``_fetch_via_playwright`` (``module_suffix=""``) and ``_fetch_via_native``
+    (``module_suffix="_native"``) — the two previously differed only in that
+    suffix and a log emoji.
     """
     parts = platform_key.split('_', 1)
     if len(parts) != 2:
@@ -73,53 +77,37 @@ def _fetch_via_playwright(platform_key, reference_date):
         return None
     platform, data_type = parts
     fn_name = f"fetch_{data_type}"
+    module_name = f"reporting.scrape_client.{platform}{module_suffix}"
     try:
-        module = importlib.import_module(f"reporting.scrape_client.{platform}")
+        module = importlib.import_module(module_name)
     except ImportError as err:
-        logger.error(f"❌ No Playwright scraper module for {platform!r}: {err}")
+        logger.error(f"❌ No {label} module for {platform!r}: {err}")
         return None
     fn = getattr(module, fn_name, None)
     if fn is None:
-        logger.error(f"❌ Playwright scraper {platform!r} has no {fn_name}()")
+        logger.error(f"❌ {label} fetcher {platform!r} has no {fn_name}()")
         return None
-    logger.info(f"🌐 Scraping {platform_key} via Playwright")
+    logger.info(f"🌐 Fetching {platform_key} via {label}")
     try:
         return fn(reference_date)
     except Exception as err:
-        logger.error(f"❌ Playwright scrape of {platform_key} failed: {err}", exc_info=True)
+        logger.error(f"❌ {label} fetch of {platform_key} failed: {err}", exc_info=True)
         return None
+
+
+def _fetch_via_playwright(platform_key, reference_date):
+    """Delegate to the per-platform Playwright scraper in ``reporting.scrape_client``."""
+    return _fetch_via_module("", "Playwright", platform_key, reference_date)
 
 
 def _fetch_via_native(platform_key, reference_date):
     """Delegate to the per-platform native-API fetcher in ``reporting.scrape_client``.
 
-    ``platform_key`` is e.g. ``"substack_profile"`` → calls
-    ``reporting.scrape_client.substack_native.fetch_profile(reference_date)``.
     The native fetchers hit the platform's own HTTP API directly (cookie auth);
     they return the same envelope as the Playwright scrapers, so they are drop-in
     interchangeable via the ``source`` config flag.
     """
-    parts = platform_key.split('_', 1)
-    if len(parts) != 2:
-        logger.error(f"❌ Cannot dispatch {platform_key!r} — expected '<platform>_<data_type>'")
-        return None
-    platform, data_type = parts
-    fn_name = f"fetch_{data_type}"
-    try:
-        module = importlib.import_module(f"reporting.scrape_client.{platform}_native")
-    except ImportError as err:
-        logger.error(f"❌ No native-API fetcher module for {platform!r}: {err}")
-        return None
-    fn = getattr(module, fn_name, None)
-    if fn is None:
-        logger.error(f"❌ Native fetcher {platform!r} has no {fn_name}()")
-        return None
-    logger.info(f"🔌 Fetching {platform_key} via native API")
-    try:
-        return fn(reference_date)
-    except Exception as err:
-        logger.error(f"❌ Native API fetch of {platform_key} failed: {err}", exc_info=True)
-        return None
+    return _fetch_via_module("_native", "native API", platform_key, reference_date)
 
 
 # Retries for the playwright/native scrape sources, run between attempts. A

--- a/tests/test_agent_skill_mirrors_in_sync.py
+++ b/tests/test_agent_skill_mirrors_in_sync.py
@@ -1,0 +1,60 @@
+"""Regression test: the `.claude/skills/<name>/SKILL.md` files that also ship
+a hand-maintained `.agents/skills/<name>/SKILL.md` mirror (for Codex/Pi, which
+don't read `.claude/`) must stay byte-identical.
+
+Filed as issue #242 finding: `.agents/skills/schedule-autoheal/SKILL.md` had
+silently diverged from its `.claude/` counterpart (description frontmatter, a
+selector-anchoring warning, and the Slack-bot rationale all differed), so a
+Codex/Pi session was reading stale prose with no signal anything was wrong.
+
+Run: & .\\.venv\\Scripts\\python.exe -m unittest discover tests -v
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLAUDE_SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+AGENTS_SKILLS_DIR = REPO_ROOT / ".agents" / "skills"
+
+
+def _mirrored_skill_names() -> list[str]:
+    """Every skill name present under both `.claude/skills/` and `.agents/skills/`."""
+    if not CLAUDE_SKILLS_DIR.is_dir() or not AGENTS_SKILLS_DIR.is_dir():
+        return []
+    claude_names = {p.name for p in CLAUDE_SKILLS_DIR.iterdir() if p.is_dir()}
+    agents_names = {p.name for p in AGENTS_SKILLS_DIR.iterdir() if p.is_dir()}
+    return sorted(claude_names & agents_names)
+
+
+class AgentSkillMirrorsInSyncTests(unittest.TestCase):
+    def test_at_least_one_mirrored_pair_exists(self):
+        # Guards against the discovery helper silently finding nothing (e.g.
+        # a directory layout change) and every test below vacuously passing.
+        self.assertTrue(
+            _mirrored_skill_names(),
+            "Expected at least one skill present under both .claude/skills/ "
+            "and .agents/skills/ — check the directory layout.",
+        )
+
+    def test_mirrored_skill_md_pairs_are_byte_identical(self):
+        for name in _mirrored_skill_names():
+            claude_path = CLAUDE_SKILLS_DIR / name / "SKILL.md"
+            agents_path = AGENTS_SKILLS_DIR / name / "SKILL.md"
+            with self.subTest(skill=name):
+                self.assertTrue(claude_path.is_file(), f"Missing {claude_path}")
+                self.assertTrue(agents_path.is_file(), f"Missing {agents_path}")
+                claude_text = claude_path.read_text(encoding="utf-8")
+                agents_text = agents_path.read_text(encoding="utf-8")
+                self.assertEqual(
+                    claude_text, agents_text,
+                    f".claude/skills/{name}/SKILL.md and .agents/skills/{name}/SKILL.md "
+                    "have diverged — keep the Codex/Pi mirror byte-identical to the "
+                    "Claude source (issue #242).",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Eight duplication findings from `/codebase-audit` (#242) collapsed onto single implementations, so a future behavior fix lands once instead of needing to be hunted down across every clone:

- `planning/instagram/schedule_instagram_posts.py` now imports its date helpers from `planning._dates` instead of a verbatim local copy.
- New `planning/_captions.py` holds the publishIG canonical-caption walk, shared by `clone_to_other_platforms.py` and `schedule_linkedin_posts.py` instead of a "kept local to avoid an import" duplicate.
- New `planning/_bootstrap.py::run_bootstrap` collapses the five near-identical per-platform Chrome-profile bootstrap scripts into one implementation plus thin `main()` shims.
- newsletter's three hand-rolled `requests`-based Notion clients (`build_newsletter.NotionClient`, `normalize_names.NotionNameNormalizer`, `normalize_url.NotionURLNormalizer`) now route through `notion_io`'s official-SDK client + retried `query_database`/`update_page` helpers, so a transient Notion error no longer breaks three paths that used to have no retry at all. Their four copy-pasted `_setup_logging` helpers move to `config.logger_config.configure_root_logging`.
- `reporting/notion/notion_update.py`'s `search_by_date`, `search_by_current_date`, and an inline third copy of the same date query now share one `find_row_for_date`.
- `reporting/notion/_client.py` gains `load_project_config`, `notion_rest_headers`, and `slugify_identifier`, replacing a byte-identical `_load_config` and near-identical name normalizer duplicated across `notion_database_list.py` and `notion_supabase_sync.py`.
- `reporting/social_client/social_api_client.py`'s `_fetch_via_playwright` and `_fetch_via_native` now delegate to one `_fetch_via_module`.
- `.agents/skills/schedule-autoheal/SKILL.md` had silently diverged from its `.claude/` source; re-synced and added a regression test asserting every mirrored SKILL.md pair stays byte-identical.

## Validation

- `& .\.venv\Scripts\python.exe -m pytest tests -v` → 259 passed, 1 skipped, **1 failed**: `tests/test_triage_criteria.py::CriteriaTests::test_owner_overrides_are_merged`. Confirmed pre-existing and unrelated — reproduces identically on a clean `main` checkout, and none of this diff's changed files touch `newsletter/triage/`. Already tracked separately as #252.
- e2e: n/a — no e2e suite in this repo; diff is backend-only, touching no Streamlit UI surface.
- UX-conformance gate: n/a — `SPEC_APPLIES=no` / `TOUCHED=no`.

Closes #242
