### PR TITLE
fix: close 7 audit-found bug findings across reporting/planning/engagement

### DIFF
--- a/engagement/check_review_app.py
+++ b/engagement/check_review_app.py
@@ -56,6 +56,17 @@ def _count_pending() -> int:
     return res.count or 0
 
 
+def _approved_keys() -> set[tuple[str, str]]:
+    """``(platform, comment_id)`` — the table's own primary key (schema.sql:35)
+    — for every row currently ``status = 'approved'``. Used to diff before/after
+    the approve click so the idempotency rollback below can scope itself to
+    just the row(s) this click approved, instead of every approved row in the
+    table (issue #246)."""
+    sb = supabase_client()
+    rows = sb.table("comments").select("platform,comment_id").eq("status", "approved").execute().data or []
+    return {(r["platform"], r["comment_id"]) for r in rows}
+
+
 def _wait_for_streamlit(page: Page, timeout_ms: int = 15_000) -> None:
     """Streamlit renders client-side — wait for the run-toolbar OR the page title."""
     page.wait_for_load_state("networkidle", timeout=timeout_ms)
@@ -162,6 +173,7 @@ def run() -> int:
 
         print("\n📱 step 5 — approve action lowers pending count by 1")
         pending_before = _count_pending()
+        approved_before = _approved_keys()
         _click_tab(page, "AI triage")
         page.wait_for_timeout(500)
         approve_clicked = False
@@ -182,9 +194,20 @@ def run() -> int:
             else:
                 _fail("approve count delta", f"expected {pending_before - 1}, got {pending_after}")
                 fails += 1
-            # Roll back so the test is idempotent — re-run friendly.
+            # Roll back so the test is idempotent — re-run friendly. Scope to
+            # exactly the row(s) THIS click approved (the before/after diff on
+            # the table's own primary key), never a blanket
+            # `.eq("status", "approved")` — that would revert every row the
+            # owner has approved by hand in the review app, not just this
+            # check's own row (issue #246).
+            newly_approved = _approved_keys() - approved_before
             sb = supabase_client()
-            sb.table("comments").update({"status": "pending", "decided_at": None}).eq("status", "approved").execute()
+            if newly_approved:
+                for platform, comment_id in newly_approved:
+                    sb.table("comments").update({"status": "pending", "decided_at": None}) \
+                        .eq("platform", platform).eq("comment_id", comment_id).execute()
+            else:
+                print("     note: rollback skipped — could not identify which row(s) the click approved")
         else:
             _pass("approve button skipped — no AI-flagged rows to approve (expected on first run)")
 

--- a/engagement/db/schema.sql
+++ b/engagement/db/schema.sql
@@ -35,12 +35,14 @@ create table if not exists comments (
     decided_at          timestamptz,
     my_reply_text       text,                             -- if I (post author) already replied — captured at scrape time
     my_replied_at       timestamptz,                      -- approximate from LI relative timestamp
+    post_posted_at      timestamptz,                      -- the post's own publish time — feeds the sub_2_min rule (issue #246)
     primary key (platform, comment_id)
 );
 
 -- Idempotent column-adds for anyone who applied an earlier schema revision.
 alter table comments add column if not exists my_reply_text text;
 alter table comments add column if not exists my_replied_at timestamptz;
+alter table comments add column if not exists post_posted_at timestamptz;
 
 create index if not exists comments_status_idx     on comments (status, classification);
 create index if not exists comments_commenter_idx  on comments (platform, commenter_url);

--- a/engagement/linkedin/scrape_comments.py
+++ b/engagement/linkedin/scrape_comments.py
@@ -565,6 +565,7 @@ def scrape_post_comments(
                 "posted_at": rec.get("posted_at_iso"),
                 "my_reply_text": rec.get("my_reply_text"),
                 "my_replied_at": rec.get("my_replied_at_iso"),
+                "post_posted_at": post_posted_at,
             }
         )
         if account_url:
@@ -578,9 +579,6 @@ def scrape_post_comments(
             )
 
     logger.info("✅ %s — extracted %d comments", post_url, len(comments_rows))
-    # Stamp post_posted_at into each row's verdict_reasons-friendly side channel for the classifier.
-    for r in comments_rows:
-        r["_post_posted_at"] = post_posted_at  # consumed by classifier only; stripped before upsert
     return comments_rows, list(commenters_seen.values()), None
 
 

--- a/engagement/reputation/update.py
+++ b/engagement/reputation/update.py
@@ -148,14 +148,13 @@ def _aggregate(
 def recompute_for_platform(platform: str = "linkedin") -> dict:
     sb = supabase_client()
 
-    # Note: `post_posted_at` is a scrape-time side-channel (stripped before
-    # upsert) — it isn't a column in the `comments` table. The cadence
-    # "seconds after my post" signal will simply be absent until that gets
-    # backfilled; for now `_seconds_after` returns None and the median
-    # seconds + sub-2-min counter stay at zero, matching rules.py behaviour.
+    # `post_posted_at` is now a real column (schema.sql), persisted by the
+    # scraper alongside each comment (issue #246) — select it explicitly so
+    # the cadence "seconds after my post" signal and sub_2_min counter below
+    # aren't silently starved, matching rules.py.
     rows = (
         sb.table("comments")
-        .select("comment_id,commenter_url,display_name,text,post_url,posted_at,scraped_at,classification")
+        .select("comment_id,commenter_url,display_name,text,post_url,posted_at,post_posted_at,scraped_at,classification")
         .eq("platform", platform)
         .execute()
         .data

--- a/launch_reporting.bat
+++ b/launch_reporting.bat
@@ -126,9 +126,15 @@ echo ========================================
 echo.
 
 :END
-REM Keep the window open so the output can be inspected after the run.
+REM Keep the window open so the output can be inspected after an interactive
+REM run — but not under AUTO_MODE (scheduler / "cron-friendly" per README),
+REM where an unconditional pause would leave the process hung forever and its
+REM %RC% never observed (issue #246; launch_planning.bat already has this
+REM shape via its :EOL skip).
+if "%AUTO_MODE%"=="1" goto EOL
 echo Press any key to close this window...
 pause >nul
+:EOL
 
 REM Propagate the pipeline's exit code so the scheduler records a crashed
 REM run as failed. reporting_pipeline.py deliberately sys.exit(1)s on any

--- a/newsletter/triage/history.py
+++ b/newsletter/triage/history.py
@@ -99,6 +99,42 @@ def _norm(text: str) -> str:
 # 1. Gmail pull (incremental, cached HTML)
 
 
+def _reextract_from_cache(existing: Dict[str, gm.EmailRecord], raw_dir: Path, min_anchor: int) -> None:
+    """Re-run link extraction from cached HTML for every record in ``existing``
+    (mutated in place). Pure local file I/O — no mailbox, no network."""
+    if not existing:
+        return
+    logger.info("♻️ re-extracting links from %d cached HTML bodies", len(existing))
+    for mid, rec in existing.items():
+        gz = raw_dir / f"{mid}.html.gz"
+        if not gz.exists():
+            continue
+        with gzip.open(gz, "rt", encoding="utf-8") as fp:
+            html = fp.read()
+        rec.links = gm.links_from_html(html, min_anchor_chars=min_anchor)
+
+
+def reextract_cached(cfg: Dict[str, Any]) -> List[gm.EmailRecord]:
+    """Re-run link extraction from already-cached HTML only — no mailbox
+    build, no Gmail search, no network I/O at all.
+
+    Split out of ``pull_emails`` (issue #246): that function always calls
+    ``gm.build_mailbox(cfg)`` + ``label_search`` + ``search_ids`` even when
+    called with ``limit=0``, so the documented offline path
+    (``--no-gmail --reextract --budget 0``, "no new network" per the README)
+    raised ``FileNotFoundError`` on a missing Gmail token instead of touching
+    only the cached HTML it was meant to re-parse.
+    """
+    emails_path = HISTORY_DIR / "emails.jsonl"
+    raw_dir = HISTORY_DIR / "raw"
+    existing = {r["message_id"]: gm.EmailRecord.from_json(r) for r in _read_jsonl(emails_path)}
+    min_anchor = int(cfg.get("min_anchor_chars", gm.DEFAULT_MIN_ANCHOR_CHARS))
+    _reextract_from_cache(existing, raw_dir, min_anchor)
+    records = sorted(existing.values(), key=lambda r: r.timestamp)
+    _write_jsonl(emails_path, (r.to_json() for r in records))
+    return records
+
+
 def pull_emails(weeks: int, *, cfg: Dict[str, Any], reextract: bool = False,
                 limit: Optional[int] = None) -> List[gm.EmailRecord]:
     emails_path = HISTORY_DIR / "emails.jsonl"
@@ -107,15 +143,8 @@ def pull_emails(weeks: int, *, cfg: Dict[str, Any], reextract: bool = False,
     existing = {r["message_id"]: gm.EmailRecord.from_json(r) for r in _read_jsonl(emails_path)}
     min_anchor = int(cfg.get("min_anchor_chars", gm.DEFAULT_MIN_ANCHOR_CHARS))
 
-    if reextract and existing:
-        logger.info("♻️ re-extracting links from %d cached HTML bodies", len(existing))
-        for mid, rec in existing.items():
-            gz = raw_dir / f"{mid}.html.gz"
-            if not gz.exists():
-                continue
-            with gzip.open(gz, "rt", encoding="utf-8") as fp:
-                html = fp.read()
-            rec.links = gm.links_from_html(html, min_anchor_chars=min_anchor)
+    if reextract:
+        _reextract_from_cache(existing, raw_dir, min_anchor)
 
     tm = gm.build_mailbox(cfg)
     try:
@@ -580,9 +609,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
 
     if args.no_gmail:
-        records = [gm.EmailRecord.from_json(r) for r in _read_jsonl(HISTORY_DIR / "emails.jsonl")]
         if args.reextract:
-            records = pull_emails(weeks, cfg=cfg, reextract=True, limit=0)
+            records = reextract_cached(cfg)
+        else:
+            records = [gm.EmailRecord.from_json(r) for r in _read_jsonl(HISTORY_DIR / "emails.jsonl")]
         logger.info("📬 %d cached emails", len(records))
     else:
         records = pull_emails(weeks, cfg=cfg, reextract=args.reextract, limit=args.limit)

--- a/planning/threads/README.md
+++ b/planning/threads/README.md
@@ -76,7 +76,7 @@ from the IG side of the editorial DB. The scheduler only **reads** these
 | Calendar header | text-equals `<Month> <Year>` (e.g. `"May 2026"`) | Use for navigation + sanity-check. |
 | Calendar `>` (next month) | `aria-label="Next month"` (button) | Click until header matches target. |
 | Day cell | `[role="gridcell"]` (size ~28×28) — find via JS, walking from a leaf `<span>` with the day digit up to its nearest `[role="gridcell"]` ancestor | The span itself is inert; the React click handler is bound on the gridcell. |
-| Disambiguating duplicate day digits (e.g. `1` appears in both current and next month) | Pick lowest-lightness span color: today=255 (white text), current-month=0 (black text), grey-month=~150 | Current-month-non-today wins. |
+| Disambiguating duplicate day digits (e.g. `1` appears in both current and next month) | Pick lowest-lightness span color: today=255 (white text), current-month=0 (black text), grey-month=~150 — **except** when the target day is today: pick highest-lightness instead | Current-month-non-today wins on lowest; today wins on highest (its cell renders white, so there's no black candidate to prefer over the grey overflow cell). |
 | Time inputs | `input[placeholder="hh"]` and `input[placeholder="mm"]` | Two separate 24-hour inputs, zero-padded values. |
 | Calendar Done | `get_by_role("button", name=/^done$/i)` | Commits the calendar selection. |
 | Final Schedule action | `get_by_role("button", name=/^schedule$/i)` scoped to the dialog | Bottom-right of the dialog; replaces the `Post` button after Done. |
@@ -103,7 +103,11 @@ from the IG side of the editorial DB. The scheduler only **reads** these
    - today           → 255 (white on dark)
    - current month   → 0   (black on white)
    - prev/next month → ~150 (light grey)
-   Pick **lowest** lightness for current-month-non-today.
+   Pick **lowest** lightness for current-month-non-today — **except** when
+   the target day is today, where the current-month cell for that digit
+   renders white (not black), so there is no black candidate and "lowest"
+   would wrongly pick the grey overflow cell instead. Pick **highest**
+   lightness in that case (content-management#246).
 
 3. **The 3-dots button has no aria-label and no test-id.** The dialog
    header contains exactly 2 svg-only icon buttons (no text); the

--- a/planning/threads/schedule_threads_posts.py
+++ b/planning/threads/schedule_threads_posts.py
@@ -307,6 +307,7 @@ _CLICK_CAL_DAY_JS = r"""
 (args) => {
     const headerText = args.headerText;
     const dayText = args.dayText;
+    const isToday = args.isToday;
     // Verify the right month is showing (failsafe).
     const headerSeen = [...document.querySelectorAll('*')]
         .some(el => (el.innerText||'').trim() === headerText);
@@ -350,8 +351,16 @@ _CLICK_CAL_DAY_JS = r"""
     //   today           = WHITE text (rgb 255,255,255) inside a dark-pill bg → lightness ≈ 255
     //   current month   = BLACK text (rgb 0,0,0)                               → lightness ≈ 0
     //   prev/next month = LIGHT grey text                                     → lightness ≈ 150–200
-    // We want the BLACK one (current-month, not today). Pick lowest lightness.
-    cells.sort((a, b) => a.spanLightness - b.spanLightness);
+    // When the target IS today, the current-month cell for that digit renders
+    // WHITE (not black) — so the only candidates are today's white cell and a
+    // same-digit grey overflow cell, and "pick lowest" would wrongly grab the
+    // overflow cell. Flip direction based on isToday instead of always
+    // assuming black is the answer.
+    if (isToday) {
+        cells.sort((a, b) => b.spanLightness - a.spanLightness);
+    } else {
+        cells.sort((a, b) => a.spanLightness - b.spanLightness);
+    }
     cells[0].cell.click();
     return {
         ok: true,
@@ -368,13 +377,22 @@ def _click_calendar_day(page: Page, target: date) -> None:
 
     Calendar days are `<div role="gridcell">` wrappers whose accessible name
     is empty; the digit lives in nested ``<span>``s. Cells from the previous
-    and next months are also present but greyed out. JS picks the brightest
-    cell with matching text (current-month).
+    and next months are also present but greyed out. JS disambiguates
+    same-digit cells by text lightness: current-month-non-today is black
+    (lowest), the overflow cell is grey (middle), and today is white
+    (highest) — so it picks the *lowest* lightness cell normally, but the
+    *highest* when ``target`` is today (its current-month cell renders white,
+    not black, leaving no black candidate to prefer over the grey overflow
+    cell).
     """
     header_text = calendar_header(target)
     day_text = str(target.day)
+    is_today = target == date.today()
     try:
-        res = page.evaluate(_CLICK_CAL_DAY_JS, {"headerText": header_text, "dayText": day_text})
+        res = page.evaluate(
+            _CLICK_CAL_DAY_JS,
+            {"headerText": header_text, "dayText": day_text, "isToday": is_today},
+        )
     except Exception as err:
         raise RuntimeError(f"Calendar day JS picker failed: {err}")
     if not res or not res.get("ok"):

--- a/reporting/notion/notion_update.py
+++ b/reporting/notion/notion_update.py
@@ -382,8 +382,15 @@ def log_field_changes(connection, page_id, changes):
         connection.rollback()
         return False
 
-def main():
-    """Main function to execute the Notion update process."""
+def main() -> bool:
+    """Main function to execute the Notion update process.
+
+    Returns ``True``/``False`` so ``reporting_pipeline.run_module`` can record
+    a step failure on any of the early bail-outs below (missing token, failed
+    client init, no editorial row, no Supabase connection) or a failed page
+    update — all of which previously returned silently on a green "completed
+    successfully" log line one level up (issue #246).
+    """
     # Parse command-line arguments
     args = parse_arguments()
     
@@ -402,7 +409,7 @@ def main():
     
     if not api_token or not databases:
         logger.error("❌ Notion API token or databases not found in config.json")
-        return
+        return False
     
     # Get database ID (from args or config)
     if args.database_id:
@@ -418,19 +425,19 @@ def main():
     notion = init_notion_client(api_token)
     if notion is None:
         logger.error("❌ Failed to initialize Notion client")
-        return
+        return False
     
     # Search for the row with the matching date (one day before) for POSTS update
     previous_day_row = search_by_date(notion, database_id, args.date)
     if previous_day_row is None:
         logger.error(f"❌ No row found for the day before date: {args.date}")
-        return
+        return False
     
     # Search for the current day row for FOLLOWERS update
     current_day_row = search_by_current_date(notion, database_id, args.date)
     if current_day_row is None:
         logger.error(f"❌ No row found for current date: {args.date}")
-        return
+        return False
     
     # Extract page_id and properties for both rows
     previous_page_id = previous_day_row.get('id', '')
@@ -481,7 +488,7 @@ def main():
     supabase_connection = get_db_connection()
     if not supabase_connection:
         logger.error("❌ Failed to connect to Supabase")
-        return
+        return False
     
     # Get data from Supabase
     logger.info("📊 Fetching data from Supabase")
@@ -585,6 +592,7 @@ def main():
                 )
 
     # Update Notion pages
+    update_ok = True
     if posts_updates or followers_updates:
         total_updates = len(posts_updates) + len(followers_updates)
         logger.info("Ready to update %d fields in Notion", total_updates)
@@ -609,6 +617,7 @@ def main():
                     log_field_changes(supabase_connection, previous_page_id, posts_changes)
                 else:
                     logger.error("❌ Failed to update posts fields on previous day")
+                    update_ok = False
             
             # Update follower fields on current day
             if followers_updates:
@@ -623,6 +632,7 @@ def main():
                     log_field_changes(supabase_connection, current_page_id, followers_changes)
                 else:
                     logger.error("❌ Failed to update follower fields on current day")
+                    update_ok = False
             
             # Print field update summary
             logger.info("=" * 60)
@@ -649,6 +659,7 @@ def main():
     logger.info("=" * 60)
 
     logger.info("✅ Notion Update Process completed")
+    return update_ok
 
 if __name__ == "__main__":
     main()

--- a/reporting/process/data_processor.py
+++ b/reporting/process/data_processor.py
@@ -572,65 +572,74 @@ def parse_arguments():
     
     return parser.parse_args()
 
-def main(args=None):
-    """Main function to execute the data processor."""
+def main(args=None) -> bool:
+    """Main function to execute the data processor.
+
+    Returns ``True``/``False`` so ``reporting_pipeline.run_module`` can record
+    a step failure when this degrades gracefully instead of raising — a
+    missing mapping config, no data to process, or a failed Supabase upload
+    all previously returned silently on a green "completed successfully" log
+    line one level up (issue #246).
+    """
     if args is None:
         # Use command-line arguments if available, otherwise parse them
         args = parse_arguments()
-    
+
     # Configure logger with appropriate level
     debug_mode = args.debug
     configure_logger(debug_mode)
-    
+
     logger.info("🚀 Starting Data Processor")
     logger.info(f"🐞 Debug mode: {'Enabled' if debug_mode else 'Disabled'}")
-    
+
     # Load configurations
     mapping_config = load_mapping_config()
     if not mapping_config:
         logger.error("❌ Failed to load mapping configuration")
-        return
-    
+        return False
+
     main_config = load_config()
 
     # Process all JSON files and get DataFrames by data type
     dataframes = process_all_files(mapping_config, main_config, debug_mode=debug_mode, target_date=args.date)
-    
+
     if not dataframes:
         logger.warning("⚠️  No data to save")
-        return
-    
+        return False
+
     # Display info about each DataFrame
     for data_type, df in dataframes.items():
         logger.info(f"📊 {data_type} DataFrame shape: {df.shape}")
         logger.info(f"📋 {data_type} Columns: {', '.join(df.columns)}")
-        
+
         if debug_mode:
             logger.debug("%s DataFrame Preview:\n%s", data_type, df.head().to_string())
             logger.debug("%s DataFrame Info: %d rows x %d cols", data_type, len(df), len(df.columns))
-    
+
     # Upload data to Supabase if enabled
+    upload_success = True
     supabase_enabled = main_config.get('supabase', {}).get('enable_upload', False)
     if supabase_enabled:
         upload_to_supabase = args.upload != 'n'  # Default to yes if not explicitly 'n'
         if upload_to_supabase:
             logger.info("📤 Uploading data to Supabase...")
-            
+
             # Upload all dataframes
-            success = upload_all_dataframes(dataframes)
-            if success:
+            upload_success = upload_all_dataframes(dataframes)
+            if upload_success:
                 logger.info("✅ Successfully uploaded all data to Supabase")
             else:
                 logger.warning("⚠️  Some errors occurred during Supabase upload")
-    
+
     # Use output format from arguments
     output_format = args.format
-    
+
     # Save DataFrames
     output_files = save_dataframes(dataframes, main_config, output_format=output_format)
-    
+
     logger.info("✅ Data Processor completed")
     logger.info(f"📁 Generated {len(output_files)} output files")
+    return bool(upload_success)
 
 if __name__ == "__main__":
     main()

--- a/reporting/process/posts_consolidator.py
+++ b/reporting/process/posts_consolidator.py
@@ -38,8 +38,13 @@ def parse_arguments():
     
     return parser.parse_args()
 
-def main(args=None):
-    """Main function to execute the posts consolidator."""
+def main(args=None) -> bool:
+    """Main function to execute the posts consolidator.
+
+    Returns ``True``/``False`` (rather than only raising) so
+    ``reporting_pipeline.run_module`` can record a step failure even when this
+    degrades gracefully instead of raising (issue #246).
+    """
     if args is None:
         # Use command-line arguments if available, otherwise parse them
         args = parse_arguments()
@@ -58,7 +63,7 @@ def main(args=None):
     connection = get_db_connection()
     if not connection:
         logger.error("❌ Failed to connect to database")
-        return
+        return False
 
     # Read + execute the consolidation SQL
     logger.info("🔄 Executing SQL to create consolidated posts table")
@@ -66,11 +71,12 @@ def main(args=None):
 
     # Close connection
     connection.close()
-    
+
     if success:
         logger.info("✅ Posts Consolidator completed successfully")
     else:
         logger.error("❌ Posts Consolidator failed")
+    return success
 
 if __name__ == "__main__":
     main()

--- a/reporting/process/profile_aggregator.py
+++ b/reporting/process/profile_aggregator.py
@@ -88,26 +88,31 @@ def parse_arguments():
 
     return parser.parse_args()
 
-def main(args=None):
-    """Main function for running the profile aggregator."""
+def main(args=None) -> bool:
+    """Main function for running the profile aggregator.
+
+    Returns ``True``/``False`` so ``reporting_pipeline.run_module`` can record
+    a step failure on a logged-but-not-raised failure (issue #246).
+    """
     if args is None:
         # Use command-line arguments if available, otherwise parse them
         args = parse_arguments()
-    
+
     # Configure logger with appropriate level based on args
     debug_mode = args.debug
     configure_logger(debug_mode)
-    
+
     logger.info("🚀 Starting Profile Aggregator")
     logger.info(f"🐞 Debug mode: {'Enabled' if debug_mode else 'Disabled'}")
-    
+
     # Aggregate profile data
     result = aggregate_profile_data()
-    
+
     if result:
         logger.info("✅ Profile aggregation completed successfully")
     else:
         logger.error("❌ Profile aggregation failed")
+    return bool(result)
 
 if __name__ == "__main__":
     main()

--- a/reporting_pipeline.py
+++ b/reporting_pipeline.py
@@ -68,6 +68,11 @@ class PipelineFailures:
       a view lost ``security_invoker`` (recorded by ``check_policy_drift_coverage``);
       this catches Supabase security drift on the project's own clock instead of
       waiting for the weekly security-advisor email (issue #50).
+    * ``unverified`` — a coverage/drift check could not run at all (no DB
+      connection, or it raised) so its posture is genuinely unknown, not
+      "clean" (issue #246). Kept separate from the other lists so a full DB
+      outage still trips ``any()`` and the alert/non-zero exit, instead of a
+      check that silently couldn't run being folded into a green run.
     """
 
     def __init__(self) -> None:
@@ -75,10 +80,12 @@ class PipelineFailures:
         self.missing_endpoints: list[str] = []
         self.missing_post_metrics: list[str] = []
         self.policy_drift: list[str] = []
+        self.unverified: list[str] = []
 
     def any(self) -> bool:
         return bool(self.step_failures or self.missing_endpoints
-                    or self.missing_post_metrics or self.policy_drift)
+                    or self.missing_post_metrics or self.policy_drift
+                    or self.unverified)
 
 
 def _load_config() -> dict | None:
@@ -167,7 +174,8 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
         from reporting.process.supabase_uploader import get_db_connection
         connection = get_db_connection()
         if not connection:
-            logger.error("❌ Posts-coverage check: no DB connection — skipped")
+            logger.error("❌ Posts-coverage check: no DB connection — could not verify, treating as unverified")
+            failures.unverified.append("posts_coverage: no DB connection")
             return
         try:
             with connection.cursor() as cursor:
@@ -199,6 +207,7 @@ def check_posts_coverage(processing_date: str, failures: "PipelineFailures") -> 
             logger.info(f"✅ Posts-coverage: all {len(COVERAGE_PLATFORMS)} platforms have post metrics for {processing_date}")
     except Exception as e:
         logger.error(f"❌ Posts-coverage check failed: {e}")
+        failures.unverified.append(f"posts_coverage: check raised — {e}")
 
 
 def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
@@ -217,7 +226,8 @@ def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
         from reporting.process.supabase_policy_script import check_policy_drift, summarize_drift
         connection = get_db_connection()
         if not connection:
-            logger.error("❌ Policy-drift check: no DB connection — skipped")
+            logger.error("❌ Policy-drift check: no DB connection — could not verify, treating as unverified")
+            failures.unverified.append("policy_drift: no DB connection")
             return
         try:
             result = check_policy_drift(connection)
@@ -237,6 +247,7 @@ def check_policy_drift_coverage(failures: "PipelineFailures") -> None:
             logger.error(f"❌ Policy-drift: {kind} {summary}")
     except Exception as e:
         logger.error(f"❌ Policy-drift check failed: {e}")
+        failures.unverified.append(f"policy_drift: check raised — {e}")
 
 
 def _resolve_reporting_channel(config: dict | None) -> str:
@@ -292,6 +303,11 @@ def _build_alert_message(failures: "PipelineFailures", processing_date: str) -> 
         lines.append("RLS/policy drift:")
         for entry in failures.policy_drift:
             lines.append(f"• {entry}")
+    if failures.unverified:
+        lines.append("")
+        lines.append("Unverified (check could not run):")
+        for entry in failures.unverified:
+            lines.append(f"• {entry}")
     return "\n".join(lines)
 
 
@@ -341,7 +357,9 @@ def run_module(module_func, module_name, debug_mode=False, extra_args=None, fail
         module_name: Name of the module for logging
         debug_mode: Whether to enable debug mode
         extra_args: List of additional arguments to pass
-        failures: Optional PipelineFailures accumulator to record step exceptions
+        failures: Optional PipelineFailures accumulator to record step
+            exceptions, and step functions that return ``False`` instead of
+            raising (issue #246).
     """
     # Save original command line arguments
     original_argv = sys.argv.copy()
@@ -358,9 +376,19 @@ def run_module(module_func, module_name, debug_mode=False, extra_args=None, fail
         if extra_args:
             sys.argv.extend(extra_args)
             
-        # Run the module
-        module_func()
-        logger.info(f"✅ {module_name} completed successfully")
+        # Run the module. A step that degrades gracefully instead of raising
+        # (e.g. no DB connection, missing config) returns False rather than
+        # None/True — record that as a step failure too, not just an
+        # exception (issue #246). Steps that don't return a bool (e.g. still
+        # only ``return``/implicit ``None`` on their success path) are
+        # treated as successful, matching prior behaviour.
+        result = module_func()
+        if result is False:
+            logger.error(f"❌ {module_name} completed with errors (see above)")
+            if failures is not None:
+                failures.step_failures.append((module_name, "step reported failure (returned False)"))
+        else:
+            logger.info(f"✅ {module_name} completed successfully")
     except Exception as e:
         logger.error(f"❌ Error in {module_name}: {e}")
         if failures is not None:


### PR DESCRIPTION
## Summary

Seven bug findings from `/codebase-audit` closed:

- `planning/threads/schedule_threads_posts.py` — fixed the calendar day-cell picker mis-selecting the overflow-month cell when the target day is today (today's cell is white and no black candidate exists); corrected the stale "picks brightest" docstring.
- `reporting_pipeline.py` — added an `unverified` failure bucket so a DB-unreachable coverage/drift check trips the alert + non-zero exit instead of folding into a silent green run; `run_module` now records a step failure when a step returns `False`, not only when it raises.
- `reporting/process/posts_consolidator.py`, `reporting/process/profile_aggregator.py`, `reporting/process/data_processor.py`, `reporting/notion/notion_update.py` — each `main()` now returns `True`/`False` on its graceful-degradation paths so the pipeline can see steps that previously failed silently (no DB, SQL failure, missing editorial row, no Supabase token).
- `engagement/check_review_app.py` — scoped the idempotency rollback to the exact `(platform, comment_id)` this run approved, instead of reverting every approved row in the table.
- `engagement/db/schema.sql`, `engagement/linkedin/scrape_comments.py`, `engagement/reputation/update.py` — persist `post_posted_at` on `comments` so the `sub_2_min` classifier rule and reputation signal, both already documented as live, actually fire instead of being a permanent no-op.
- `newsletter/triage/history.py` — split the reextract-from-cache logic out of `pull_emails` so the documented `--no-gmail --reextract --budget 0` offline path no longer round-trips Gmail (and no longer raises on a missing token).
- `launch_reporting.bat` — skip the unconditional `pause` under `AUTO_MODE` so a scheduled run's exit code is actually observed, matching `launch_planning.bat`.

## Validation

- `& .\.venv\Scripts\python.exe -m pytest tests -v` → 259 passed, 1 skipped, **1 failed**: `tests/test_triage_criteria.py::CriteriaTests::test_owner_overrides_are_merged`. Confirmed pre-existing and unrelated — reproduces identically on a clean checkout with no local `results/newsletter/triage/overrides.json`, none of this diff's changed files touch `newsletter/triage/criteria.py` or that test, and #253/#254 hit the same failure. Already tracked separately as #252.
- e2e: n/a — no e2e suite in this repo; diff is backend/pipeline-only, touching no Streamlit UI surface (`app/`).
- UX-conformance gate: n/a — `SPEC_APPLIES=no` (non-web-surface diff).

Closes #246
